### PR TITLE
return pointer from to.StringMapPtr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v2.0.0
+
+- Changed `to.StringMapPtr` method signature to return a pointer
+
 ## v1.0.0
 
 - Added Logging inspectors to trace http.Request / Response

--- a/autorest/to/convert.go
+++ b/autorest/to/convert.go
@@ -31,13 +31,13 @@ func StringMap(msp map[string]*string) map[string]string {
 	return ms
 }
 
-// StringMapPtr returns a map of string pointers built from the passed map of strings.
-func StringMapPtr(ms map[string]string) map[string]*string {
+// StringMapPtr returns a pointer to a map of string pointers built from the passed map of strings.
+func StringMapPtr(ms map[string]string) *map[string]*string {
 	msp := make(map[string]*string, len(ms))
 	for k, s := range ms {
 		msp[k] = StringPtr(s)
 	}
-	return msp
+	return &msp
 }
 
 // Bool returns a bool value for the passed bool pointer. It returns false if the pointer is nil.

--- a/autorest/to/convert_test.go
+++ b/autorest/to/convert_test.go
@@ -49,7 +49,7 @@ func TestStringMapHandlesNil(t *testing.T) {
 
 func TestStringMapPtr(t *testing.T) {
 	ms := map[string]string{"foo": "foo", "bar": "bar", "baz": "baz"}
-	for k, msp := range StringMapPtr(ms) {
+	for k, msp := range *StringMapPtr(ms) {
 		if ms[k] != *msp {
 			t.Errorf("to: StringMapPtr incorrectly converted an entry -- expected [%s]%v, received[%s]%v",
 				k, ms[k], k, *msp)


### PR DESCRIPTION
All Tags fields actually accept `*map[string]*string` in Azure SDK. (`ack --go Tags | grep -v '^//' | grep map`)

cc: @brendandixon PTAL