### PR TITLE
Re-adding code to close Response Body if Sending returns an error

### DIFF
--- a/autorest/client.go
+++ b/autorest/client.go
@@ -207,6 +207,11 @@ func (c Client) Send(req *http.Request) (*http.Response, error) {
 		}
 	}
 
+	if err != nil {
+		Respond(resp,
+			ByClosing())
+	}
+
 	return resp, err
 }
 

--- a/autorest/client_test.go
+++ b/autorest/client_test.go
@@ -407,6 +407,19 @@ func TestClientSendDefaultsToUsingStatusCodeOK(t *testing.T) {
 	}
 }
 
+func TestClientSendClosesReponseBodyWhenReturningError(t *testing.T) {
+	s := mocks.NewSender()
+	s.EmitErrors(1)
+	r := mocks.NewResponse()
+	s.SetResponse(r)
+	c := Client{Sender: s}
+
+	c.Send(mocks.NewRequest())
+	if r.Body.(*mocks.Body).IsOpen() {
+		t.Error("autorest: Client#Send failed to close the response body when returning an error")
+	}
+}
+
 func TestClientSendPollsIfNeeded(t *testing.T) {
 	r := mocks.NewRequest()
 	s := mocks.NewSender()


### PR DESCRIPTION
We were too aggressive in removing the Body closure when Send returns an error. If Send returns an unmanufactured error (e.g., network failure), we should close the Response Body any time the Body is non-nil.

Signed-off-by: Brendan Dixon <brendand@microsoft.com>