### PR TITLE
Implement certificate based auth for service principal tokens

### DIFF
--- a/autorest/azure/example/README.md
+++ b/autorest/azure/example/README.md
@@ -1,0 +1,115 @@
+# autorest azure example
+
+## Usage
+
+This example covers how to make an authenticated call to the Azure Resource Manager APIs, using certificate-based authentication.
+
+0. Export some required variables
+
+    ```
+    export SUBSCRIPTION_ID="aff271ee-e9be-4441-b9bb-42f5af4cbaeb"
+    export TENANT_ID="13de0a15-b5db-44b9-b682-b4ba82afbd29"
+    export RESOURCE_GROUP="someresourcegroup"
+    ```
+
+    * replace both values with your own
+
+1. Create a private key
+
+    ```
+    openssl genrsa -out "example.key" 2048
+    ```
+
+
+
+2. Create the certificate
+
+    ```
+    openssl req -new -key "example.key" -subj "/CN=example" -out "example.csr"
+
+    openssl x509 -req -in "example.csr" -signkey "example.key" -out "example.crt" -days 10000
+    ```
+
+
+
+3. Create the PKCS12 version of the certificate (with no password)
+
+    ```
+    openssl pkcs12 -export -out "example.pfx" -inkey "example.key" -in "example.crt" -passout pass:
+    ```
+
+
+
+4. Register a new Azure AD Application with the certificate contents
+
+    ```
+    certificateContents="$(tail -n+2 "example.key" | head -n-1)"
+   
+    azure ad app create \
+        --name "example-azuread-app" \
+        --home-page="http://example-azuread-app/home" \
+        --identifier-uris "http://example-azuread-app/app" \
+        --key-usage "Verify" \
+        --end-date "2020-01-01" \
+        --key-value "${certificateContents}"
+    ```
+
+
+
+5. Create a new service principal using the "Application Id" from the previous step
+
+    ```
+    azure ad sp create "APPLICATION_ID"
+    ```
+
+    * Replace APPLICATION_ID with the "Application Id" returned in step 4
+
+
+
+6. Grant your service principal necessary permissions
+
+    ```
+    azure role assignment create \
+        --resource-group "${RESOURCE_GROUP}" \
+        --roleName "Contributor" \
+        --subscription "${SUBSCRIPTION_ID}" \
+        --spn "http://example-azuread-app/app"
+    ```
+
+    * Replace SUBSCRIPTION_ID with your subscription id
+    * Replace RESOURCE_GROUP with the resource group for the assignment
+    * Ensure that the `spn` parameter matches an `identifier-url` from Step 4
+
+
+
+7. Run this example app to see your resource groups
+
+    ```
+    go run main.go \
+        --tenantId="${TENANT_ID}" \
+        --subscriptionId="${SUBSCRIPTION_ID}" \
+        --applicationId="http://example-azuread-app/app" \
+        --certificatePath="certificate.pfx"
+    ```
+
+
+You should see something like this as output:
+
+```
+2015/11/08 18:28:39 Using these settings:
+2015/11/08 18:28:39 * certificatePath: certificate.pfx
+2015/11/08 18:28:39 * applicationID: http://example-azuread-app/app
+2015/11/08 18:28:39 * tenantID: 13de0a15-b5db-44b9-b682-b4ba82afbd29
+2015/11/08 18:28:39 * subscriptionID: aff271ee-e9be-4441-b9bb-42f5af4cbaeb
+2015/11/08 18:28:39 loading certificate... 
+2015/11/08 18:28:39 retrieve oauth token... 
+2015/11/08 18:28:39 querying the list of resource groups... 
+2015/11/08 18:28:50 
+2015/11/08 18:28:50 Groups: {"value":[{"id":"/subscriptions/aff271ee-e9be-4441-b9bb-42f5af4cbaeb/resourceGroups/kube-66f30810","name":"kube-66f30810","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded"}}]}
+```
+
+
+
+## Notes
+
+You may need to wait sometime between executing step 4, step 5 and step 6. If you issue those requests too quickly, you might hit an AD server that is not consistent with the server where the resource was created.

