### PR TITLE
Add responder for Azure-specific errors

### DIFF
--- a/autorest/azure/azure.go
+++ b/autorest/azure/azure.go
@@ -6,6 +6,8 @@ See the included examples for more detail.
 package azure
 
 import (
+	"fmt"
+	"io/ioutil"
 	"net/http"
 	"strconv"
 
@@ -24,6 +26,22 @@ const (
 	// in the response.
 	HeaderRequestID = "x-ms-request-id"
 )
+
+// Error describes an error response returned by Azure service.
+type Error struct {
+	ServiceError *struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	} `json:"error"` // JSON object returned in service response body
+	StatusCode int    // HTTP response status code
+	RequestID  string // x-ms-request-id-header
+}
+
+// Error returns a human-friendly error message from service error.
+func (e *Error) Error() string {
+	return fmt.Sprintf("azure: Service returned an error. Code=%q Message=%q Status=%d",
+		e.ServiceError.Code, e.ServiceError.Message, e.StatusCode)
+}
 
 // WithReturningClientID returns a PrepareDecorator that adds an HTTP extension header of
 // x-ms-client-request-id whose value is the passed, undecorated UUID (e.g.,
@@ -69,4 +87,38 @@ func ExtractClientID(resp *http.Response) string {
 // x-ms-request-id header.
 func ExtractRequestID(resp *http.Response) string {
 	return autorest.ExtractHeaderValue(HeaderRequestID, resp)
+}
+
+// WithErrorUnlessStatusCode returns a RespondDecorator that emits an
+// azure.Error by reading the response body unless the response HTTP status code
+// is among the set passed.
+//
+// If there is a chance service may return responses other than the Azure error
+// format and the response cannot be parsed into an error, a decoding error will
+// be returned containing the response body. In any case, the Responder will
+// return an error if the status code is not satisfied.
+//
+// If this Responder returns an error, the response body will be replaced with
+// an in-memory reader, which needs no further closing.
+func WithErrorUnlessStatusCode(codes ...int) autorest.RespondDecorator {
+	return func(r autorest.Responder) autorest.Responder {
+		return autorest.ResponderFunc(func(resp *http.Response) error {
+			err := r.Respond(resp)
+			if err == nil && !autorest.ResponseHasStatusCode(resp, codes...) {
+				var e Error
+				defer resp.Body.Close()
+
+				b, decodeErr := autorest.CopyAndDecode(autorest.EncodedAsJSON, resp.Body, &e)
+				resp.Body = ioutil.NopCloser(&b) // replace body with in-memory reader
+				if decodeErr != nil || e.ServiceError == nil {
+					return fmt.Errorf("autorest/azure: error response cannot be parsed: %q error: %v", b.String(), err)
+				}
+
+				e.RequestID = ExtractRequestID(resp)
+				e.StatusCode = resp.StatusCode
+				err = &e
+			}
+			return err
+		})
+	}
 }


### PR DESCRIPTION
@brendandixon/@colemickens,

I took a stab at handling the Azure error responses specifically to allow them to be deserialized and surfaced to the caller in a nice, type-safe way. An Azure service error response looks like this:

```json
{
    "error": {
        "code": "LocationRequired",
        "message": "The location property is required for this definition."
    }
}
```

Logic is as follows:

* if statuscode=4xx or 5xx:
    * read the response body (and close) and unmarshal into `*AzureError` type.
    * if `*AzureError` looks alright: return it
    * otherwise: let the next decorator run

Downsides:
* the next decorator won't have the resp.Body anymore (such as WithErrorUnlessStatusCode will be returning a closed resp.Body)
* will work if Azure always returns this kind of a response.

Please let me know what you think.

We'll probably make this `WithAzureErrorCheckUnlessStatusCode(...)` if we end up using, but I wanted to stop here and get feedback.