### PR TITLE
Allow user to specify tenant id during device flow

### DIFF
--- a/autorest/azure/devicetoken.go
+++ b/autorest/azure/devicetoken.go
@@ -13,16 +13,17 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/Azure/go-autorest/autorest"
 )
 
 const (
-	// OAuthDeviceEndpoint is Azure's OAuth2 Device Flow Endpoint
-	OAuthDeviceEndpoint = "https://login.microsoftonline.com/common/oauth2/devicecode"
-	// OAuthTokenEndpoint is Azure's OAuth2 Token Endpoint
-	OAuthTokenEndpoint = "https://login.microsoftonline.com/common/oauth2/token"
+	// OAuthDeviceEndpointTemplate is Azure's OAuth2 Device Flow Endpoint
+	OAuthDeviceEndpointTemplate = "https://login.microsoftonline.com/{tenantId}/oauth2/devicecode"
+	// OAuthTokenEndpointTemplate is Azure's OAuth2 Token Endpoint
+	OAuthTokenEndpointTemplate = "https://login.microsoftonline.com/{tenantId}/oauth2/token"
 
 	// authAPIVersionQueryParamName is the name
 	authAPIVersionQueryParamName  = "api-version"
@@ -63,7 +64,9 @@ type DeviceCode struct {
 	Interval        *int64  `json:"interval,string,omitempty"`
 
 	Message  *string `json:"message"` // Azure specific
-	Resource *string // store this as well, needed during token exchange for azure
+	Resource string  // store the following, stored when initiating, used when exchanging
+	ClientID string
+	TenantID string
 }
 
 // TokenError is the object returned by the token exchange endpoint
@@ -86,12 +89,14 @@ type deviceToken struct {
 
 // InitiateDeviceAuth initiates a device auth flow. It returns a DeviceCode
 // that can be used with CheckForUserCompletion or WaitForUserCompletion.
-func InitiateDeviceAuth(client *autorest.Client, clientID, resource string) (*DeviceCode, error) {
+func InitiateDeviceAuth(client *autorest.Client, clientID, tenantID, resource string) (*DeviceCode, error) {
+	oAuthDeviceEndpoint := strings.Replace(OAuthDeviceEndpointTemplate, "{tenantId}", tenantID, -1)
+
 	req, _ := autorest.Prepare(
 		&http.Request{},
 		autorest.AsPost(),
 		autorest.AsFormURLEncoded(),
-		autorest.WithBaseURL(OAuthDeviceEndpoint),
+		autorest.WithBaseURL(oAuthDeviceEndpoint),
 		autorest.WithFormData(url.Values{
 			"client_id": []string{clientID},
 			"resource":  []string{resource},
@@ -115,24 +120,28 @@ func InitiateDeviceAuth(client *autorest.Client, clientID, resource string) (*De
 		return nil, fmt.Errorf("%s %s: %s", logPrefix, errCodeHandlingFails, err)
 	}
 
-	code.Resource = &resource
+	code.ClientID = clientID
+	code.TenantID = tenantID
+	code.Resource = resource
 
 	return &code, nil
 }
 
 // CheckForUserCompletion takes a DeviceCode and checks with the Azure AD OAuth endpoint
 // to see if the device flow has: been completed, timed out, or otherwise failed
-func CheckForUserCompletion(client *autorest.Client, clientID string, code *DeviceCode) (*Token, error) {
+func CheckForUserCompletion(client *autorest.Client, code *DeviceCode) (*Token, error) {
+	oAuthTokenEndpoint := strings.Replace(OAuthTokenEndpointTemplate, "{tenantId}", code.TenantID, -1)
+
 	req, _ := autorest.Prepare(
 		&http.Request{},
 		autorest.AsPost(),
 		autorest.AsFormURLEncoded(),
-		autorest.WithBaseURL(OAuthTokenEndpoint),
+		autorest.WithBaseURL(oAuthTokenEndpoint),
 		autorest.WithFormData(url.Values{
-			"client_id":  []string{clientID},
+			"client_id":  []string{code.ClientID},
 			"code":       []string{*code.DeviceCode},
 			"grant_type": []string{OAuthGrantTypeDeviceCode},
-			"resource":   []string{*code.Resource},
+			"resource":   []string{code.Resource},
 		}),
 		autorest.WithQueryParameters(map[string]interface{}{
 			authAPIVersionQueryParamName: authAPIVersionQueryParamValue,
@@ -173,12 +182,12 @@ func CheckForUserCompletion(client *autorest.Client, clientID string, code *Devi
 
 // WaitForUserCompletion calls CheckForUserCompletion repeatedly until a token is granted or an error state occurs.
 // This prevents the user from looping and checking against 'ErrDeviceAuthorizationPending'.
-func WaitForUserCompletion(client *autorest.Client, clientID string, code *DeviceCode) (*Token, error) {
+func WaitForUserCompletion(client *autorest.Client, code *DeviceCode) (*Token, error) {
 	intervalDuration := time.Duration(*code.Interval) * time.Second
 	waitDuration := intervalDuration
 
 	for {
-		token, err := CheckForUserCompletion(client, clientID, code)
+		token, err := CheckForUserCompletion(client, code)
 
 		if err == nil {
 			return token, nil

--- a/autorest/azure/devicetoken.go
+++ b/autorest/azure/devicetoken.go
@@ -90,16 +90,17 @@ type deviceToken struct {
 // InitiateDeviceAuth initiates a device auth flow. It returns a DeviceCode
 // that can be used with CheckForUserCompletion or WaitForUserCompletion.
 func InitiateDeviceAuth(client *autorest.Client, clientID, tenantID, resource string) (*DeviceCode, error) {
-	oAuthDeviceEndpoint := strings.Replace(OAuthDeviceEndpointTemplate, "{tenantId}", tenantID, -1)
-
 	req, _ := autorest.Prepare(
 		&http.Request{},
 		autorest.AsPost(),
 		autorest.AsFormURLEncoded(),
-		autorest.WithBaseURL(oAuthDeviceEndpoint),
+		autorest.WithBaseURL(OAuthDeviceEndpointTemplate),
 		autorest.WithFormData(url.Values{
 			"client_id": []string{clientID},
 			"resource":  []string{resource},
+		}),
+		autorest.WithPathParameters(map[string]interface{}{
+			"tenantId": tenantID,
 		}),
 		autorest.WithQueryParameters(map[string]interface{}{
 			authAPIVersionQueryParamName: authAPIVersionQueryParamValue,
@@ -142,6 +143,9 @@ func CheckForUserCompletion(client *autorest.Client, code *DeviceCode) (*Token, 
 			"code":       []string{*code.DeviceCode},
 			"grant_type": []string{OAuthGrantTypeDeviceCode},
 			"resource":   []string{code.Resource},
+		}),
+		autorest.WithPathParameters(map[string]interface{}{
+			"tenantId": code.TenantID,
 		}),
 		autorest.WithQueryParameters(map[string]interface{}{
 			authAPIVersionQueryParamName: authAPIVersionQueryParamValue,

--- a/autorest/azure/example/main.go
+++ b/autorest/azure/example/main.go
@@ -16,11 +16,12 @@ import (
 	"golang.org/x/crypto/pkcs12"
 )
 
-const resourceGroupURLTemplate = "https://management.azure.com/subscriptions/{subscription-id}/resourcegroups"
-const apiVersion = "2015-01-01"
-
-const nativeAppClientID = "a87032a7-203c-4bf7-913c-44c50d23409a"
-const resource = azure.AzureResourceManagerScope
+const (
+	resourceGroupURLTemplate = "https://management.azure.com/subscriptions/{subscription-id}/resourcegroups"
+	apiVersion               = "2015-01-01"
+	nativeAppClientID        = "a87032a7-203c-4bf7-913c-44c50d23409a"
+	resource                 = "https://management.core.windows.net/"
+)
 
 var (
 	mode           string
@@ -30,6 +31,7 @@ var (
 
 	tokenCachePath string
 	forceRefresh   bool
+	impatient      bool
 
 	certificatePath string
 )
@@ -41,28 +43,34 @@ func init() {
 	flag.StringVar(&tenantID, "tenantId", "", "tenant id")
 	flag.StringVar(&subscriptionID, "subscriptionId", "", "subscription id")
 	flag.StringVar(&tokenCachePath, "tokenCachePath", "", "location of oauth token cache")
-	flag.BoolVar(&forceRefresh, "forceRefresh", false, "pass true to force a token refresh")
+	flag.BoolVar(&forceRefresh, "forceRefresh", true, "pass true to force a token refresh")
+	flag.BoolVar(&impatient, "impatient", true, "pass true to check for device completion every 1 second")
 
 	flag.Parse()
 
 	log.Printf("mode(%s) certPath(%s) appID(%s) tenantID(%s), subID(%s)\n",
 		mode, certificatePath, applicationID, tenantID, subscriptionID)
 
-	if strings.Trim(tenantID, " ") == "" ||
-		strings.Trim(subscriptionID, " ") == "" {
-		log.Fatalln("Bad usage. Please specify applicationID, tenantID, subscriptionID")
+	if mode == "certificate" &&
+		(strings.Trim(tenantID, " ") == "" || strings.Trim(subscriptionID, " ") == "") {
+		log.Fatalln("Bad usage. Using certificate mode. Please specify tenantID, subscriptionID")
 	}
 
-	if mode != "certificate" && mode != "cached" && mode != "device" {
-		log.Fatalln("Bad usage. Mode must be one of 'certificate', 'cached' or 'device'.")
+	if mode != "certificate" && mode != "device" {
+		log.Fatalln("Bad usage. Mode must be one of 'certificate' or 'device'.")
 	}
 
 	if mode == "device" && applicationID == "" {
+		log.Println("Using device mode auth. Will use `azkube` clientID since none was specified on the comand line.")
 		applicationID = nativeAppClientID
 	}
 
 	if mode == "certificate" && strings.Trim(certificatePath, " ") == "" {
 		log.Fatalln("Bad usage. Mode 'certificate' requires the 'certificatePath' argument.")
+	}
+
+	if strings.Trim(tenantID, " ") == "" || strings.Trim(subscriptionID, " ") == "" || strings.Trim(applicationID, " ") == "" {
+		log.Fatalln("Bad usage. Must specify the 'tenantId' and 'subscriptionId'")
 	}
 }
 
@@ -104,7 +112,7 @@ func getSptFromCertificate(clientID, tenantID, resource, certicatePath string, c
 
 	certificate, rsaPrivateKey, err := decodePkcs12(certData, "")
 	if err != nil {
-		return nil, fmt.Errorf("failed to decode pkcs12 certificate while creating spt")
+		return nil, fmt.Errorf("failed to decode pkcs12 certificate while creating spt: %v", err)
 	}
 
 	spt, _ := azure.NewServicePrincipalTokenFromCertificate(
@@ -120,29 +128,37 @@ func getSptFromCertificate(clientID, tenantID, resource, certicatePath string, c
 
 func getSptFromDeviceFlow(clientID, tenantID, resource string, callbacks ...azure.TokenRefreshCallback) (*azure.ServicePrincipalToken, error) {
 	oauthClient := &autorest.Client{}
-	deviceCode, err := azure.InitiateDeviceAuth(oauthClient, clientID, resource)
+	deviceCode, err := azure.InitiateDeviceAuth(oauthClient, clientID, tenantID, resource)
 	if err != nil {
 		return nil, fmt.Errorf("failed to start device auth flow: %s", err)
 	}
 
 	fmt.Println(*deviceCode.Message)
 
-	token, err := azure.WaitForUserCompletion(oauthClient, clientID, deviceCode)
+	if impatient {
+		var i int64 = 1
+		deviceCode.Interval = &i
+	}
+
+	token, err := azure.WaitForUserCompletion(oauthClient, deviceCode)
 	if err != nil {
 		return nil, fmt.Errorf("failed to finish device auth flow: %s", err)
 	}
 
-	spt, _ := azure.NewServicePrincipalTokenFromManualToken(
+	spt, err := azure.NewServicePrincipalTokenFromManualToken(
 		clientID,
 		tenantID,
 		resource,
 		*token,
 		callbacks...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get oauth token from device flow: %v", err)
+	}
 
 	return spt, nil
 }
 
-func getresourceGroups(client *autorest.Client) ([]string, error) {
+func printResourceGroups(client *autorest.Client) error {
 	p := map[string]interface{}{"subscription-id": subscriptionID}
 	q := map[string]interface{}{"api-version": apiVersion}
 
@@ -154,7 +170,7 @@ func getresourceGroups(client *autorest.Client) ([]string, error) {
 
 	resp, err := client.Send(req)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	value := struct {
@@ -167,22 +183,26 @@ func getresourceGroups(client *autorest.Client) ([]string, error) {
 	dec := json.NewDecoder(resp.Body)
 	err = dec.Decode(&value)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	var names = make([]string, len(value.ResourceGroups))
+	var groupNames = make([]string, len(value.ResourceGroups))
 	for i, name := range value.ResourceGroups {
-		names[i] = name.Name
+		groupNames[i] = name.Name
 	}
-	return names, nil
+
+	log.Println("Groups:", strings.Join(groupNames, ","))
+	return err
 }
 
 func saveToken(spt azure.Token) {
-	err := azure.SaveToken(tokenCachePath, 0600, spt)
-	if err != nil {
-		log.Println("error saving token", err)
-	} else {
-		log.Println("saved token to", tokenCachePath)
+	if tokenCachePath != "" {
+		err := azure.SaveToken(tokenCachePath, 0600, spt)
+		if err != nil {
+			log.Println("error saving token", err)
+		} else {
+			log.Println("saved token to", tokenCachePath)
+		}
 	}
 }
 
@@ -191,8 +211,8 @@ func main() {
 	var err error
 
 	callback := func(t azure.Token) error {
-		log.Println("refresh callback was called because the cached oauth token was stale")
-		saveToken(spt.Token)
+		log.Println("refresh callback was called")
+		saveToken(t)
 		return nil
 	}
 
@@ -226,18 +246,14 @@ func main() {
 	client := &autorest.Client{}
 	client.Authorizer = spt
 
-	groupNames, err := getresourceGroups(client)
-	if err != nil {
-		log.Fatalln("failed to retrieve groups:", err)
-	}
-
-	log.Println("Groups:", strings.Join(groupNames, ","))
+	printResourceGroups(client)
 
 	if forceRefresh {
-		spt.Token.ExpiresOn = "0"
 		err = spt.Refresh()
 		if err != nil {
 			panic(err)
 		}
+		printResourceGroups(client)
 	}
+
 }

--- a/autorest/azure/example/main.go
+++ b/autorest/azure/example/main.go
@@ -43,8 +43,7 @@ func init() {
 	flag.StringVar(&tenantID, "tenantId", "", "tenant id")
 	flag.StringVar(&subscriptionID, "subscriptionId", "", "subscription id")
 	flag.StringVar(&tokenCachePath, "tokenCachePath", "", "location of oauth token cache")
-	flag.BoolVar(&forceRefresh, "forceRefresh", true, "pass true to force a token refresh")
-	flag.BoolVar(&impatient, "impatient", true, "pass true to check for device completion every 1 second")
+	flag.BoolVar(&forceRefresh, "forceRefresh", false, "pass true to force a token refresh")
 
 	flag.Parse()
 
@@ -52,7 +51,7 @@ func init() {
 		mode, certificatePath, applicationID, tenantID, subscriptionID)
 
 	if mode == "certificate" &&
-		(strings.Trim(tenantID, " ") == "" || strings.Trim(subscriptionID, " ") == "") {
+		(strings.TrimSpace(tenantID) == "" || strings.TrimSpace(subscriptionID) == "") {
 		log.Fatalln("Bad usage. Using certificate mode. Please specify tenantID, subscriptionID")
 	}
 
@@ -60,16 +59,16 @@ func init() {
 		log.Fatalln("Bad usage. Mode must be one of 'certificate' or 'device'.")
 	}
 
-	if mode == "device" && applicationID == "" {
+	if mode == "device" && strings.TrimSpace(applicationID) == "" {
 		log.Println("Using device mode auth. Will use `azkube` clientID since none was specified on the comand line.")
 		applicationID = nativeAppClientID
 	}
 
-	if mode == "certificate" && strings.Trim(certificatePath, " ") == "" {
+	if mode == "certificate" && strings.TrimSpace(certificatePath) == "" {
 		log.Fatalln("Bad usage. Mode 'certificate' requires the 'certificatePath' argument.")
 	}
 
-	if strings.Trim(tenantID, " ") == "" || strings.Trim(subscriptionID, " ") == "" || strings.Trim(applicationID, " ") == "" {
+	if strings.TrimSpace(tenantID) == "" || strings.TrimSpace(subscriptionID) == "" || strings.TrimSpace(applicationID) == "" {
 		log.Fatalln("Bad usage. Must specify the 'tenantId' and 'subscriptionId'")
 	}
 }
@@ -135,11 +134,6 @@ func getSptFromDeviceFlow(clientID, tenantID, resource string, callbacks ...azur
 
 	fmt.Println(*deviceCode.Message)
 
-	if impatient {
-		var i int64 = 1
-		deviceCode.Interval = &i
-	}
-
 	token, err := azure.WaitForUserCompletion(oauthClient, deviceCode)
 	if err != nil {
 		return nil, fmt.Errorf("failed to finish device auth flow: %s", err)
@@ -191,7 +185,7 @@ func printResourceGroups(client *autorest.Client) error {
 		groupNames[i] = name.Name
 	}
 
-	log.Println("Groups:", strings.Join(groupNames, ","))
+	log.Println("Groups:", strings.Join(groupNames, ", "))
 	return err
 }
 
@@ -255,5 +249,4 @@ func main() {
 		}
 		printResourceGroups(client)
 	}
-
 }

--- a/autorest/azure/token.go
+++ b/autorest/azure/token.go
@@ -212,6 +212,7 @@ func NewServicePrincipalTokenFromManualToken(id string, tenantID string, resourc
 	}
 
 	spt.Token = token
+
 	return spt, nil
 }
 

--- a/autorest/azure/token_test.go
+++ b/autorest/azure/token_test.go
@@ -199,13 +199,14 @@ func testServicePrincipalTokenRefreshSetsBody(t *testing.T, spt *ServicePrincipa
 				})
 			}
 		})())
+	fmt.Println(spt == nil)
 	spt.SetSender(s)
 	spt.Refresh()
 }
 
 func TestServicePrincipalTokenManualRefreshSetsBody(t *testing.T) {
-	sptCert := newServicePrincipalTokenManual()
-	testServicePrincipalTokenRefreshSetsBody(t, sptCert, func(t *testing.T, b []byte) {
+	sptManual := newServicePrincipalTokenManual()
+	testServicePrincipalTokenRefreshSetsBody(t, sptManual, func(t *testing.T, b []byte) {
 		if string(b) != defaultManualFormData {
 			t.Errorf("azure: ServicePrincipalToken#Refresh did not correctly set the HTTP Request Body -- expected %v, received %v",
 				defaultManualFormData, string(b))


### PR DESCRIPTION
This PR is meant to address issues affecting the reliability of device auth flow across a variety of scenarios (various combinations of apps, app owners, tenants, org/personal accounts).

This makes the device token auth flow a bit more generic. I was going to implement an alternative approach, but this is actually fine. The consumer can do what they like:

1. If they were, say interested in creating a really user friendly tool that didn't require knowledge of a subscriptionID ahead of time, they can get a `common` access tokens, list tenants, and refresh the `common` access token for a `tenant-specific` access token.

2. On the other hand, if the consumer knows `tenantID` they can go directly to the correct authority and skip the refresh orchestration (which is what was suggested to us by AAD, though I'm still not sure I agree. We document the common endpoint and we document the use of multiresource tokens granted by the common endpoint).

3. Or if the consumer has only the subscriptionID, they can attempt to get the subscription which will then contain a WWW-Authenticate header that includes a link to the correct authority and tenant specfic oauth endpoint. Then this tenantID can be used as in option 2.

I've tested this with: my personal MSA, my personal subscription's tenant's organizational user, my Microsoft.com organizational user.

@ahmetalpbalkan can you pull this branch and try it with my client id, and with your personal and then microsoft.com accounts? Thanks.

