### PR TITLE
-- Added Logging inspectors to trace http.Request / Response

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,23 +52,75 @@ Decorators hold their passed state within a closure (such as the path components
 above). Be careful to share Preparers and Responders only in a context where such held state
 applies. For example, it may not make sense to share a Preparer that applies a query string from a
 fixed set of values. Similarly, sharing a Responder that reads the response body into a passed
-struct (e.g., ByUnmarshallingJson) is likely incorrect.
+struct (e.g., `ByUnmarshallingJson`) is likely incorrect.
 
-Lastly, the Swagger specification (https://swagger.io) that drives AutoRest
-(https://github.com/Azure/autorest/) precisely defines two date forms: date and date-time. The
-github.com/Azure/go-autorest/autorest/date package provides time.Time derivations to ensure
-correct parsing and formatting.
-
-Errors raised by autorest objects and methods will conform to the autorest.Error interface.
+Errors raised by autorest objects and methods will conform to the `autorest.Error` interface.
 
 See the included examples for more detail. For details on the suggested use of this package by
 generated clients, see the Client described below.
 
+## Helpers
+
+### Handling Swagger Dates
+
+The Swagger specification (https://swagger.io) that drives AutoRest
+(https://github.com/Azure/autorest/) precisely defines two date forms: date and date-time. The
+github.com/Azure/go-autorest/autorest/date package provides time.Time derivations to ensure correct
+parsing and formatting.
+
+### Handling Empty Values
+
+In JSON, missing values have different semantics than empty values. This is especially true for
+services using the HTTP PATCH verb. The JSON submitted with a PATCH request generally contains
+only those values to modify. Missing values are to be left unchanged. Developers, then, require a
+means to both specify an empty value and to leave the value out of the submitted JSON.
+
+The Go JSON package (`encoding/json`) supports the `omitempty` tag. When specified, it omits
+empty values from the rendered JSON. Since Go defines default values for all base types (such as ""
+for string and 0 for int) and provides no means to mark a value as actually empty, the JSON package
+treats default values as meaning empty, omitting them from the rendered JSON. This means that, using
+the Go base types encoded through the default JSON package, it is not possible to create JSON to
+clear a value at the server.
+
+The workaround within the Go community is to use pointers to base types in lieu of base types within
+structures that map to JSON. For example, instead of a value of type `string`, the workaround uses
+`*string`. While this enables distinguishing empty values from those to be unchanged, creating
+pointers to a base type (notably constant, in-line values) requires additional variables. This, for
+example,
+
+```go
+  s := struct {
+    S *string
+  }{ S: &"foo" }
+```
+fails, while, this
+
+```go
+  v := "foo"
+  s := struct {
+    S *string
+  }{ S: &v }
+```
+succeeds.
+
+To ease using pointers, the subpackage `to` contains helpers that convert to and from pointers for
+Go base types which have Swagger analogs. It also provides a helper that converts between
+`map[string]string` and `map[string]*string`, enabling the JSON to specify that the value
+associated with a key should be cleared. With the helpers, the previous example becomes
+
+```go
+  s := struct {
+    S *string
+  }{ S: to.StringPtr("foo") }
+```
 
 ## Install
 
 ```bash
 go get github.com/Azure/go-autorest/autorest
+go get github.com/Azure/go-autorest/autorest/azure
+go get github.com/Azure/go-autorest/autorest/date
+go get github.com/Azure/go-autorest/autorest/to
 ```
 
 ## License

--- a/autorest/autorest.go
+++ b/autorest/autorest.go
@@ -1,6 +1,6 @@
 /*
 Package autorest implements an HTTP request pipeline suitable for use across multiple go-routines
-and provides the shared routines relied on by AutoRest (see https://github.com/azure/autorest/)
+and provides the shared routines relied on by AutoRest (see https://github.com/Azure/autorest/)
 generated Go code.
 
 The package breaks sending and responding to HTTP requests into three phases: Preparing, Sending,
@@ -45,8 +45,8 @@ fixed set of values. Similarly, sharing a Responder that reads the response body
 struct (e.g., ByUnmarshallingJson) is likely incorrect.
 
 Lastly, the Swagger specification (https://swagger.io) that drives AutoRest
-(https://github.com/azure/autorest/) precisely defines two date forms: date and date-time. The
-github.com/azure/go-autorest/autorest/date package provides time.Time derivations to ensure
+(https://github.com/Azure/autorest/) precisely defines two date forms: date and date-time. The
+github.com/Azure/go-autorest/autorest/date package provides time.Time derivations to ensure
 correct parsing and formatting.
 
 Errors raised by autorest objects and methods will conform to the autorest.Error interface.

--- a/autorest/autorest_test.go
+++ b/autorest/autorest_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/azure/go-autorest/autorest/mocks"
+	"github.com/Azure/go-autorest/autorest/mocks"
 )
 
 func TestResponseHasStatusCode(t *testing.T) {
@@ -43,7 +43,7 @@ func TestResponseRequiresPollingLeavesBodyOpen(t *testing.T) {
 
 func TestResponseRequiresPollingDefaultsToAcceptedStatusCode(t *testing.T) {
 	resp := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
-	setAcceptedHeaders(resp)
+	mocks.SetAcceptedHeaders(resp)
 
 	if !ResponseRequiresPolling(resp) {
 		t.Error("autorest: ResponseRequiresPolling failed to create a request for default 202 Accepted status code")
@@ -52,7 +52,7 @@ func TestResponseRequiresPollingDefaultsToAcceptedStatusCode(t *testing.T) {
 
 func TestResponseRequiresPollingReturnsFalseForUnexpectedStatusCodes(t *testing.T) {
 	resp := mocks.NewResponseWithStatus("500 InternalServerError", http.StatusInternalServerError)
-	setAcceptedHeaders(resp)
+	mocks.SetAcceptedHeaders(resp)
 
 	if ResponseRequiresPolling(resp) {
 		t.Error("autorest: ResponseRequiresPolling did not return false when ignoring a status code")
@@ -79,7 +79,7 @@ func TestNewPollingRequestDoesNotReturnARequestWhenLocationHeaderIsMissing(t *te
 
 func TestNewPollingRequestReturnsAnErrorWhenPrepareFails(t *testing.T) {
 	resp := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
-	setAcceptedHeaders(resp)
+	mocks.SetAcceptedHeaders(resp)
 
 	_, err := NewPollingRequest(resp, mockFailingAuthorizer{})
 	if err == nil {
@@ -89,7 +89,7 @@ func TestNewPollingRequestReturnsAnErrorWhenPrepareFails(t *testing.T) {
 
 func TestNewPollingRequestLeavesBodyOpenWhenPrepareFails(t *testing.T) {
 	resp := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
-	setAcceptedHeaders(resp)
+	mocks.SetAcceptedHeaders(resp)
 	resp.Header.Set(http.CanonicalHeaderKey(headerLocation), testBadURL)
 
 	_, err := NewPollingRequest(resp, NullAuthorizer{})
@@ -100,7 +100,7 @@ func TestNewPollingRequestLeavesBodyOpenWhenPrepareFails(t *testing.T) {
 
 func TestNewPollingRequestDoesNotReturnARequestWhenPrepareFails(t *testing.T) {
 	resp := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
-	setAcceptedHeaders(resp)
+	mocks.SetAcceptedHeaders(resp)
 	resp.Header.Set(http.CanonicalHeaderKey(headerLocation), testBadURL)
 
 	req, _ := NewPollingRequest(resp, NullAuthorizer{})
@@ -111,7 +111,7 @@ func TestNewPollingRequestDoesNotReturnARequestWhenPrepareFails(t *testing.T) {
 
 func TestNewPollingRequestClosesTheResponseBody(t *testing.T) {
 	resp := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
-	setAcceptedHeaders(resp)
+	mocks.SetAcceptedHeaders(resp)
 
 	NewPollingRequest(resp, NullAuthorizer{})
 	if resp.Body.(*mocks.Body).IsOpen() {
@@ -121,7 +121,7 @@ func TestNewPollingRequestClosesTheResponseBody(t *testing.T) {
 
 func TestNewPollingRequestReturnsAGetRequest(t *testing.T) {
 	resp := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
-	setAcceptedHeaders(resp)
+	mocks.SetAcceptedHeaders(resp)
 
 	req, _ := NewPollingRequest(resp, NullAuthorizer{})
 	if req.Method != "GET" {
@@ -131,17 +131,17 @@ func TestNewPollingRequestReturnsAGetRequest(t *testing.T) {
 
 func TestNewPollingRequestProvidesTheURL(t *testing.T) {
 	resp := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
-	setAcceptedHeaders(resp)
+	mocks.SetAcceptedHeaders(resp)
 
 	req, _ := NewPollingRequest(resp, NullAuthorizer{})
-	if req.URL.String() != testURL {
-		t.Errorf("autorest: NewPollingRequest did not create an HTTP with the expected URL -- received %v, expected %v", req.URL, testURL)
+	if req.URL.String() != mocks.TestURL {
+		t.Errorf("autorest: NewPollingRequest did not create an HTTP with the expected URL -- received %v, expected %v", req.URL, mocks.TestURL)
 	}
 }
 
 func TestNewPollingRequestAppliesAuthorization(t *testing.T) {
 	resp := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
-	setAcceptedHeaders(resp)
+	mocks.SetAcceptedHeaders(resp)
 
 	req, _ := NewPollingRequest(resp, mockAuthorizer{})
 	if req.Header.Get(http.CanonicalHeaderKey(headerAuthorization)) != testAuthorizationHeader {
@@ -152,11 +152,11 @@ func TestNewPollingRequestAppliesAuthorization(t *testing.T) {
 
 func TestGetPollingLocation(t *testing.T) {
 	resp := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
-	setAcceptedHeaders(resp)
+	mocks.SetAcceptedHeaders(resp)
 
 	l := GetPollingLocation(resp)
 	if len(l) == 0 {
-		t.Errorf("autorest: GetPollingLocation failed to return Location header -- expected %v, received %v", testURL, l)
+		t.Errorf("autorest: GetPollingLocation failed to return Location header -- expected %v, received %v", mocks.TestURL, l)
 	}
 }
 
@@ -171,11 +171,11 @@ func TestGetPollingLocationReturnsEmptyStringForMissingLocation(t *testing.T) {
 
 func TestGetPollingDelay(t *testing.T) {
 	resp := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
-	setAcceptedHeaders(resp)
+	mocks.SetAcceptedHeaders(resp)
 
 	d := GetPollingDelay(resp, DefaultPollingDelay)
-	if d != testDelay {
-		t.Errorf("autorest: GetPollingDelay failed to returned the expected delay -- expected %v, received %v", testDelay, d)
+	if d != mocks.TestDelay {
+		t.Errorf("autorest: GetPollingDelay failed to returned the expected delay -- expected %v, received %v", mocks.TestDelay, d)
 	}
 }
 
@@ -191,7 +191,7 @@ func TestGetPollingDelayReturnsDefaultDelayIfRetryHeaderIsMissing(t *testing.T) 
 
 func TestGetPollingDelayReturnsDefaultDelayIfRetryHeaderIsMalformed(t *testing.T) {
 	resp := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
-	setAcceptedHeaders(resp)
+	mocks.SetAcceptedHeaders(resp)
 	resp.Header.Set(http.CanonicalHeaderKey(headerRetryAfter), "a very bad non-integer value")
 
 	d := GetPollingDelay(resp, DefaultPollingDelay)
@@ -206,7 +206,7 @@ func TestPollForAttemptsStops(t *testing.T) {
 	client.EmitErrors(-1)
 
 	resp := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
-	setAcceptedHeaders(resp)
+	mocks.SetAcceptedHeaders(resp)
 
 	req, _ := NewPollingRequest(resp, NullAuthorizer{})
 
@@ -222,7 +222,7 @@ func TestPollForDurationsStops(t *testing.T) {
 
 	d := 10 * time.Millisecond
 	resp := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
-	setAcceptedHeaders(resp)
+	mocks.SetAcceptedHeaders(resp)
 
 	req, _ := NewPollingRequest(resp, NullAuthorizer{})
 
@@ -239,10 +239,9 @@ func TestPollForDurationsStopsWithinReason(t *testing.T) {
 
 	d := 10 * time.Millisecond
 	resp := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
-	setAcceptedHeaders(resp)
-	setRetryHeader(resp, d)
+	mocks.SetAcceptedHeaders(resp)
+	mocks.SetRetryHeader(resp, d)
 	client.SetResponse(resp)
-	client.ReuseResponse(true)
 
 	req, _ := NewPollingRequest(resp, NullAuthorizer{})
 
@@ -259,10 +258,9 @@ func TestPollingHonorsDelay(t *testing.T) {
 
 	d1 := 10 * time.Millisecond
 	resp := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
-	setAcceptedHeaders(resp)
-	setRetryHeader(resp, d1)
+	mocks.SetAcceptedHeaders(resp)
+	mocks.SetRetryHeader(resp, d1)
 	client.SetResponse(resp)
-	client.ReuseResponse(true)
 
 	req, _ := NewPollingRequest(resp, NullAuthorizer{})
 
@@ -278,9 +276,8 @@ func TestPollingReturnsErrorForExpectedStatusCode(t *testing.T) {
 	client := mocks.NewSender()
 
 	resp := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
-	setAcceptedHeaders(resp)
+	mocks.SetAcceptedHeaders(resp)
 	client.SetResponse(resp)
-	client.ReuseResponse(true)
 
 	req, _ := NewPollingRequest(resp, NullAuthorizer{})
 
@@ -295,7 +292,7 @@ func TestPollingReturnsNoErrorForUnexpectedStatusCode(t *testing.T) {
 	client.EmitStatus("500 InternalServerError", http.StatusInternalServerError)
 
 	resp := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
-	setAcceptedHeaders(resp)
+	mocks.SetAcceptedHeaders(resp)
 
 	req, _ := NewPollingRequest(resp, NullAuthorizer{})
 
@@ -309,9 +306,8 @@ func TestPollingReturnsDefaultsToAcceptedStatusCode(t *testing.T) {
 	client := mocks.NewSender()
 
 	resp := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
-	setAcceptedHeaders(resp)
+	mocks.SetAcceptedHeaders(resp)
 	client.SetResponse(resp)
-	client.ReuseResponse(true)
 
 	req, _ := NewPollingRequest(resp, NullAuthorizer{})
 
@@ -326,7 +322,7 @@ func TestPollingLeavesFinalBodyOpen(t *testing.T) {
 	client.EmitStatus("500 InternalServerError", http.StatusInternalServerError)
 
 	resp := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
-	setAcceptedHeaders(resp)
+	mocks.SetAcceptedHeaders(resp)
 
 	req, _ := NewPollingRequest(resp, NullAuthorizer{})
 
@@ -340,9 +336,8 @@ func TestDecorateForPollingCloseBodyOnEachAttempt(t *testing.T) {
 	client := mocks.NewSender()
 
 	resp := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
-	setAcceptedHeaders(resp)
+	mocks.SetAcceptedHeaders(resp)
 	client.SetResponse(resp)
-	client.ReuseResponse(true)
 
 	req, _ := NewPollingRequest(resp, NullAuthorizer{})
 	resp, _ = PollForAttempts(client, req, time.Duration(0), 5)

--- a/autorest/azure/azure.go
+++ b/autorest/azure/azure.go
@@ -4,3 +4,69 @@ Package azure provides Azure-specific implementations used with AutoRest.
 See the included examples for more detail.
 */
 package azure
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/Azure/go-autorest/autorest"
+)
+
+const (
+	// HeaderClientID is the Azure extension header to set a user-specified request ID.
+	HeaderClientID = "x-ms-client-request-id"
+
+	// HeaderReturnClientID is the Azure extension header to set if the user-specified request ID
+	// should be included in the response.
+	HeaderReturnClientID = "x-ms-return-client-request-id"
+
+	// HeaderRequestID is the Azure extension header of the service generated request ID returned
+	// in the response.
+	HeaderRequestID = "x-ms-request-id"
+)
+
+// WithReturningClientID returns a PrepareDecorator that adds an HTTP extension header of
+// x-ms-client-request-id whose value is the passed, undecorated UUID (e.g.,
+// "0F39878C-5F76-4DB8-A25D-61D2C193C3CA"). It also sets the x-ms-return-client-request-id
+// header to true such that UUID accompanies the http.Response.
+func WithReturningClientID(uuid string) autorest.PrepareDecorator {
+	preparer := autorest.CreatePreparer(
+		WithClientID(uuid),
+		WithReturnClientID(true))
+
+	return func(p autorest.Preparer) autorest.Preparer {
+		return autorest.PreparerFunc(func(r *http.Request) (*http.Request, error) {
+			r, err := p.Prepare(r)
+			if err != nil {
+				return r, err
+			}
+			return preparer.Prepare(r)
+		})
+	}
+}
+
+// WithClientID returns a PrepareDecorator that adds an HTTP extension header of
+// x-ms-client-request-id whose value is passed, undecorated UUID (e.g.,
+// "0F39878C-5F76-4DB8-A25D-61D2C193C3CA").
+func WithClientID(uuid string) autorest.PrepareDecorator {
+	return autorest.WithHeader(HeaderClientID, uuid)
+}
+
+// WithReturnClientID returns a PrepareDecorator that adds an HTTP extension header of
+// x-ms-return-client-request-id whose boolean value indicates if the value of the
+// x-ms-client-request-id header should be included in the http.Response.
+func WithReturnClientID(b bool) autorest.PrepareDecorator {
+	return autorest.WithHeader(HeaderReturnClientID, strconv.FormatBool(b))
+}
+
+// ExtractClientID extracts the client identifier from the x-ms-client-request-id header set on the
+// http.Request sent to the service (and returned in the http.Response)
+func ExtractClientID(resp *http.Response) string {
+	return autorest.ExtractHeaderValue(HeaderClientID, resp)
+}
+
+// ExtractRequestID extracts the Azure server generated request identifier from the
+// x-ms-request-id header.
+func ExtractRequestID(resp *http.Response) string {
+	return autorest.ExtractHeaderValue(HeaderRequestID, resp)
+}

--- a/autorest/azure/azure_test.go
+++ b/autorest/azure/azure_test.go
@@ -1,0 +1,97 @@
+package azure
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"testing"
+
+	. "github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/mocks"
+)
+
+// Use a Client Inspector to set the request identifier.
+func ExampleWithClientID() {
+	uuid := "71FDB9F4-5E49-4C12-B266-DE7B4FD999A6"
+	req, _ := Prepare(&http.Request{},
+		AsGet(),
+		WithBaseURL("https://microsoft.com/a/b/c/"))
+
+	c := Client{Sender: mocks.NewSender()}
+	c.RequestInspector = WithReturningClientID(uuid)
+
+	c.Send(req)
+	fmt.Printf("Inspector added the %s header with the value %s\n",
+		HeaderClientID, req.Header.Get(HeaderClientID))
+	fmt.Printf("Inspector added the %s header with the value %s\n",
+		HeaderReturnClientID, req.Header.Get(HeaderReturnClientID))
+	// Output:
+	// Inspector added the x-ms-client-request-id header with the value 71FDB9F4-5E49-4C12-B266-DE7B4FD999A6
+	// Inspector added the x-ms-return-client-request-id header with the value true
+}
+
+func TestWithReturningClientIDReturnsError(t *testing.T) {
+	var errIn error
+	uuid := "71FDB9F4-5E49-4C12-B266-DE7B4FD999A6"
+	_, errOut := Prepare(&http.Request{},
+		withErrorPrepareDecorator(&errIn),
+		WithReturningClientID(uuid))
+
+	if errOut == nil || errIn != errOut {
+		t.Errorf("azure: WithReturningClientID failed to exit early when receiving an error -- expected (%v), received (%v)",
+			errIn, errOut)
+	}
+}
+
+func TestWithClientID(t *testing.T) {
+	uuid := "71FDB9F4-5E49-4C12-B266-DE7B4FD999A6"
+	req, _ := Prepare(&http.Request{},
+		WithClientID(uuid))
+
+	if req.Header.Get(HeaderClientID) != uuid {
+		t.Errorf("azure: WithClientID failed to set %s -- expected %s, received %s",
+			HeaderClientID, uuid, req.Header.Get(HeaderClientID))
+	}
+}
+
+func TestWithReturnClientID(t *testing.T) {
+	b := false
+	req, _ := Prepare(&http.Request{},
+		WithReturnClientID(b))
+
+	if req.Header.Get(HeaderReturnClientID) != strconv.FormatBool(b) {
+		t.Errorf("azure: WithReturnClientID failed to set %s -- expected %s, received %s",
+			HeaderClientID, strconv.FormatBool(b), req.Header.Get(HeaderClientID))
+	}
+}
+
+func TestExtractClientID(t *testing.T) {
+	uuid := "71FDB9F4-5E49-4C12-B266-DE7B4FD999A6"
+	resp := mocks.NewResponse()
+	mocks.SetResponseHeader(resp, HeaderClientID, uuid)
+
+	if ExtractClientID(resp) != uuid {
+		t.Errorf("azure: ExtractClientID failed to extract the %s -- expected %s, received %s",
+			HeaderClientID, uuid, ExtractClientID(resp))
+	}
+}
+
+func TestExtractRequestID(t *testing.T) {
+	uuid := "71FDB9F4-5E49-4C12-B266-DE7B4FD999A6"
+	resp := mocks.NewResponse()
+	mocks.SetResponseHeader(resp, HeaderRequestID, uuid)
+
+	if ExtractRequestID(resp) != uuid {
+		t.Errorf("azure: ExtractRequestID failed to extract the %s -- expected %s, received %s",
+			HeaderRequestID, uuid, ExtractRequestID(resp))
+	}
+}
+
+func withErrorPrepareDecorator(e *error) PrepareDecorator {
+	return func(p Preparer) Preparer {
+		return PreparerFunc(func(r *http.Request) (*http.Request, error) {
+			*e = fmt.Errorf("autorest: Faux Prepare Error")
+			return r, *e
+		})
+	}
+}

--- a/autorest/date/date.go
+++ b/autorest/date/date.go
@@ -1,7 +1,7 @@
 /*
 Package date provides time.Time derivatives that conform to the Swagger.io (https://swagger.io/)
 defined date   formats: Date and DateTime. Both types may, in most cases, be used in lieu of
-time.Time types. And both convert   to time.Time through a ToTime method.
+time.Time types. And both convert to time.Time through a ToTime method.
 */
 package date
 

--- a/autorest/mocks/helpers.go
+++ b/autorest/mocks/helpers.go
@@ -3,6 +3,23 @@ package mocks
 import (
 	"fmt"
 	"net/http"
+	"time"
+)
+
+const (
+	// TestDelay is the Retry-After delay used in tests.
+	TestDelay = 0 * time.Second
+
+	// TestHeader is the header used in tests.
+	TestHeader = "x-test-header"
+
+	// TestURL is the URL used in tests.
+	TestURL = "https://microsoft.com/a/b/c/"
+)
+
+const (
+	headerLocation   = "Location"
+	headerRetryAfter = "Retry-After"
 )
 
 // NewRequest instantiates a new request.
@@ -58,4 +75,30 @@ func SetResponseHeader(resp *http.Response, h string, v string) {
 		resp.Header = make(http.Header)
 	}
 	resp.Header.Set(h, v)
+}
+
+// SetResponseHeaderValues adds a header containing all the passed string values.
+func SetResponseHeaderValues(resp *http.Response, h string, values []string) {
+	if resp.Header == nil {
+		resp.Header = make(http.Header)
+	}
+	for _, v := range values {
+		resp.Header.Add(h, v)
+	}
+}
+
+// SetAcceptedHeaders adds the headers usually associated with a 202 Accepted response.
+func SetAcceptedHeaders(resp *http.Response) {
+	SetLocationHeader(resp, TestURL)
+	SetRetryHeader(resp, TestDelay)
+}
+
+// SetLocationHeader adds the Location header.
+func SetLocationHeader(resp *http.Response, location string) {
+	SetResponseHeader(resp, http.CanonicalHeaderKey(headerLocation), location)
+}
+
+// SetRetryHeader adds the Retry-After header.
+func SetRetryHeader(resp *http.Response, delay time.Duration) {
+	SetResponseHeader(resp, http.CanonicalHeaderKey(headerRetryAfter), fmt.Sprintf("%v", delay.Seconds()))
 }

--- a/autorest/preparer.go
+++ b/autorest/preparer.go
@@ -16,6 +16,7 @@ const (
 
 	headerAuthorization = "Authorization"
 	headerContentType   = "Content-Type"
+	headerUserAgent     = "User-Agent"
 )
 
 // Preparer is the interface that wraps the Prepare method.
@@ -77,8 +78,8 @@ func WithNothing() PrepareDecorator {
 	}
 }
 
