### PR TITLE
Ensured Azure service errors are unwrapped

### DIFF
--- a/autorest/error.go
+++ b/autorest/error.go
@@ -10,44 +10,29 @@ const (
 	UndefinedStatusCode = 0
 )
 
-// Error describes the methods implemented by autorest errors.
-type Error interface {
-	error
+// DetailedError encloses a error with details of the package, method, and associated HTTP
+// status code (if any).
+type DetailedError struct {
+	Original error
 
-	// PackageType should return the package type of the object emitting the error. For types, the
-	// value should match that produced the the '%T' format specifier of the fmt package. For other
-	// elements, such as functions, it returns just the package name (e.g., "autorest").
-	PackageType() string
+	// PackageType is the package type of the object emitting the error. For types, the value
+	// matches that produced the the '%T' format specifier of the fmt package. For other elements,
+	// such as functions, it is just the package name (e.g., "autorest").
+	PackageType string
 
-	// Method should return the name of the method raising the error.
-	Method() string
+	// Method is the name of the method raising the error.
+	Method string
 
-	// StatusCode returns the HTTP Response StatusCode (if non-zero) that led to the error.
-	StatusCode() int
+	// StatusCode is the HTTP Response StatusCode (if non-zero) that led to the error.
+	StatusCode int
 
-	// Message should return the error message.
-	Message() string
-
-	// String should return a formatted containing all available details (i.e., PackageType, Method,
-	// Message, and original error (if any)).
-	String() string
-
-	// Original should return the original error, if any, and nil otherwise.
-	Original() error
-}
-
-type baseError struct {
-	packageType string
-	method      string
-	statusCode  int
-	message     string
-
-	original error
+	// Message is the error message.
+	Message string
 }
 
 // NewError creates a new Error conforming object from the passed packageType, method, and
 // message. message is treated as a format string to which the optional args apply.
-func NewError(packageType string, method string, message string, args ...interface{}) Error {
+func NewError(packageType string, method string, message string, args ...interface{}) DetailedError {
 	return NewErrorWithError(nil, packageType, method, nil, message, args...)
 }
 
@@ -55,7 +40,7 @@ func NewError(packageType string, method string, message string, args ...interfa
 // packageType, method, statusCode of the given resp (UndefinedStatusCode if
 // resp is nil), and message. message is treated as a format string to which the
 // optional args apply.
-func NewErrorWithResponse(packageType string, method string, resp *http.Response, message string, args ...interface{}) Error {
+func NewErrorWithResponse(packageType string, method string, resp *http.Response, message string, args ...interface{}) DetailedError {
 	return NewErrorWithError(nil, packageType, method, resp, message, args...)
 }
 
@@ -63,60 +48,29 @@ func NewErrorWithResponse(packageType string, method string, resp *http.Response
 // passed packageType, method, statusCode of the given resp (UndefinedStatusCode
 // if resp is nil), message, and original error. message is treated as a format
 // string to which the optional args apply.
-func NewErrorWithError(original error, packageType string, method string, resp *http.Response, message string, args ...interface{}) Error {
-	if v, ok := original.(Error); ok {
+func NewErrorWithError(original error, packageType string, method string, resp *http.Response, message string, args ...interface{}) DetailedError {
+	if v, ok := original.(DetailedError); ok {
 		return v
 	}
+
 	statusCode := UndefinedStatusCode
 	if resp != nil {
 		statusCode = resp.StatusCode
 	}
-	return baseError{
-		packageType: packageType,
-		method:      method,
-		statusCode:  statusCode,
-		message:     fmt.Sprintf(message, args...),
-		original:    original,
+	return DetailedError{
+		Original:    original,
+		PackageType: packageType,
+		Method:      method,
+		StatusCode:  statusCode,
+		Message:     fmt.Sprintf(message, args...),
 	}
 }
 
-// PackageType returns the package type of the object emitting the error. For types, the value
-// matches that produced the the '%T' format specifier of the fmt package. For other elements,
-// such as functions, it returns just the package name (e.g., "autorest").
-func (be baseError) PackageType() string {
-	return be.packageType
-}
-
-// Method returns the name of the method raising the error.
-func (be baseError) Method() string {
-	return be.method
-}
-
-// StatusCode returns the HTTP Response StatusCode (if non-zero) that led to the error.
-func (be baseError) StatusCode() int {
-	return be.statusCode
-}
-
-// Message is the error message.
-func (be baseError) Message() string {
-	return be.message
-}
-
-// Original returns the original error, if any, and nil otherwise.
-func (be baseError) Original() error {
-	return be.original
-}
-
-// Error returns the same formatted string as String.
-func (be baseError) Error() string {
-	return be.String()
-}
-
-// String returns a formatted containing all available details (i.e., PackageType, Method,
+// Error returns a formatted containing all available details (i.e., PackageType, Method,
 // StatusCode, Message, and original error (if any)).
-func (be baseError) String() string {
-	if be.original == nil {
-		return fmt.Sprintf("%s:%s %v %s", be.packageType, be.method, be.statusCode, be.message)
+func (e DetailedError) Error() string {
+	if e.Original == nil {
+		return fmt.Sprintf("%s:%s %v %s", e.PackageType, e.Method, e.StatusCode, e.Message)
 	}
-	return fmt.Sprintf("%s:%s %v %s -- Original Error: %v", be.packageType, be.method, be.statusCode, be.message, be.original)
+	return fmt.Sprintf("%s:%s %v %s -- Original Error: %v", e.PackageType, e.Method, e.StatusCode, e.Message, e.Original)
 }

--- a/autorest/error_test.go
+++ b/autorest/error_test.go
@@ -11,31 +11,31 @@ import (
 func TestNewErrorWithError_AssignsPackageType(t *testing.T) {
 	e := NewErrorWithError(fmt.Errorf("original"), "packageType", "method", nil, "message")
 
-	if e.PackageType() != "packageType" {
-		t.Errorf("autorest: Error failed to set package type -- expected %v, received %v", "packageType", e.PackageType())
+	if e.PackageType != "packageType" {
+		t.Errorf("autorest: Error failed to set package type -- expected %v, received %v", "packageType", e.PackageType)
 	}
 }
 
 func TestNewErrorWithError_AssignsMethod(t *testing.T) {
 	e := NewErrorWithError(fmt.Errorf("original"), "packageType", "method", nil, "message")
 
-	if e.Method() != "method" {
-		t.Errorf("autorest: Error failed to set method -- expected %v, received %v", "method", e.Method())
+	if e.Method != "method" {
+		t.Errorf("autorest: Error failed to set method -- expected %v, received %v", "method", e.Method)
 	}
 }
 
 func TestNewErrorWithError_AssignsMessage(t *testing.T) {
 	e := NewErrorWithError(fmt.Errorf("original"), "packageType", "method", nil, "message")
 
-	if e.Message() != "message" {
-		t.Errorf("autorest: Error failed to set message -- expected %v, received %v", "message", e.Message())
+	if e.Message != "message" {
+		t.Errorf("autorest: Error failed to set message -- expected %v, received %v", "message", e.Message)
 	}
 }
 
 func TestNewErrorWithError_AssignsUndefinedStatusCodeIfRespNil(t *testing.T) {
 	e := NewErrorWithError(nil, "packageType", "method", nil, "message")
-	if e.StatusCode() != UndefinedStatusCode {
-		t.Errorf("autorest: Error failed to set status code -- expected %v, received %v", UndefinedStatusCode, e.StatusCode())
+	if e.StatusCode != UndefinedStatusCode {
+		t.Errorf("autorest: Error failed to set status code -- expected %v, received %v", UndefinedStatusCode, e.StatusCode)
 	}
 }
 
@@ -44,17 +44,17 @@ func TestNewErrorWithError_AssignsStatusCode(t *testing.T) {
 		StatusCode: http.StatusBadRequest,
 		Status:     http.StatusText(http.StatusBadRequest)}, "message")
 
-	if e.StatusCode() != http.StatusBadRequest {
-		t.Errorf("autorest: Error failed to set status code -- expected %v, received %v", http.StatusBadRequest, e.StatusCode())
+	if e.StatusCode != http.StatusBadRequest {
+		t.Errorf("autorest: Error failed to set status code -- expected %v, received %v", http.StatusBadRequest, e.StatusCode)
 	}
 }
 
 func TestNewErrorWithError_AcceptsArgs(t *testing.T) {
 	e := NewErrorWithError(fmt.Errorf("original"), "packageType", "method", nil, "message %s", "arg")
 
-	if matched, _ := regexp.MatchString(`.*arg.*`, e.Message()); !matched {
+	if matched, _ := regexp.MatchString(`.*arg.*`, e.Message); !matched {
 		t.Errorf("autorest: Error failed to apply message arguments -- expected %v, received %v",
-			`.*arg.*`, e.Message())
+			`.*arg.*`, e.Message)
 	}
 }
 
@@ -62,8 +62,8 @@ func TestNewErrorWithError_AssignsError(t *testing.T) {
 	err := fmt.Errorf("original")
 	e := NewErrorWithError(err, "packageType", "method", nil, "message")
 
-	if e.Original() != err {
-		t.Errorf("autorest: Error failed to set error -- expected %v, received %v", err, e.Original())
+	if e.Original != err {
+		t.Errorf("autorest: Error failed to set error -- expected %v, received %v", err, e.Original)
 	}
 }
 
@@ -72,16 +72,16 @@ func TestNewErrorWithResponse_ContainsStatusCode(t *testing.T) {
 		StatusCode: http.StatusBadRequest,
 		Status:     http.StatusText(http.StatusBadRequest)}, "message")
 
-	if e.StatusCode() != http.StatusBadRequest {
-		t.Errorf("autorest: Error failed to set status code -- expected %v, received %v", http.StatusBadRequest, e.StatusCode())
+	if e.StatusCode != http.StatusBadRequest {
+		t.Errorf("autorest: Error failed to set status code -- expected %v, received %v", http.StatusBadRequest, e.StatusCode)
 	}
 }
 
 func TestNewErrorWithResponse_nilResponse_ReportsUndefinedStatusCode(t *testing.T) {
 	e := NewErrorWithResponse("packageType", "method", nil, "message")
 
-	if e.StatusCode() != UndefinedStatusCode {
-		t.Errorf("autorest: Error failed to set status code -- expected %v, received %v", UndefinedStatusCode, e.StatusCode())
+	if e.StatusCode != UndefinedStatusCode {
+		t.Errorf("autorest: Error failed to set status code -- expected %v, received %v", UndefinedStatusCode, e.StatusCode)
 	}
 }
 
@@ -103,7 +103,25 @@ func TestNewErrorWithError_Forwards(t *testing.T) {
 	}
 }
 
-func TestErrorError(t *testing.T) {
+func TestNewErrorWithError_DoesNotWrapADetailedError(t *testing.T) {
+	e1 := NewError("packageType1", "method1", "message1 %s", "arg1")
+	e2 := NewErrorWithError(e1, "packageType2", "method2", nil, "message2 %s", "arg2")
+
+	if !reflect.DeepEqual(e1, e2) {
+		t.Errorf("autorest: NewErrorWithError incorrectly wrapped a DetailedError -- expected %v, received %v", e1, e2)
+	}
+}
+
+func TestNewErrorWithError_WrapsAnError(t *testing.T) {
+	e1 := fmt.Errorf("Inner Error")
+	var e2 interface{} = NewErrorWithError(e1, "packageType", "method", nil, "message")
+
+	if _, ok := e2.(DetailedError); !ok {
+		t.Errorf("autorest: NewErrorWithError failed to wrap a standard error -- received %T", e2)
+	}
+}
+
+func TestDetailedError(t *testing.T) {
 	err := fmt.Errorf("original")
 	e := NewErrorWithError(err, "packageType", "method", nil, "message")
 
@@ -113,58 +131,58 @@ func TestErrorError(t *testing.T) {
 	}
 }
 
-func TestErrorStringConstainsPackageType(t *testing.T) {
+func TestDetailedErrorConstainsPackageType(t *testing.T) {
 	e := NewErrorWithError(fmt.Errorf("original"), "packageType", "method", nil, "message")
 
-	if matched, _ := regexp.MatchString(`.*packageType.*`, e.String()); !matched {
+	if matched, _ := regexp.MatchString(`.*packageType.*`, e.Error()); !matched {
 		t.Errorf("autorest: Error#String failed to include PackageType -- expected %v, received %v",
-			`.*packageType.*`, e.String())
+			`.*packageType.*`, e.Error())
 	}
 }
 
-func TestErrorStringConstainsMethod(t *testing.T) {
+func TestDetailedErrorConstainsMethod(t *testing.T) {
 	e := NewErrorWithError(fmt.Errorf("original"), "packageType", "method", nil, "message")
 
-	if matched, _ := regexp.MatchString(`.*method.*`, e.String()); !matched {
+	if matched, _ := regexp.MatchString(`.*method.*`, e.Error()); !matched {
 		t.Errorf("autorest: Error#String failed to include Method -- expected %v, received %v",
-			`.*method.*`, e.String())
+			`.*method.*`, e.Error())
 	}
 }
 
-func TestErrorStringConstainsMessage(t *testing.T) {
+func TestDetailedErrorConstainsMessage(t *testing.T) {
 	e := NewErrorWithError(fmt.Errorf("original"), "packageType", "method", nil, "message")
 
-	if matched, _ := regexp.MatchString(`.*message.*`, e.String()); !matched {
+	if matched, _ := regexp.MatchString(`.*message.*`, e.Error()); !matched {
 		t.Errorf("autorest: Error#String failed to include Message -- expected %v, received %v",
-			`.*message.*`, e.String())
+			`.*message.*`, e.Error())
 	}
 }
 
-func TestErrorStringConstainsStatusCode(t *testing.T) {
+func TestDetailedErrorConstainsStatusCode(t *testing.T) {
 	e := NewErrorWithError(fmt.Errorf("original"), "packageType", "method", &http.Response{
 		StatusCode: http.StatusBadRequest,
 		Status:     http.StatusText(http.StatusBadRequest)}, "message")
 
-	if matched, _ := regexp.MatchString(`.*400.*`, e.String()); !matched {
+	if matched, _ := regexp.MatchString(`.*400.*`, e.Error()); !matched {
 		t.Errorf("autorest: Error#String failed to include Status Code -- expected %v, received %v",
-			`.*400.*`, e.String())
+			`.*400.*`, e.Error())
 	}
 }
 
-func TestErrorStringConstainsOriginal(t *testing.T) {
+func TestDetailedErrorConstainsOriginal(t *testing.T) {
 	e := NewErrorWithError(fmt.Errorf("original"), "packageType", "method", nil, "message")
 
-	if matched, _ := regexp.MatchString(`.*original.*`, e.String()); !matched {
+	if matched, _ := regexp.MatchString(`.*original.*`, e.Error()); !matched {
 		t.Errorf("autorest: Error#String failed to include Original error -- expected %v, received %v",
-			`.*original.*`, e.String())
+			`.*original.*`, e.Error())
 	}
 }
 
-func TestErrorStringSkipsOriginal(t *testing.T) {
+func TestDetailedErrorSkipsOriginal(t *testing.T) {
 	e := NewError("packageType", "method", "message")
 
-	if matched, _ := regexp.MatchString(`.*Original.*`, e.String()); matched {
+	if matched, _ := regexp.MatchString(`.*Original.*`, e.Error()); matched {
 		t.Errorf("autorest: Error#String included missing Original error -- unexpected %v, received %v",
-			`.*Original.*`, e.String())
+			`.*Original.*`, e.Error())
 	}
 }


### PR DESCRIPTION
Restructured Azure and Autorest errors to ensure they are not unnecessarily wrapped.

Signed-off-by: Brendan Dixon <brendand@microsoft.com>