### PR TITLE
Fix nil dereference panic in NewErrorWithError when resp=nil

### DIFF
--- a/autorest/autorest.go
+++ b/autorest/autorest.go
@@ -93,7 +93,7 @@ func ResponseRequiresPolling(resp *http.Response, codes ...int) bool {
 func NewPollingRequest(resp *http.Response, c Client) (*http.Request, error) {
 	location := GetPollingLocation(resp)
 	if location == "" {
-		return nil, NewErrorWithStatusCode("autorest", "NewPollingRequest", resp.StatusCode, "Location header missing from response that requires polling")
+		return nil, NewErrorWithResponse("autorest", "NewPollingRequest", resp, "Location header missing from response that requires polling")
 	}
 
 	req, err := Prepare(&http.Request{},
@@ -101,7 +101,7 @@ func NewPollingRequest(resp *http.Response, c Client) (*http.Request, error) {
 		WithBaseURL(location),
 		c.WithAuthorization())
 	if err != nil {
-		return nil, NewErrorWithError(err, "autorest", "NewPollingRequest", UndefinedStatusCode, "Failure creating poll request to %s", location)
+		return nil, NewErrorWithError(err, "autorest", "NewPollingRequest", nil, "Failure creating poll request to %s", location)
 	}
 
 	Respond(resp,

--- a/autorest/azure/token.go
+++ b/autorest/azure/token.go
@@ -236,7 +236,7 @@ func (spt *ServicePrincipalToken) Refresh() error {
 	resp, err := autorest.SendWithSender(spt.sender, req)
 	if err != nil {
 		return autorest.NewErrorWithError(err,
-			"azure.ServicePrincipalToken", "Refresh", resp.StatusCode, "Failure sending request for Service Principal %s",
+			"azure.ServicePrincipalToken", "Refresh", resp, "Failure sending request for Service Principal %s",
 			spt.clientID)
 	}
 
@@ -248,7 +248,7 @@ func (spt *ServicePrincipalToken) Refresh() error {
 		autorest.ByClosing())
 	if err != nil {
 		return autorest.NewErrorWithError(err,
-			"azure.ServicePrincipalToken", "Refresh", resp.StatusCode, "Failure handling response to Service Principal %s request",
+			"azure.ServicePrincipalToken", "Refresh", resp, "Failure handling response to Service Principal %s request",
 			spt.clientID)
 	}
 
@@ -288,7 +288,7 @@ func (spt *ServicePrincipalToken) WithAuthorization() autorest.PrepareDecorator 
 				err := spt.EnsureFresh()
 				if err != nil {
 					return r, autorest.NewErrorWithError(err,
-						"azure.ServicePrincipalToken", "WithAuthorization", autorest.UndefinedStatusCode, "Failed to refresh Service Principal Token for request to %s",
+						"azure.ServicePrincipalToken", "WithAuthorization", nil, "Failed to refresh Service Principal Token for request to %s",
 						r.URL)
 				}
 			}

--- a/autorest/client.go
+++ b/autorest/client.go
@@ -141,7 +141,7 @@ func NewClientWithUserAgent(ua string) Client {
 // requires it, otherwise it returns nil.
 func (c Client) IsPollingAllowed(resp *http.Response, codes ...int) error {
 	if c.DoNotPoll() && ResponseRequiresPolling(resp, codes...) {
-		return NewErrorWithStatusCode("autorest/Client", "IsPollingAllowed", resp.StatusCode, "Response to %s requires polling but polling is disabled",
+		return NewErrorWithResponse("autorest/Client", "IsPollingAllowed", resp, "Response to %s requires polling but polling is disabled",
 			resp.Request.URL)
 	}
 	return nil
@@ -154,13 +154,13 @@ func (c Client) PollAsNeeded(resp *http.Response, codes ...int) (*http.Response,
 	}
 
 	if c.DoNotPoll() {
-		return resp, NewErrorWithStatusCode("autorest/Client", "PollAsNeeded", resp.StatusCode, "Polling for %s is required, but polling is disabled",
+		return resp, NewErrorWithResponse("autorest/Client", "PollAsNeeded", resp, "Polling for %s is required, but polling is disabled",
 			resp.Request.URL)
 	}
 
 	req, err := NewPollingRequest(resp, c)
 	if err != nil {
-		return resp, NewErrorWithError(err, "autorest/Client", "PollAsNeeded", resp.StatusCode, "Unable to create polling request for response to %s",
+		return resp, NewErrorWithError(err, "autorest/Client", "PollAsNeeded", resp, "Unable to create polling request for response to %s",
 			resp.Request.URL)
 	}
 
@@ -196,7 +196,7 @@ func (c Client) Send(req *http.Request) (*http.Response, error) {
 		c.WithAuthorization(),
 		c.WithInspection())
 	if err != nil {
-		return nil, NewErrorWithError(err, "autorest/Client", "Send", UndefinedStatusCode, "Preparing request failed")
+		return nil, NewErrorWithError(err, "autorest/Client", "Send", nil, "Preparing request failed")
 	}
 
 	resp, err := SendWithSender(c, req)

--- a/autorest/error.go
+++ b/autorest/error.go
@@ -2,6 +2,7 @@ package autorest
 
 import (
 	"fmt"
+	"net/http"
 )
 
 const (
@@ -47,21 +48,28 @@ type baseError struct {
 // NewError creates a new Error conforming object from the passed packageType, method, and
 // message. message is treated as a format string to which the optional args apply.
 func NewError(packageType string, method string, message string, args ...interface{}) Error {
-	return NewErrorWithError(nil, packageType, method, UndefinedStatusCode, message, args...)
+	return NewErrorWithError(nil, packageType, method, nil, message, args...)
 }
 
-// NewErrorWithStatusCode creates a new Error conforming object from the passed packageType, method,
-// statusCode, and message. message is treated as a format string to which the optional args apply.
-func NewErrorWithStatusCode(packageType string, method string, statusCode int, message string, args ...interface{}) Error {
-	return NewErrorWithError(nil, packageType, method, statusCode, message, args...)
-}
-
-// NewErrorWithError creates a new Error conforming object from the passed packageType, method,
-// statusCode, message, and original error. message is treated as a format string to which the
+// NewErrorWithResponse creates a new Error conforming object from the passed
+// packageType, method, statusCode of the given resp (UndefinedStatusCode if
+// resp is nil), and message. message is treated as a format string to which the
 // optional args apply.
-func NewErrorWithError(original error, packageType string, method string, statusCode int, message string, args ...interface{}) Error {
-	if _, ok := original.(Error); ok {
-		return original.(Error)
+func NewErrorWithResponse(packageType string, method string, resp *http.Response, message string, args ...interface{}) Error {
+	return NewErrorWithError(nil, packageType, method, resp, message, args...)
+}
+
+// NewErrorWithError creates a new Error conforming object from the
+// passed packageType, method, statusCode of the given resp (UndefinedStatusCode
+// if resp is nil), message, and original error. message is treated as a format
+// string to which the optional args apply.
+func NewErrorWithError(original error, packageType string, method string, resp *http.Response, message string, args ...interface{}) Error {
+	if v, ok := original.(Error); ok {
+		return v
+	}
+	statusCode := UndefinedStatusCode
+	if resp != nil {
+		statusCode = resp.StatusCode
 	}
 	return baseError{
 		packageType: packageType,

--- a/autorest/error_test.go
+++ b/autorest/error_test.go
@@ -85,7 +85,16 @@ func TestNewErrorWithResponse_nilResponse_ReportsUndefinedStatusCode(t *testing.
 	}
 }
 
-func TestNewErrorForwards(t *testing.T) {
+func TestNewErrorWithResponse_Forwards(t *testing.T) {
+	e1 := NewError("packageType", "method", "message %s", "arg")
+	e2 := NewErrorWithResponse("packageType", "method", nil, "message %s", "arg")
+
+	if !reflect.DeepEqual(e1, e2) {
+		t.Error("autorest: NewError did not return an error equivelent to NewErrorWithError")
+	}
+}
+
+func TestNewErrorWithError_Forwards(t *testing.T) {
 	e1 := NewError("packageType", "method", "message %s", "arg")
 	e2 := NewErrorWithError(nil, "packageType", "method", nil, "message %s", "arg")
 

--- a/autorest/error_test.go
+++ b/autorest/error_test.go
@@ -8,40 +8,49 @@ import (
 	"testing"
 )
 
-func TestNewErrorWithErrorAssignsPackageType(t *testing.T) {
-	e := NewErrorWithError(fmt.Errorf("original"), "packageType", "method", http.StatusBadRequest, "message")
+func TestNewErrorWithError_AssignsPackageType(t *testing.T) {
+	e := NewErrorWithError(fmt.Errorf("original"), "packageType", "method", nil, "message")
 
 	if e.PackageType() != "packageType" {
 		t.Errorf("autorest: Error failed to set package type -- expected %v, received %v", "packageType", e.PackageType())
 	}
 }
 
-func TestNewErrorWithErrorAssignsMethod(t *testing.T) {
-	e := NewErrorWithError(fmt.Errorf("original"), "packageType", "method", http.StatusBadRequest, "message")
+func TestNewErrorWithError_AssignsMethod(t *testing.T) {
+	e := NewErrorWithError(fmt.Errorf("original"), "packageType", "method", nil, "message")
 
 	if e.Method() != "method" {
 		t.Errorf("autorest: Error failed to set method -- expected %v, received %v", "method", e.Method())
 	}
 }
 
-func TestNewErrorWithErrorAssignsMessage(t *testing.T) {
-	e := NewErrorWithError(fmt.Errorf("original"), "packageType", "method", http.StatusBadRequest, "message")
+func TestNewErrorWithError_AssignsMessage(t *testing.T) {
+	e := NewErrorWithError(fmt.Errorf("original"), "packageType", "method", nil, "message")
 
 	if e.Message() != "message" {
 		t.Errorf("autorest: Error failed to set message -- expected %v, received %v", "message", e.Message())
 	}
 }
 
-func TestNewErrorWithErrorAssignsStatusCode(t *testing.T) {
-	e := NewErrorWithError(fmt.Errorf("original"), "packageType", "method", http.StatusBadRequest, "message")
+func TestNewErrorWithError_AssignsUndefinedStatusCodeIfRespNil(t *testing.T) {
+	e := NewErrorWithError(nil, "packageType", "method", nil, "message")
+	if e.StatusCode() != UndefinedStatusCode {
+		t.Errorf("autorest: Error failed to set status code -- expected %v, received %v", UndefinedStatusCode, e.StatusCode())
+	}
+}
+
+func TestNewErrorWithError_AssignsStatusCode(t *testing.T) {
+	e := NewErrorWithError(fmt.Errorf("original"), "packageType", "method", &http.Response{
+		StatusCode: http.StatusBadRequest,
+		Status:     http.StatusText(http.StatusBadRequest)}, "message")
 
 	if e.StatusCode() != http.StatusBadRequest {
 		t.Errorf("autorest: Error failed to set status code -- expected %v, received %v", http.StatusBadRequest, e.StatusCode())
 	}
 }
 
-func TestNewErrorWithErrorAcceptsArgs(t *testing.T) {
-	e := NewErrorWithError(fmt.Errorf("original"), "packageType", "method", http.StatusBadRequest, "message %s", "arg")
+func TestNewErrorWithError_AcceptsArgs(t *testing.T) {
+	e := NewErrorWithError(fmt.Errorf("original"), "packageType", "method", nil, "message %s", "arg")
 
 	if matched, _ := regexp.MatchString(`.*arg.*`, e.Message()); !matched {
 		t.Errorf("autorest: Error failed to apply message arguments -- expected %v, received %v",
@@ -49,18 +58,36 @@ func TestNewErrorWithErrorAcceptsArgs(t *testing.T) {
 	}
 }
 
-func TestNewErrorWithErrorAssignsError(t *testing.T) {
+func TestNewErrorWithError_AssignsError(t *testing.T) {
 	err := fmt.Errorf("original")
-	e := NewErrorWithError(err, "packageType", "method", http.StatusBadRequest, "message")
+	e := NewErrorWithError(err, "packageType", "method", nil, "message")
 
 	if e.Original() != err {
 		t.Errorf("autorest: Error failed to set error -- expected %v, received %v", err, e.Original())
 	}
 }
 
+func TestNewErrorWithResponse_ContainsStatusCode(t *testing.T) {
+	e := NewErrorWithResponse("packageType", "method", &http.Response{
+		StatusCode: http.StatusBadRequest,
+		Status:     http.StatusText(http.StatusBadRequest)}, "message")
+
+	if e.StatusCode() != http.StatusBadRequest {
+		t.Errorf("autorest: Error failed to set status code -- expected %v, received %v", http.StatusBadRequest, e.StatusCode())
+	}
+}
+
+func TestNewErrorWithResponse_nilResponse_ReportsUndefinedStatusCode(t *testing.T) {
+	e := NewErrorWithResponse("packageType", "method", nil, "message")
+
+	if e.StatusCode() != UndefinedStatusCode {
+		t.Errorf("autorest: Error failed to set status code -- expected %v, received %v", UndefinedStatusCode, e.StatusCode())
+	}
+}
+
 func TestNewErrorForwards(t *testing.T) {
 	e1 := NewError("packageType", "method", "message %s", "arg")
-	e2 := NewErrorWithError(nil, "packageType", "method", UndefinedStatusCode, "message %s", "arg")
+	e2 := NewErrorWithError(nil, "packageType", "method", nil, "message %s", "arg")
 
 	if !reflect.DeepEqual(e1, e2) {
 		t.Error("autorest: NewError did not return an error equivelent to NewErrorWithError")
@@ -69,7 +96,7 @@ func TestNewErrorForwards(t *testing.T) {
 
 func TestErrorError(t *testing.T) {
 	err := fmt.Errorf("original")
-	e := NewErrorWithError(err, "packageType", "method", http.StatusBadRequest, "message")
+	e := NewErrorWithError(err, "packageType", "method", nil, "message")
 
 	if matched, _ := regexp.MatchString(`.*original.*`, e.Error()); !matched {
 		t.Errorf("autorest: Error#Error failed to return original error message -- expected %v, received %v",
@@ -78,7 +105,7 @@ func TestErrorError(t *testing.T) {
 }
 
 func TestErrorStringConstainsPackageType(t *testing.T) {
-	e := NewErrorWithError(fmt.Errorf("original"), "packageType", "method", http.StatusBadRequest, "message")
+	e := NewErrorWithError(fmt.Errorf("original"), "packageType", "method", nil, "message")
 
 	if matched, _ := regexp.MatchString(`.*packageType.*`, e.String()); !matched {
 		t.Errorf("autorest: Error#String failed to include PackageType -- expected %v, received %v",
@@ -87,7 +114,7 @@ func TestErrorStringConstainsPackageType(t *testing.T) {
 }
 
 func TestErrorStringConstainsMethod(t *testing.T) {
-	e := NewErrorWithError(fmt.Errorf("original"), "packageType", "method", http.StatusBadRequest, "message")
+	e := NewErrorWithError(fmt.Errorf("original"), "packageType", "method", nil, "message")
 
 	if matched, _ := regexp.MatchString(`.*method.*`, e.String()); !matched {
 		t.Errorf("autorest: Error#String failed to include Method -- expected %v, received %v",
@@ -96,7 +123,7 @@ func TestErrorStringConstainsMethod(t *testing.T) {
 }
 
 func TestErrorStringConstainsMessage(t *testing.T) {
-	e := NewErrorWithError(fmt.Errorf("original"), "packageType", "method", http.StatusBadRequest, "message")
+	e := NewErrorWithError(fmt.Errorf("original"), "packageType", "method", nil, "message")
 
 	if matched, _ := regexp.MatchString(`.*message.*`, e.String()); !matched {
 		t.Errorf("autorest: Error#String failed to include Message -- expected %v, received %v",
@@ -105,7 +132,9 @@ func TestErrorStringConstainsMessage(t *testing.T) {
 }
 
 func TestErrorStringConstainsStatusCode(t *testing.T) {
-	e := NewErrorWithError(fmt.Errorf("original"), "packageType", "method", http.StatusBadRequest, "message")
+	e := NewErrorWithError(fmt.Errorf("original"), "packageType", "method", &http.Response{
+		StatusCode: http.StatusBadRequest,
+		Status:     http.StatusText(http.StatusBadRequest)}, "message")
 
 	if matched, _ := regexp.MatchString(`.*400.*`, e.String()); !matched {
 		t.Errorf("autorest: Error#String failed to include Status Code -- expected %v, received %v",
@@ -114,7 +143,7 @@ func TestErrorStringConstainsStatusCode(t *testing.T) {
 }
 
 func TestErrorStringConstainsOriginal(t *testing.T) {
-	e := NewErrorWithError(fmt.Errorf("original"), "packageType", "method", http.StatusBadRequest, "message")
+	e := NewErrorWithError(fmt.Errorf("original"), "packageType", "method", nil, "message")
 
 	if matched, _ := regexp.MatchString(`.*original.*`, e.String()); !matched {
 		t.Errorf("autorest: Error#String failed to include Original error -- expected %v, received %v",

--- a/autorest/responder.go
+++ b/autorest/responder.go
@@ -133,7 +133,7 @@ func WithErrorUnlessStatusCode(codes ...int) RespondDecorator {
 		return ResponderFunc(func(resp *http.Response) error {
 			err := r.Respond(resp)
 			if err == nil && !ResponseHasStatusCode(resp, codes...) {
-				err = NewErrorWithStatusCode("autorest", "WithErrorUnlessStatusCode", resp.StatusCode, "%v %v failed with %s",
+				err = NewErrorWithResponse("autorest", "WithErrorUnlessStatusCode", resp, "%v %v failed with %s",
 					resp.Request.Method,
 					resp.Request.URL,
 					resp.Status)

--- a/autorest/sender.go
+++ b/autorest/sender.go
@@ -139,7 +139,7 @@ func DoErrorIfStatusCode(codes ...int) SendDecorator {
 		return SenderFunc(func(r *http.Request) (*http.Response, error) {
 			resp, err := s.Do(r)
 			if err == nil && ResponseHasStatusCode(resp, codes...) {
-				err = NewErrorWithStatusCode("autorest", "DoErrorIfStatusCode", resp.StatusCode, "%v %v failed with %s",
+				err = NewErrorWithResponse("autorest", "DoErrorIfStatusCode", resp, "%v %v failed with %s",
 					resp.Request.Method,
 					resp.Request.URL,
 					resp.Status)
@@ -157,7 +157,7 @@ func DoErrorUnlessStatusCode(codes ...int) SendDecorator {
 		return SenderFunc(func(r *http.Request) (*http.Response, error) {
 			resp, err := s.Do(r)
 			if err == nil && !ResponseHasStatusCode(resp, codes...) {
-				err = NewErrorWithStatusCode("autorest", "DoErrorUnlessStatusCode", resp.StatusCode, "%v %v failed with %s",
+				err = NewErrorWithResponse("autorest", "DoErrorUnlessStatusCode", resp, "%v %v failed with %s",
 					resp.Request.Method,
 					resp.Request.URL,
 					resp.Status)


### PR DESCRIPTION
In cases where resp would be nil (such as net.Dial failures) code
in azure sdk et al. just panics with nil dereference error.

I am making NewErrorWithError take an *http.Response instead of
status code and handling nil of this argument internally.

Also removed NewErrorWithStatusCode and added NewErrorWithResponse
for cases where inner error does not exist.