### PR TITLE
Removing codes... from Send()

### DIFF
--- a/autorest/azure/example/main.go
+++ b/autorest/azure/example/main.go
@@ -99,7 +99,7 @@ func getResourceGroups(client *autorest.Client) (*string, error) {
 		autorest.WithPathParameters(p),
 		autorest.WithQueryParameters(q))
 
-	resp, err := client.Send(req, http.StatusOK)
+	resp, err := client.Send(req)
 	if err != nil {
 		return nil, err
 	}

--- a/autorest/client.go
+++ b/autorest/client.go
@@ -191,11 +191,7 @@ func (c Client) PollForDuration() bool {
 // Send sends the passed http.Request after applying authorization. It will poll if the client
 // allows polling and the http.Response status code requires it. It will close the http.Response
 // Body if the request returns an error.
-func (c Client) Send(req *http.Request, codes ...int) (*http.Response, error) {
-	if len(codes) == 0 {
-		codes = []int{http.StatusOK}
-	}
-
+func (c Client) Send(req *http.Request) (*http.Response, error) {
 	req, err := Prepare(req,
 		c.WithAuthorization(),
 		c.WithInspection())
@@ -203,8 +199,7 @@ func (c Client) Send(req *http.Request, codes ...int) (*http.Response, error) {
 		return nil, NewErrorWithError(err, "autorest/Client", "Send", UndefinedStatusCode, "Preparing request failed")
 	}
 
-	resp, err := SendWithSender(c, req,
-		DoErrorUnlessStatusCode(codes...))
+	resp, err := SendWithSender(c, req)
 	if err == nil {
 		err = c.IsPollingAllowed(resp)
 		if err == nil {

--- a/autorest/client.go
+++ b/autorest/client.go
@@ -207,11 +207,6 @@ func (c Client) Send(req *http.Request) (*http.Response, error) {
 		}
 	}
 
-	if err != nil {
-		Respond(resp,
-			ByClosing())
-	}
-
 	return resp, err
 }
 

--- a/autorest/client_test.go
+++ b/autorest/client_test.go
@@ -407,50 +407,13 @@ func TestClientSendDefaultsToUsingStatusCodeOK(t *testing.T) {
 	}
 }
 
-func TestClientSendClosesReponseBodyWhenReturningError(t *testing.T) {
-	s := mocks.NewSender()
-	r := mocks.NewResponseWithStatus("500 InternalServerError", http.StatusInternalServerError)
-	s.SetResponse(r)
-	c := Client{Sender: s}
-
-	c.Send(mocks.NewRequest())
-	if r.Body.(*mocks.Body).IsOpen() {
-		t.Error("autorest: Client#Send failed to close the response body when returning an error")
-	}
-}
-
-func TestClientSendReturnsErrorWithUnexpectedStatusCode(t *testing.T) {
-	r := mocks.NewRequest()
-	s := mocks.NewSender()
-	s.EmitStatus("500 InternalServerError", http.StatusInternalServerError)
-	c := Client{Sender: s}
-
-	_, err := c.Send(r)
-	if err == nil {
-		t.Error("autorest: Client#Send failed to return an error for an unexpected Status Code")
-	}
-}
-
-func TestClientSendDoesNotReturnErrorForExpectedStatusCode(t *testing.T) {
-	r := mocks.NewRequest()
-	s := mocks.NewSender()
-	s.EmitStatus("500 InternalServerError", http.StatusInternalServerError)
-	c := Client{Sender: s}
-
-	_, err := c.Send(r, http.StatusInternalServerError)
-	if err != nil {
-		t.Errorf("autorest: Client#Send returned an error for an expected Status Code -- %v",
-			err)
-	}
-}
-
 func TestClientSendPollsIfNeeded(t *testing.T) {
 	r := mocks.NewRequest()
 	s := mocks.NewSender()
 	s.SetPollAttempts(5)
 	c := Client{Sender: s, PollingMode: PollUntilAttempts, PollingAttempts: 10}
 
-	c.Send(r, http.StatusOK, http.StatusAccepted)
+	c.Send(r)
 	if s.Attempts() != (5 + 1) {
 		t.Errorf("autorest: Client#Send failed to poll the expected number of times -- attempts %d",
 			s.Attempts())
@@ -462,7 +425,7 @@ func TestClientSendDoesNotPollIfUnnecessary(t *testing.T) {
 	s := mocks.NewSender()
 	c := Client{Sender: s, PollingMode: PollUntilAttempts, PollingAttempts: 10}
 
-	c.Send(r, http.StatusOK, http.StatusAccepted)
+	c.Send(r)
 	if s.Attempts() != 1 {
 		t.Errorf("autorest: Client#Send unexpectedly polled -- attempts %d",
 			s.Attempts())


### PR DESCRIPTION
Breaking change. This will require changing the call to `Send()` in the auto-generated SDK.

![image](https://cloud.githubusercontent.com/assets/159209/12462981/1353895c-bf76-11e5-8363-e5a9ed589ba5.png)