-// WithHeader returns a PrepareDecorator that adds the specified HTTP header and value to the
-// http.Request. It will canonicalize the passed header name (via http.CanonicalHeaderKey) before
+// WithHeader returns a PrepareDecorator that sets the specified HTTP header of the http.Request to
+// the passed value. It canonicalizes the passed header name (via http.CanonicalHeaderKey) before
 // adding the header.
 func WithHeader(header string, value string) PrepareDecorator {
 	return func(p Preparer) Preparer {
@@ -88,7 +89,7 @@ func WithHeader(header string, value string) PrepareDecorator {
 				if r.Header == nil {
 					r.Header = make(http.Header)
 				}
-				r.Header.Add(http.CanonicalHeaderKey(header), value)
+				r.Header.Set(http.CanonicalHeaderKey(header), value)
 			}
 			return r, err
 		})
@@ -105,6 +106,12 @@ func WithBearerAuthorization(token string) PrepareDecorator {
 // is the passed contentType.
 func AsContentType(contentType string) PrepareDecorator {
 	return WithHeader(headerContentType, contentType)
+}
+
+// WithUserAgent returns a PrepareDecorator that adds an HTTP User-Agent header whose value is the
+// passed string.
+func WithUserAgent(ua string) PrepareDecorator {
+	return WithHeader(headerUserAgent, ua)
 }
 
 // AsFormURLEncoded returns a PrepareDecorator that adds an HTTP Content-Type header whose value is

--- a/autorest/sender_test.go
+++ b/autorest/sender_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/azure/go-autorest/autorest/mocks"
+	"github.com/Azure/go-autorest/autorest/mocks"
 )
 
 func ExampleSendWithSender() {
@@ -160,10 +160,9 @@ func TestAfterRetryDelayWaits(t *testing.T) {
 	d := 10 * time.Millisecond
 
 	resp := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
-	setAcceptedHeaders(resp)
-	setRetryHeader(resp, d)
+	mocks.SetAcceptedHeaders(resp)
+	mocks.SetRetryHeader(resp, d)
 	client.SetResponse(resp)
-	client.ReuseResponse(true)
 
 	tt := time.Now()
 	r, _ := SendWithSender(client, mocks.NewRequest(),

--- a/autorest/to/convert.go
+++ b/autorest/to/convert.go
@@ -1,0 +1,119 @@
+/*
+Package to provides helpers to ease working with pointer values of marshalled structures.
+*/
+package to
+
+// String returns a string value for the passed string pointer. It returns the empty string if the
+// pointer is nil.
+func String(s *string) string {
+	if s != nil {
+		return *s
+	}
+	return ""
+}
+
+// StringPtr returns a pointer to the passed string.
+func StringPtr(s string) *string {
+	return &s
+}
+
+// StringMap returns a map of strings built from the map of string pointers. The empty string is
+// used for nil pointers.
+func StringMap(msp map[string]*string) map[string]string {
+	ms := make(map[string]string, len(msp))
+	for k, sp := range msp {
+		if sp != nil {
+			ms[k] = *sp
+		} else {
+			ms[k] = ""
+		}
+	}
+	return ms
+}
+
+// StringMapPtr returns a map of string pointers built from the passed map of strings.
+func StringMapPtr(ms map[string]string) map[string]*string {
+	msp := make(map[string]*string, len(ms))
+	for k, s := range ms {
+		msp[k] = StringPtr(s)
+	}
+	return msp
+}
+
+// Bool returns a bool value for the passed bool pointer. It returns false if the pointer is nil.
+func Bool(b *bool) bool {
+	if b != nil {
+		return *b
+	}
+	return false
+}
+
+// BoolPtr returns a pointer to the passed bool.
+func BoolPtr(b bool) *bool {
+	return &b
+}
+
+// Int returns an int value for the passed int pointer. It returns 0 if the pointer is nil.
+func Int(i *int) int {
+	if i != nil {
+		return *i
+	}
+	return 0
+}
+
+// IntPtr returns a pointer to the passed int.
+func IntPtr(i int) *int {
+	return &i
+}
+
+// Int32 returns an int value for the passed int pointer. It returns 0 if the pointer is nil.
+func Int32(i *int32) int32 {
+	if i != nil {
+		return *i
+	}
+	return 0
+}
+
+// Int32Ptr returns a pointer to the passed int32.
+func Int32Ptr(i int32) *int32 {
+	return &i
+}
+
+// Int64 returns an int value for the passed int pointer. It returns 0 if the pointer is nil.
+func Int64(i *int64) int64 {
+	if i != nil {
+		return *i
+	}
+	return 0
+}
+
+// Int64Ptr returns a pointer to the passed int64.
+func Int64Ptr(i int64) *int64 {
+	return &i
+}
+
+// Float32 returns an int value for the passed int pointer. It returns 0.0 if the pointer is nil.
+func Float32(i *float32) float32 {
+	if i != nil {
+		return *i
+	}
+	return 0.0
+}
+
+// Float32Ptr returns a pointer to the passed float32.
+func Float32Ptr(i float32) *float32 {
+	return &i
+}
+
+// Float64 returns an int value for the passed int pointer. It returns 0.0 if the pointer is nil.
+func Float64(i *float64) float64 {
+	if i != nil {
+		return *i
+	}
+	return 0.0
+}
+
+// Float64Ptr returns a pointer to the passed float64.
+func Float64Ptr(i float64) *float64 {
+	return &i
+}

--- a/autorest/to/convert_test.go
+++ b/autorest/to/convert_test.go
@@ -1,0 +1,196 @@
+package to
+
+import (
+	"testing"
+)
+
+func TestString(t *testing.T) {
+	v := ""
+	if String(&v) != v {
+		t.Errorf("to: String failed to return the correct string -- expected %v, received %v",
+			v, String(&v))
+	}
+}
+
+func TestStringHandlesNil(t *testing.T) {
+	if String(nil) != "" {
+		t.Errorf("to: String failed to correctly convert nil -- expected %v, received %v",
+			"", String(nil))
+	}
+}
+
+func TestStringPtr(t *testing.T) {
+	v := ""
+	if *StringPtr(v) != v {
+		t.Errorf("to: StringPtr failed to return the correct string -- expected %v, received %v",
+			v, *StringPtr(v))
+	}
+}
+
+func TestStringMap(t *testing.T) {
+	msp := map[string]*string{"foo": StringPtr("foo"), "bar": StringPtr("bar"), "baz": StringPtr("baz")}
+	for k, v := range StringMap(msp) {
+		if *msp[k] != v {
+			t.Errorf("to: StringMap incorrectly converted an entry -- expected [%s]%v, received[%s]%v",
+				k, v, k, *msp[k])
+		}
+	}
+}
+
+func TestStringMapHandlesNil(t *testing.T) {
+	msp := map[string]*string{"foo": StringPtr("foo"), "bar": nil, "baz": StringPtr("baz")}
+	for k, v := range StringMap(msp) {
+		if msp[k] == nil && v != "" {
+			t.Errorf("to: StringMap incorrectly converted a nil entry -- expected [%s]%v, received[%s]%v",
+				k, v, k, *msp[k])
+		}
+	}
+}
+
+func TestStringMapPtr(t *testing.T) {
+	ms := map[string]string{"foo": "foo", "bar": "bar", "baz": "baz"}
+	for k, msp := range StringMapPtr(ms) {
+		if ms[k] != *msp {
+			t.Errorf("to: StringMapPtr incorrectly converted an entry -- expected [%s]%v, received[%s]%v",
+				k, ms[k], k, *msp)
+		}
+	}
+}
+
+func TestBool(t *testing.T) {
+	v := false
+	if Bool(&v) != v {
+		t.Errorf("to: Bool failed to return the correct string -- expected %v, received %v",
+			v, Bool(&v))
+	}
+}
+
+func TestBoolHandlesNil(t *testing.T) {
+	if Bool(nil) != false {
+		t.Errorf("to: Bool failed to correctly convert nil -- expected %v, received %v",
+			false, Bool(nil))
+	}
+}
+
+func TestBoolPtr(t *testing.T) {
+	v := false
+	if *BoolPtr(v) != v {
+		t.Errorf("to: BoolPtr failed to return the correct string -- expected %v, received %v",
+			v, *BoolPtr(v))
+	}
+}
+
+func TestInt(t *testing.T) {
+	v := 0
+	if Int(&v) != v {
+		t.Errorf("to: Int failed to return the correct string -- expected %v, received %v",
+			v, Int(&v))
+	}
+}
+
+func TestIntHandlesNil(t *testing.T) {
+	if Int(nil) != 0 {
+		t.Errorf("to: Int failed to correctly convert nil -- expected %v, received %v",
+			0, Int(nil))
+	}
+}
+
+func TestIntPtr(t *testing.T) {
+	v := 0
+	if *IntPtr(v) != v {
+		t.Errorf("to: IntPtr failed to return the correct string -- expected %v, received %v",
+			v, *IntPtr(v))
+	}
+}
+
+func TestInt32(t *testing.T) {
+	v := int32(0)
+	if Int32(&v) != v {
+		t.Errorf("to: Int32 failed to return the correct string -- expected %v, received %v",
+			v, Int32(&v))
+	}
+}
+
+func TestInt32HandlesNil(t *testing.T) {
+	if Int32(nil) != int32(0) {
+		t.Errorf("to: Int32 failed to correctly convert nil -- expected %v, received %v",
+			0, Int32(nil))
+	}
+}
+
+func TestInt32Ptr(t *testing.T) {
+	v := int32(0)
+	if *Int32Ptr(v) != v {
+		t.Errorf("to: Int32Ptr failed to return the correct string -- expected %v, received %v",
+			v, *Int32Ptr(v))
+	}
+}
+
+func TestInt64(t *testing.T) {
+	v := int64(0)
+	if Int64(&v) != v {
+		t.Errorf("to: Int64 failed to return the correct string -- expected %v, received %v",
+			v, Int64(&v))
+	}
+}
+
+func TestInt64HandlesNil(t *testing.T) {
+	if Int64(nil) != int64(0) {
+		t.Errorf("to: Int64 failed to correctly convert nil -- expected %v, received %v",
+			0, Int64(nil))
+	}
+}
+
+func TestInt64Ptr(t *testing.T) {
+	v := int64(0)
+	if *Int64Ptr(v) != v {
+		t.Errorf("to: Int64Ptr failed to return the correct string -- expected %v, received %v",
+			v, *Int64Ptr(v))
+	}
+}
+
+func TestFloat32(t *testing.T) {
+	v := float32(0)
+	if Float32(&v) != v {
+		t.Errorf("to: Float32 failed to return the correct string -- expected %v, received %v",
+			v, Float32(&v))
+	}
+}
+
+func TestFloat32HandlesNil(t *testing.T) {
+	if Float32(nil) != float32(0) {
+		t.Errorf("to: Float32 failed to correctly convert nil -- expected %v, received %v",
+			0, Float32(nil))
+	}
+}
+
+func TestFloat32Ptr(t *testing.T) {
+	v := float32(0)
+	if *Float32Ptr(v) != v {
+		t.Errorf("to: Float32Ptr failed to return the correct string -- expected %v, received %v",
+			v, *Float32Ptr(v))
+	}
+}
+
+func TestFloat64(t *testing.T) {
+	v := float64(0)
+	if Float64(&v) != v {
+		t.Errorf("to: Float64 failed to return the correct string -- expected %v, received %v",
+			v, Float64(&v))
+	}
+}
+
+func TestFloat64HandlesNil(t *testing.T) {
+	if Float64(nil) != float64(0) {
+		t.Errorf("to: Float64 failed to correctly convert nil -- expected %v, received %v",
+			0, Float64(nil))
+	}
+}
+
+func TestFloat64Ptr(t *testing.T) {
+	v := float64(0)
+	if *Float64Ptr(v) != v {
+		t.Errorf("to: Float64Ptr failed to return the correct string -- expected %v, received %v",
+			v, *Float64Ptr(v))
+	}
+}

--- a/autorest/utility_test.go
+++ b/autorest/utility_test.go
@@ -5,16 +5,13 @@ import (
 	"net/http"
 	"reflect"
 	"testing"
-	"time"
 
-	"github.com/azure/go-autorest/autorest/mocks"
+	"github.com/Azure/go-autorest/autorest/mocks"
 )
 
 const (
 	testAuthorizationHeader = "BEARER SECRETTOKEN"
-	testDelay               = 0 * time.Second
 	testBadURL              = ""
-	testURL                 = "https://microsoft.com/a/b/c/"
 	jsonT                   = `
     {
       "name":"Rob Pike",
@@ -70,19 +67,6 @@ func TestEnsureStrings(t *testing.T) {
 	if !reflect.DeepEqual(v, r) {
 		t.Errorf("autorest: ensureValueStrings returned %v\n", v)
 	}
-}
-
-func setAcceptedHeaders(resp *http.Response) {
-	setLocationHeader(resp, testURL)
-	setRetryHeader(resp, testDelay)
-}
-
-func setLocationHeader(resp *http.Response, location string) {
-	mocks.SetResponseHeader(resp, http.CanonicalHeaderKey(headerLocation), location)
-}
-
-func setRetryHeader(resp *http.Response, delay time.Duration) {
-	mocks.SetResponseHeader(resp, http.CanonicalHeaderKey(headerRetryAfter), fmt.Sprintf("%v", delay.Seconds()))
 }
 
 func doEnsureBodyClosed(t *testing.T) SendDecorator {
@@ -154,7 +138,7 @@ func withErrorRespondDecorator(e *error) RespondDecorator {
 			if err != nil {
 				return err
 			}
-			*e = fmt.Errorf("autorest: Faux Error")
+			*e = fmt.Errorf("autorest: Faux Respond Error")
 			return *e
 		})
 	}

--- a/autorest/version.go
+++ b/autorest/version.go
@@ -1,0 +1,18 @@
+package autorest
+
+import (
+	"fmt"
+)
+
+const (
+	major        = "1"
+	minor        = "0"
+	patch        = "0"
+	tag          = ""
+	semVerFormat = "%s.%s.%s%s"
+)
+
+// Version returns the semantic version (see http://semver.org).
+func Version() string {
+	return fmt.Sprintf(semVerFormat, major, minor, patch, tag)
+}

--- a/autorest/version_test.go
+++ b/autorest/version_test.go
@@ -1,0 +1,13 @@
+package autorest
+
+import (
+	"testing"
+)
+
+func TestVersion(t *testing.T) {
+	v := "1.0.0"
+	if Version() != v {
+		t.Errorf("autorest: Version failed to return the expected version -- expected %s, received %s",
+			v, Version())
+	}
+}


### PR DESCRIPTION
- Added support for User-Agent header
- Changed WithHeader PrepareDecorator to use set vs. add
- Added JSON to error when unmarshalling fails
-Added Client#Send method
- Corrected case of "Azure" in package paths
- Added convert helpers, Azure helpers, and improved ease-of-use
- Corrected golint issues

Signed-off-by: Brendan Dixon <brendand@microsoft.com>