--- a/autorest/azure/example/main.go
+++ b/autorest/azure/example/main.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"flag"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+const resourceGroupURLTemplate = "https://management.azure.com/subscriptions/{subscription-id}/resourcegroups"
+const apiVersion = "2015-01-01"
+
+var (
+	certificatePath string
+	applicationID   string
+	tenantID        string
+	subscriptionID  string
+)
+
+func init() {
+	flag.StringVar(&certificatePath, "certificatePath", "", "path to pk12/pfx certificate")
+	flag.StringVar(&applicationID, "applicationId", "", "application id")
+	flag.StringVar(&tenantID, "tenantId", "", "tenant id")
+	flag.StringVar(&subscriptionID, "subscriptionId", "", "subscription id")
+	flag.Parse()
+
+	log.Println("Using these settings:")
+	log.Println("* certificatePath:", certificatePath)
+	log.Println("* applicationID:", applicationID)
+	log.Println("* tenantID:", tenantID)
+	log.Println("* subscriptionID:", subscriptionID)
+
+	if strings.Trim(certificatePath, " ") == "" ||
+		strings.Trim(applicationID, " ") == "" ||
+		strings.Trim(tenantID, " ") == "" ||
+		strings.Trim(subscriptionID, " ") == "" {
+		log.Fatalln("Bad usage. Please specify all four parameters")
+	}
+}
+
+func main() {
+	log.Println("loading certificate... ")
+	certData, err := ioutil.ReadFile(certificatePath)
+	if err != nil {
+		log.Fatalln("failed", err)
+	}
+
+	log.Println("retrieve oauth token... ")
+	spt, err := azure.NewServicePrincipalTokenFromCertificate(
+		applicationID,
+		certData,
+		"",
+		tenantID,
+		azure.AzureResourceManagerScope)
+	if err != nil {
+		log.Fatalln("failed", err)
+		panic(err)
+	}
+
+	client := &autorest.Client{}
+	client.Authorizer = spt
+
+	log.Println("querying the list of resource groups... ")
+	groupsAsString, err := getResourceGroups(client)
+	if err != nil {
+		log.Fatalln("failed", err)
+	}
+
+	log.Println("")
+	log.Println("Groups:", *groupsAsString)
+}
+
+func getResourceGroups(client *autorest.Client) (*string, error) {
+	var p map[string]interface{}
+	var req *http.Request
+	p = map[string]interface{}{
+		"subscription-id": subscriptionID,
+	}
+	q := map[string]interface{}{
+		"api-version": apiVersion,
+	}
+
+	req, _ = autorest.Prepare(&http.Request{},
+		autorest.AsGet(),
+		autorest.WithBaseURL(resourceGroupURLTemplate),
+		autorest.WithPathParameters(p),
+		autorest.WithQueryParameters(q))
+
+	resp, err := client.Send(req, http.StatusOK)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+	contents, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	contentsString := string(contents)
+
+	return &contentsString, nil
+}

--- a/autorest/azure/token.go
+++ b/autorest/azure/token.go
@@ -1,18 +1,27 @@
 package azure
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha1"
+	"encoding/base64"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
 	"time"
 
 	"github.com/Azure/go-autorest/autorest"
+	"github.com/dgrijalva/jwt-go"
+	"golang.org/x/crypto/pkcs12"
 )
 
 const (
 	defaultRefresh = 5 * time.Minute
 	oauthURL       = "https://login.microsoftonline.com/{tenantID}/oauth2/{requestType}?api-version=1.0"
 	tokenBaseDate  = "1970-01-01T00:00:00Z"
+
+	jwtAudienceTemplate = "https://login.microsoftonline.com/%s/oauth2/token"
 
 	// AzureResourceManagerScope is the OAuth scope for the Azure Resource Manager.
 	AzureResourceManagerScope = "https://management.azure.com/"
@@ -66,31 +75,136 @@ func (t *Token) WithAuthorization() autorest.PrepareDecorator {
 	}
 }
 
