### PR TITLE
Add StringSlice/StringSlicePtr

### DIFF
--- a/autorest/to/convert.go
+++ b/autorest/to/convert.go
@@ -17,6 +17,20 @@ func StringPtr(s string) *string {
 	return &s
 }
 
+// StringSlice returns a string slice value for the passed string slice pointer. It returns a nil
+// slice if the pointer is nil.
+func StringSlice(s *[]string) []string {
+	if s != nil {
+		return *s
+	}
+	return nil
+}
+
+// StringSlicePtr returns a pointer to the passed string slice.
+func StringSlicePtr(s []string) *[]string {
+	return &s
+}
+
 // StringMap returns a map of strings built from the map of string pointers. The empty string is
 // used for nil pointers.
 func StringMap(msp map[string]*string) map[string]string {

--- a/autorest/to/convert_test.go
+++ b/autorest/to/convert_test.go
@@ -1,6 +1,7 @@
 package to
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -24,6 +25,29 @@ func TestStringPtr(t *testing.T) {
 	if *StringPtr(v) != v {
 		t.Errorf("to: StringPtr failed to return the correct string -- expected %v, received %v",
 			v, *StringPtr(v))
+	}
+}
+
+func TestStringSlice(t *testing.T) {
+	v := []string{}
+	if out := StringSlice(&v); !reflect.DeepEqual(out, v) {
+		t.Errorf("to: StringSlice failed to return the correct slice -- expected %v, received %v",
+			v, out)
+	}
+}
+
+func TestStringSliceHandlesNil(t *testing.T) {
+	if out := StringSlice(nil); out != nil {
+		t.Errorf("to: StringSlice failed to correctly convert nil -- expected %v, received %v",
+			nil, out)
+	}
+}
+
+func TestStringSlicePtr(t *testing.T) {
+	v := []string{"a", "b"}
+	if out := StringSlicePtr(v); !reflect.DeepEqual(*out, v) {
+		t.Errorf("to: StringSlicePtr failed to return the correct slice -- expected %v, received %v",
+			v, *out)
 	}
 }
 


### PR DESCRIPTION
Azure Go SDK makes use of `*[]string` type in various models.
[`arm/network.AddressSpace`][1] is an example. Adding helper methods to
handle conversion of string slices to pointers and vice versa.

Signed-off-by: Ahmet Alp Balkan
cc: @brendandixon 

[1]: https://github.com/Azure/azure-sdk-for-go/blob/master/arm/network/models.go#L440