+// ServicePrincipalSecret is an interface that allows various secret mechanism to fill the form
+// that is submitted when acquiring an oAuth token.
+type ServicePrincipalSecret interface {
+	SetAuthenticationValues(spt *ServicePrincipalToken, values *url.Values) error
+}
+
+// ServicePrincipalTokenSecret implements ServicePrincipalSecret for client_secret type authorization.
+type ServicePrincipalTokenSecret struct {
+	ClientSecret string
+}
+
+// SetAuthenticationValues is a method of the interface ServicePrincipalTokenSecret.
+// It will populate the form submitted during oAuth Token Acquisition using the client_secret.
+func (tokenSecret *ServicePrincipalTokenSecret) SetAuthenticationValues(spt *ServicePrincipalToken, v *url.Values) error {
+	v.Set("client_secret", tokenSecret.ClientSecret)
+	return nil
+}
+
+// ServicePrincipalCertificateSecret implements ServicePrincipalSecret for certificate auth with signed JWTs.
+type ServicePrincipalCertificateSecret struct {
+	Pkcs12   []byte
+	Password string
+}
+
+// SignJwt returns the JWT signed with the certificate's private key.
+func (secret *ServicePrincipalCertificateSecret) SignJwt(spt *ServicePrincipalToken) (string, error) {
+	privateKey, cert, err := pkcs12.Decode(secret.Pkcs12, secret.Password)
+	if err != nil {
+		return "", err
+	}
+
+	rsaPrivateKey, isRsaKey := privateKey.(*rsa.PrivateKey)
+	if !isRsaKey {
+		return "", fmt.Errorf("PKCS12 certificate must contain an RSA private key")
+	}
+
+	hasher := sha1.New()
+	_, err = hasher.Write(cert.Raw)
+	if err != nil {
+		return "", err
+	}
+
+	thumbprint := base64.URLEncoding.EncodeToString(hasher.Sum(nil))
+
+	// The jti (JWT ID) claim provides a unique identifier for the JWT.
+	jti := make([]byte, 20)
+	_, err = rand.Read(jti)
+	if err != nil {
+		return "", err
+	}
+
+	token := jwt.New(jwt.SigningMethodRS256)
+	token.Header["x5t"] = thumbprint
+	token.Claims = map[string]interface{}{
+		"aud": fmt.Sprintf(jwtAudienceTemplate, spt.tenantID),
+		"iss": spt.clientID,
+		"sub": spt.clientID,
+		"jti": base64.URLEncoding.EncodeToString(jti),
+		"nbf": time.Now().Unix(),
+		"exp": time.Now().Add(time.Hour * 24).Unix(),
+	}
+
+	signedString, err := token.SignedString(rsaPrivateKey)
+	return signedString, nil
+}
+
+// SetAuthenticationValues is a method of the interface ServicePrincipalTokenSecret.
+// It will populate the form submitted during oAuth Token Acquisition using a JWT signed with a certificate.
+func (secret *ServicePrincipalCertificateSecret) SetAuthenticationValues(spt *ServicePrincipalToken, v *url.Values) error {
+	jwt, err := secret.SignJwt(spt)
+	if err != nil {
+		return err
+	}
+
+	v.Set("client_assertion", jwt)
+	v.Set("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
+	return nil
+}
+
 // ServicePrincipalToken encapsulates a Token created for a Service Principal.
 type ServicePrincipalToken struct {
 	Token
 
+	secret        ServicePrincipalSecret
 	clientID      string
-	clientSecret  string
-	resource      string
 	tenantID      string
+	resource      string
 	autoRefresh   bool
 	refreshWithin time.Duration
 	sender        autorest.Sender
 }
 
-// NewServicePrincipalToken creates a ServicePrincipalToken from the supplied Service Principal
-// credentials scoped to the named resource.
-func NewServicePrincipalToken(id string, secret string, tenantID string, resource string) (*ServicePrincipalToken, error) {
+// NewServicePrincipalTokenWithSecret create a ServicePrincipalToken using the supplied ServicePrincipalSecret implementation.
+func NewServicePrincipalTokenWithSecret(id string, tenantID string, resource string, secret ServicePrincipalSecret) (*ServicePrincipalToken, error) {
 	spt := &ServicePrincipalToken{
+		secret:        secret,
 		clientID:      id,
-		clientSecret:  secret,
 		resource:      resource,
 		tenantID:      tenantID,
 		autoRefresh:   true,
 		refreshWithin: defaultRefresh,
-		sender:        &http.Client{}}
+		sender:        &http.Client{},
+	}
 	return spt, nil
+}
+
+// NewServicePrincipalToken creates a ServicePrincipalToken from the supplied Service Principal
+// credentials scoped to the named resource.
+func NewServicePrincipalToken(id string, secret string, tenantID string, resource string) (*ServicePrincipalToken, error) {
+	return NewServicePrincipalTokenWithSecret(
+		id,
+		tenantID,
+		resource,
+		&ServicePrincipalTokenSecret{
+			ClientSecret: secret,
+		},
+	)
+}
+
+// NewServicePrincipalTokenFromCertificate create a ServicePrincipalToken from the supplied pkcs12 bytes.
+func NewServicePrincipalTokenFromCertificate(id string, pkcs12 []byte, password string, tenantID string, resource string) (*ServicePrincipalToken, error) {
+	return NewServicePrincipalTokenWithSecret(
+		id,
+		tenantID,
+		resource,
+		&ServicePrincipalCertificateSecret{
+			Pkcs12:   pkcs12,
+			Password: password,
+		},
+	)
 }
 
 // EnsureFresh will refresh the token if it will expire within the refresh window (as set by
@@ -111,16 +225,23 @@ func (spt *ServicePrincipalToken) Refresh() error {
 
 	v := url.Values{}
 	v.Set("client_id", spt.clientID)
-	v.Set("client_secret", spt.clientSecret)
 	v.Set("grant_type", "client_credentials")
 	v.Set("resource", spt.resource)
 
-	req, _ := autorest.Prepare(&http.Request{},
+	err := spt.secret.SetAuthenticationValues(spt, &v)
+	if err != nil {
+		return err
+	}
+
+	req, err := autorest.Prepare(&http.Request{},
 		autorest.AsPost(),
 		autorest.AsFormURLEncoded(),
 		autorest.WithBaseURL(oauthURL),
 		autorest.WithPathParameters(p),
 		autorest.WithFormData(v))
+	if err != nil {
+		return err
+	}
 
 	resp, err := autorest.SendWithSender(spt.sender, req)
 	if err != nil {
@@ -129,15 +250,19 @@ func (spt *ServicePrincipalToken) Refresh() error {
 			spt.clientID)
 	}
 
+	var newToken Token
+
 	err = autorest.Respond(resp,
 		autorest.WithErrorUnlessOK(),
-		autorest.ByUnmarshallingJSON(spt),
+		autorest.ByUnmarshallingJSON(&newToken),
 		autorest.ByClosing())
 	if err != nil {
 		return autorest.NewErrorWithError(err,
 			"azure.ServicePrincipalToken", "Refresh", "Failure handling response to Service Principal %s request",
 			spt.clientID)
 	}
+
+	spt.Token = newToken
 
 	return nil
 }

--- a/autorest/version.go
+++ b/autorest/version.go
@@ -6,8 +6,8 @@ import (
 
 const (
 	major        = "1"
-	minor        = "0"
-	patch        = "1"
+	minor        = "1"
+	patch        = "0"
 	tag          = ""
 	semVerFormat = "%s.%s.%s%s"
 )

--- a/autorest/version_test.go
+++ b/autorest/version_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestVersion(t *testing.T) {
-	v := "1.0.1"
+	v := "1.1.0"
 	if Version() != v {
 		t.Errorf("autorest: Version failed to return the expected version -- expected %s, received %s",
 			v, Version())


### PR DESCRIPTION
This PR enables the use of certificates to retrieve a service principal auth token.

It replaces `clientSecret` on SPT with a field `secret` which is a struct implementing `ServicePrincipalSecret`. In `Refresh()`, rather than just adding the "client_secret" to the form, we call `ServicePrincipalSecret`'s `SetAuthValues` to modify the form as needed.

`ServicePrincipalTokenSecret` will add `client_secret` to the request.

`ServicePrincipalCertSecret` will add `client_assertion` and `client_assertion_type` to the request. 

It does introduce two new dependencies to `go-autorest`:
 
* `github.com/dgrijalva/jwt-go`
* `golang.org/x/crypto/pkcs12` (the one Paul just pushed back into x/crypto)

It *could* be possible to avoid those by:

1. Reimplementing the few things needed from `jwt-go`.
2. Requiring the user to specify a PKCS#1-formatted or PKCS#8-formatted certificate instead of a PKCS#12 certificate. But, most Microsoft stuff seems to prefer PKCS#12 (most relevantly, Azure KeyVault).

I've tested this manually, and also included an example in the PR that starts from scratch and results in listing the subscription's resource groups, after retrieving an OAuth token via JWT signed with the cert's private key.