### PR TITLE
Added RepondDecorators to unmarshall primitive types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v5.0.0
+- Added new RespondDecorators unmarshalling primitive types
+- Corrected application of inspection and authorization PrependDecorators
+
 ## v4.0.0
 - Added support for Azure long-running operations.
 - Added cancelation support to all decorators and functions that may delay.

--- a/autorest/autorest.go
+++ b/autorest/autorest.go
@@ -101,8 +101,7 @@ func NewPollingRequest(resp *http.Response, c Client) (*http.Request, error) {
 
 	req, err := Prepare(&http.Request{},
 		AsGet(),
-		WithBaseURL(location),
-		c.WithAuthorization())
+		WithBaseURL(location))
 	if err != nil {
 		return nil, NewErrorWithError(err, "autorest", "NewPollingRequest", nil, "Failure creating poll request to %s", location)
 	}

--- a/autorest/autorest_test.go
+++ b/autorest/autorest_test.go
@@ -80,8 +80,9 @@ func TestNewPollingRequestDoesNotReturnARequestWhenLocationHeaderIsMissing(t *te
 func TestNewPollingRequestReturnsAnErrorWhenPrepareFails(t *testing.T) {
 	resp := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
 	mocks.SetAcceptedHeaders(resp)
+	resp.Header.Set(http.CanonicalHeaderKey(HeaderLocation), mocks.TestBadURL)
 
-	_, err := NewPollingRequest(resp, Client{Authorizer: mockFailingAuthorizer{}})
+	_, err := NewPollingRequest(resp, Client{})
 	if err == nil {
 		t.Error("autorest: NewPollingRequest failed to return an error when Prepare fails")
 	}
@@ -136,17 +137,6 @@ func TestNewPollingRequestProvidesTheURL(t *testing.T) {
 	req, _ := NewPollingRequest(resp, Client{Authorizer: NullAuthorizer{}})
 	if req.URL.String() != mocks.TestURL {
 		t.Errorf("autorest: NewPollingRequest did not create an HTTP with the expected URL -- received %v, expected %v", req.URL, mocks.TestURL)
-	}
-}
-
-func TestNewPollingRequestAppliesAuthorization(t *testing.T) {
-	resp := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
-	mocks.SetAcceptedHeaders(resp)
-
-	req, _ := NewPollingRequest(resp, Client{Authorizer: mockAuthorizer{}})
-	if req.Header.Get(http.CanonicalHeaderKey(headerAuthorization)) != mocks.TestAuthorizationHeader {
-		t.Errorf("autorest: NewPollingRequest did not apply authorization -- received %v, expected %v",
-			req.Header.Get(http.CanonicalHeaderKey(headerAuthorization)), mocks.TestAuthorizationHeader)
 	}
 }
 

--- a/autorest/azure/azure.go
+++ b/autorest/azure/azure.go
@@ -152,8 +152,7 @@ func NewAsyncPollingRequest(resp *http.Response, c autorest.Client) (*http.Reque
 
 	req, err := autorest.Prepare(&http.Request{},
 		autorest.AsGet(),
-		autorest.WithBaseURL(location),
-		c.WithAuthorization())
+		autorest.WithBaseURL(location))
 	if err != nil {
 		return nil, autorest.NewErrorWithError(err, "azure", "NewAsyncPollingRequest", nil, "Failure creating poll request to %s", location)
 	}

--- a/autorest/client.go
+++ b/autorest/client.go
@@ -192,13 +192,6 @@ func (c Client) PollForDuration() bool {
 // allows polling and the http.Response status code requires it. It will close the http.Response
 // Body if the request returns an error.
 func (c Client) Send(req *http.Request) (*http.Response, error) {
-	req, err := Prepare(req,
-		c.WithAuthorization(),
-		c.WithInspection())
-	if err != nil {
-		return nil, NewErrorWithError(err, "autorest/Client", "Send", nil, "Preparing request failed")
-	}
-
 	resp, err := SendWithSender(c, req)
 	if err == nil {
 		err = c.IsPollingAllowed(resp)
@@ -221,6 +214,12 @@ func (c Client) Send(req *http.Request) (*http.Response, error) {
 func (c Client) Do(r *http.Request) (*http.Response, error) {
 	if len(c.UserAgent) > 0 {
 		r, _ = Prepare(r, WithUserAgent(c.UserAgent))
+	}
+	r, err := Prepare(r,
+		c.WithInspection(),
+		c.WithAuthorization())
+	if err != nil {
+		return nil, NewErrorWithError(err, "autorest/Client", "Do", nil, "Preparing request failed")
 	}
 	return c.sender().Do(r)
 }

--- a/autorest/client_test.go
+++ b/autorest/client_test.go
@@ -247,6 +247,7 @@ func TestClientPollAsNeededReturnsErrorIfUnableToCreateRequest(t *testing.T) {
 
 	r := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
 	mocks.SetAcceptedHeaders(r)
+	mocks.SetLocationHeader(r, "                                 ")
 
 	_, err := c.PollAsNeeded(r)
 	if err == nil {
@@ -358,31 +359,6 @@ func TestClientSenderReturnsHttpClientByDefault(t *testing.T) {
 	}
 }
 
-func TestClientSendSetsAuthorization(t *testing.T) {
-	r := mocks.NewRequest()
-	s := mocks.NewSender()
-	c := Client{Authorizer: mockAuthorizer{}, Sender: s}
-
-	c.Send(r)
-	if len(r.Header.Get(http.CanonicalHeaderKey(headerAuthorization))) <= 0 {
-		t.Errorf("autorest: Client#Send failed to set Authorization header -- %s=%s",
-			http.CanonicalHeaderKey(headerAuthorization),
-			r.Header.Get(http.CanonicalHeaderKey(headerAuthorization)))
-	}
-}
-
-func TestClientSendInvokesInspector(t *testing.T) {
-	r := mocks.NewRequest()
-	s := mocks.NewSender()
-	i := &mockInspector{}
-	c := Client{RequestInspector: i.WithInspection(), Sender: s}
-
-	c.Send(r)
-	if !i.wasInvoked {
-		t.Error("autorest: Client#Send failed to invoke the RequestInspector")
-	}
-}
-
 func TestClientSendReturnsPrepareError(t *testing.T) {
 	r := mocks.NewRequest()
 	s := mocks.NewSender()
@@ -488,6 +464,31 @@ func TestClientDoSetsUserAgent(t *testing.T) {
 		t.Errorf("autorest: Client#Do failed to correctly set User-Agent header: %s=%s",
 			http.CanonicalHeaderKey(headerUserAgent),
 			r.Header.Get(http.CanonicalHeaderKey(headerUserAgent)))
+	}
+}
+
+func TestClientDoSetsAuthorization(t *testing.T) {
+	r := mocks.NewRequest()
+	s := mocks.NewSender()
+	c := Client{Authorizer: mockAuthorizer{}, Sender: s}
+
+	c.Do(r)
+	if len(r.Header.Get(http.CanonicalHeaderKey(headerAuthorization))) <= 0 {
+		t.Errorf("autorest: Client#Send failed to set Authorization header -- %s=%s",
+			http.CanonicalHeaderKey(headerAuthorization),
+			r.Header.Get(http.CanonicalHeaderKey(headerAuthorization)))
+	}
+}
+
+func TestClientDoInvokesInspector(t *testing.T) {
+	r := mocks.NewRequest()
+	s := mocks.NewSender()
+	i := &mockInspector{}
+	c := Client{RequestInspector: i.WithInspection(), Sender: s}
+
+	c.Do(r)
+	if !i.wasInvoked {
+		t.Error("autorest: Client#Send failed to invoke the RequestInspector")
 	}
 }
 

--- a/autorest/date/date.go
+++ b/autorest/date/date.go
@@ -7,6 +7,10 @@ package date
 
 import (
 	"fmt"
+	"github.com/Azure/go-autorest/autorest"
+	"io"
+	"io/ioutil"
+	"net/http"
 	"time"
 )
 
@@ -27,6 +31,28 @@ func ParseDate(date string) (d Date, err error) {
 	d = Date{}
 	d.Time, err = time.Parse(rfc3339FullDate, date)
 	return d, err
+}
+
+func readDate(r io.Reader) (Date, error) {
+	b, err := ioutil.ReadAll(r)
+	if err == nil {
+		return ParseDate(string(b))
+	}
+	return Date{}, err
+}
+
+// ByUnmarshallingDate returns a RespondDecorator that decodes the http.Response Body into a Date
+// pointed to by d.
+func ByUnmarshallingDate(d *Date) autorest.RespondDecorator {
+	return func(r autorest.Responder) autorest.Responder {
+		return autorest.ResponderFunc(func(resp *http.Response) error {
+			err := r.Respond(resp)
+			if err == nil {
+				*d, err = readDate(resp.Body)
+			}
+			return err
+		})
+	}
 }
 
 // MarshalBinary preserves the Date as a byte array conforming to RFC3339 full-date (i.e.,

--- a/autorest/date/time.go
+++ b/autorest/date/time.go
@@ -1,6 +1,10 @@
 package date
 
 import (
+	"github.com/Azure/go-autorest/autorest"
+	"io"
+	"io/ioutil"
+	"net/http"
 	"time"
 )
 
@@ -15,6 +19,28 @@ func ParseTime(date string) (d Time, err error) {
 	d = Time{}
 	d.Time, err = time.Parse(time.RFC3339, date)
 	return d, err
+}
+
+func readTime(r io.Reader) (Time, error) {
+	b, err := ioutil.ReadAll(r)
+	if err == nil {
+		return ParseTime(string(b))
+	}
+	return Time{}, err
+}
+
+// ByUnmarshallingTime returns a RespondDecorator that decodes the http.Response Body into a Time
+// pointed to by t.
+func ByUnmarshallingTime(t *Time) autorest.RespondDecorator {
+	return func(r autorest.Responder) autorest.Responder {
+		return autorest.ResponderFunc(func(resp *http.Response) error {
+			err := r.Respond(resp)
+			if err == nil {
+				*t, err = readTime(resp.Body)
+			}
+			return err
+		})
+	}
 }
 
 // MarshalBinary preserves the Time as a byte array conforming to RFC3339 date-time (i.e.,

--- a/autorest/date/time_test.go
+++ b/autorest/date/time_test.go
@@ -3,6 +3,8 @@ package date
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/mocks"
 	"reflect"
 	"testing"
 	"time"
@@ -160,5 +162,46 @@ func TestTimeToTime(t *testing.T) {
 		return
 	default:
 		t.Errorf("datetime: ToTime failed to return a time.Time")
+	}
+}
+
+func TestDate_ByUnmarshallingTime(t *testing.T) {
+	t1 := Time{}
+	t2 := Time{Time: time.Date(2001, time.February, 3, 4, 5, 6, 0, time.UTC)}
+
+	r := mocks.NewResponseWithContent("2001-02-03T04:05:06Z")
+	err := autorest.Respond(r,
+		ByUnmarshallingTime(&t1),
+		autorest.ByClosing())
+	if err != nil {
+		t.Errorf("date: ByUnmarshallingTime failed (%v)", err)
+	}
+	if !reflect.DeepEqual(t1, t2) {
+		t.Errorf("date: ByUnmarshallingTime failed to properly unmarshall -- expected %v, received %v", t2, t1)
+	}
+}
+
+func TestDate_ByUnmarshallingTimeFailsWithInvalidValues(t *testing.T) {
+	t1 := Time{}
+
+	r := mocks.NewResponseWithContent("Not a Time")
+	err := autorest.Respond(r,
+		ByUnmarshallingTime(&t1),
+		autorest.ByClosing())
+	if err == nil {
+		t.Errorf("date: ByUnmarshallingTime failed to return an error for an invalid string")
+	}
+}
+
+func TestDate_ByUnmarshallingTimeFailsWithInvalidReader(t *testing.T) {
+	t1 := Time{}
+
+	r := mocks.NewResponseWithContent("2001-02-03T04:05:06Z")
+	r.Body.Close()
+	err := autorest.Respond(r,
+		ByUnmarshallingTime(&t1),
+		autorest.ByClosing())
+	if err == nil {
+		t.Errorf("date: ByUnmarshallingTime failed to return an error for an invalid io.Reader")
 	}
 }

--- a/autorest/mocks/helpers.go
+++ b/autorest/mocks/helpers.go
@@ -11,7 +11,7 @@ const (
 	TestAuthorizationHeader = "BEARER SECRETTOKEN"
 
 	// TestBadURL is a malformed URL
-	TestBadURL = ""
+	TestBadURL = "                               "
 
 	// TestDelay is the Retry-After delay used in tests.
 	TestDelay = 0 * time.Second

--- a/autorest/preparer.go
+++ b/autorest/preparer.go
@@ -165,7 +165,11 @@ func WithBaseURL(baseURL string) PrepareDecorator {
 		return PreparerFunc(func(r *http.Request) (*http.Request, error) {
 			r, err := p.Prepare(r)
 			if err == nil {
-				u, err := url.Parse(baseURL)
+				var u *url.URL
+				u, err = url.Parse(baseURL)
+				if u.Scheme == "" {
+					err = fmt.Errorf("autorest: No scheme detected in URL %s", baseURL)
+				}
 				if err == nil {
 					r.URL = u
 				}

--- a/autorest/responder.go
+++ b/autorest/responder.go
@@ -97,6 +97,90 @@ func ByClosingIfError() RespondDecorator {
 	}
 }
 
+// ByUnmarshallingBool returns a RespondDecorator that decodes the http.Response Body into a bool
+// pointed to by b.
+func ByUnmarshallingBool(b *bool) RespondDecorator {
+	return func(r Responder) Responder {
+		return ResponderFunc(func(resp *http.Response) error {
+			err := r.Respond(resp)
+			if err == nil {
+				*b, err = readBool(resp.Body)
+			}
+			return err
+		})
+	}
+}
+
+// ByUnmarshallingFloat32 returns a RespondDecorator that decodes the http.Response Body into a
+// float32 pointed to by f.
+func ByUnmarshallingFloat32(f *float32) RespondDecorator {
+	return func(r Responder) Responder {
+		return ResponderFunc(func(resp *http.Response) error {
+			err := r.Respond(resp)
+			if err == nil {
+				*f, err = readFloat32(resp.Body)
+			}
+			return err
+		})
+	}
+}
+
+// ByUnmarshallingFloat64 returns a RespondDecorator that decodes the http.Response Body into a
+// float64 pointed to by f.
+func ByUnmarshallingFloat64(f *float64) RespondDecorator {
+	return func(r Responder) Responder {
+		return ResponderFunc(func(resp *http.Response) error {
+			err := r.Respond(resp)
+			if err == nil {
+				*f, err = readFloat64(resp.Body)
+			}
+			return err
+		})
+	}
+}
+
+// ByUnmarshallingInt32 returns a RespondDecorator that decodes the http.Response Body into an
+// int32 pointed to by i.
+func ByUnmarshallingInt32(i *int32) RespondDecorator {
+	return func(r Responder) Responder {
+		return ResponderFunc(func(resp *http.Response) error {
+			err := r.Respond(resp)
+			if err == nil {
+				*i, err = readInt32(resp.Body)
+			}
+			return err
+		})
+	}
+}
+
+// ByUnmarshallingInt64 returns a RespondDecorator that decodes the http.Response Body into an
+// int64 pointed to by i.
+func ByUnmarshallingInt64(i *int64) RespondDecorator {
+	return func(r Responder) Responder {
+		return ResponderFunc(func(resp *http.Response) error {
+			err := r.Respond(resp)
+			if err == nil {
+				*i, err = readInt64(resp.Body)
+			}
+			return err
+		})
+	}
+}
+
+// ByUnmarshallingString returns a RespondDecorator that decodes the http.Response Body into a
+// string pointed to by s.
+func ByUnmarshallingString(s *string) RespondDecorator {
+	return func(r Responder) Responder {
+		return ResponderFunc(func(resp *http.Response) error {
+			err := r.Respond(resp)
+			if err == nil {
+				*s, err = readString(resp.Body)
+			}
+			return err
+		})
+	}
+}
+
 // ByUnmarshallingJSON returns a RespondDecorator that decodes a JSON document returned in the
 // response Body into the value pointed to by v.
 func ByUnmarshallingJSON(v interface{}) RespondDecorator {

--- a/autorest/responder_test.go
+++ b/autorest/responder_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -261,6 +262,164 @@ func TestByClosingIfErrorDoesNotClosesIfNoErrorOccurs(t *testing.T) {
 
 	if !r.Body.(*mocks.Body).IsOpen() {
 		t.Errorf("autorest: ByClosingIfError closed the response body even though no error occurred")
+	}
+}
+
+func Test_ByUnmarshallingBool(t *testing.T) {
+	m := map[string]bool{
+		"true":  true,
+		"True":  true,
+		"false": false,
+		"False": false,
+	}
+	for s, expected := range m {
+		var b bool
+		r := mocks.NewResponseWithContent(s)
+		err := Respond(r,
+			ByUnmarshallingBool(&b),
+			ByClosing())
+		if err != nil {
+			t.Errorf("autorest: ByUnmarshallingBool returned an unexpected error parsing %v -- %v", s, err)
+		}
+		if b != expected {
+			t.Errorf("autorest: ByUnmarshallingBool failed to correctly unmarshall -- expected %v, received %v", expected, b)
+		}
+	}
+}
+
+func Test_ByUnmarshallingBoolFailsWithInvalidString(t *testing.T) {
+	var b bool
+	r := mocks.NewResponseWithContent("Not a Boolean")
+	err := Respond(r,
+		ByUnmarshallingBool(&b),
+		ByClosing())
+	if err == nil {
+		t.Errorf("autorest: ByUnmarshallingBool failed to return an error for an invalid string")
+	}
+}
+
+func Test_ByUnmarshallingFloat32(t *testing.T) {
+	for _, ch := range []byte{'e', 'E', 'f', 'g', 'G'} {
+		var f1, f2 float32
+		f2 = float32(123456.789)
+		r := mocks.NewResponseWithContent(strconv.FormatFloat(float64(f2), ch, -1, 64))
+		err := Respond(r,
+			ByUnmarshallingFloat32(&f1),
+			ByClosing())
+		if err != nil {
+			t.Errorf("autorest: ByUnmarshallingFloat32 returned an unexpected error parsing format %c -- %v", ch, err)
+		}
+		if f1 != f2 {
+			t.Errorf("autorest: ByUnmarshallingFloat32 failed to correctly unmarshall -- expected %v, received %v", f2, f1)
+		}
+	}
+}
+
+func Test_ByUnmarshallingFloat32FailsWithInvalidString(t *testing.T) {
+	var f float32
+	r := mocks.NewResponseWithContent("Not a Float32")
+	err := Respond(r,
+		ByUnmarshallingFloat32(&f),
+		ByClosing())
+	if err == nil {
+		t.Errorf("autorest: ByUnmarshallingFloat32 failed to return an error for an invalid string")
+	}
+}
+
+func Test_ByUnmarshallingFloat64(t *testing.T) {
+	for _, ch := range []byte{'e', 'E', 'f', 'g', 'G'} {
+		var f1, f2 float64
+		f2 = float64(123456.789)
+		r := mocks.NewResponseWithContent(strconv.FormatFloat(float64(f2), ch, -1, 64))
+		err := Respond(r,
+			ByUnmarshallingFloat64(&f1),
+			ByClosing())
+		if err != nil {
+			t.Errorf("autorest: ByUnmarshallingFloat64 returned an unexpected error parsing format %c -- %v", ch, err)
+		}
+		if f1 != f2 {
+			t.Errorf("autorest: ByUnmarshallingFloat64 failed to correctly unmarshall -- expected %v, received %v", f2, f1)
+		}
+	}
+}
+
+func Test_ByUnmarshallingFloat64FailsWithInvalidString(t *testing.T) {
+	var f float64
+	r := mocks.NewResponseWithContent("Not a Float64")
+	err := Respond(r,
+		ByUnmarshallingFloat64(&f),
+		ByClosing())
+	if err == nil {
+		t.Errorf("autorest: ByUnmarshallingFloat64 failed to return an error for an invalid string")
+	}
+}
+
+func Test_ByUnmarshallingInt32(t *testing.T) {
+	for _, i2 := range []int32{-123456, 123456} {
+		var i1 int32
+		r := mocks.NewResponseWithContent(strconv.FormatInt(int64(i2), 10))
+		err := Respond(r,
+			ByUnmarshallingInt32(&i1),
+			ByClosing())
+		if err != nil {
+			t.Errorf("autorest: ByUnmarshallingInt32 returned an unexpected error -- %v", err)
+		}
+		if i1 != i2 {
+			t.Errorf("autorest: ByUnmarshallingInt32 failed to correctly unmarshall -- expected %v, received %v", i2, i1)
+		}
+	}
+}
+
+func Test_ByUnmarshallingInt32FailsWithInvalidString(t *testing.T) {
+	var i int32
+	r := mocks.NewResponseWithContent("Not an Integer")
+	err := Respond(r,
+		ByUnmarshallingInt32(&i),
+		ByClosing())
+	if err == nil {
+		t.Errorf("autorest: ByUnmarshallingInt32 failed to return an error for an invalid string")
+	}
+}
+
+func Test_ByUnmarshallingInt64(t *testing.T) {
+	for _, i2 := range []int64{-123456, 123456} {
+		var i1 int64
+		r := mocks.NewResponseWithContent(strconv.FormatInt(int64(i2), 10))
+		err := Respond(r,
+			ByUnmarshallingInt64(&i1),
+			ByClosing())
+		if err != nil {
+			t.Errorf("autorest: ByUnmarshallingInt64 returned an unexpected error -- %v", err)
+		}
+		if i1 != i2 {
+			t.Errorf("autorest: ByUnmarshallingInt64 failed to correctly unmarshall -- expected %v, received %v", i2, i1)
+		}
+	}
+}
+
+func Test_ByUnmarshallingInt64FailsWithInvalidString(t *testing.T) {
+	var i int64
+	r := mocks.NewResponseWithContent("Not an Integer")
+	err := Respond(r,
+		ByUnmarshallingInt64(&i),
+		ByClosing())
+	if err == nil {
+		t.Errorf("autorest: ByUnmarshallingInt64 failed to return an error for an invalid string")
+	}
+}
+
+func Test_ByUnmarshallingString(t *testing.T) {
+	var s1, s2 string
+	s2 = "Expected string"
+	r := mocks.NewResponseWithContent(s2)
+	err := Respond(r,
+		ByUnmarshallingString(&s1),
+		ByClosing())
+	if err != nil {
+		t.Errorf("autorest: ByUnmarshallingString returned an unexpected error -- %v", err)
+	}
+	if s1 != s2 {
+		t.Errorf("autorest: ByUnmarshallingString failed to correctly unmarshall -- expected %v, received %v", s2, s1)
 	}
 }
 

--- a/autorest/utility.go
+++ b/autorest/utility.go
@@ -6,7 +6,9 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/url"
+	"strconv"
 )
 
 // EncodedAs is a series of constants specifying various data encodings
@@ -44,6 +46,55 @@ func NewDecoder(encodedAs EncodedAs, r io.Reader) Decoder {
 func CopyAndDecode(encodedAs EncodedAs, r io.Reader, v interface{}) (bytes.Buffer, error) {
 	b := bytes.Buffer{}
 	return b, NewDecoder(encodedAs, io.TeeReader(r, &b)).Decode(v)
+}
+
+func readBool(r io.Reader) (bool, error) {
+	s, err := readString(r)
+	if err == nil {
+		return strconv.ParseBool(s)
+	}
+	return false, err
+}
+
+func readFloat32(r io.Reader) (float32, error) {
+	s, err := readString(r)
+	if err == nil {
+		v, err := strconv.ParseFloat(s, 32)
+		return float32(v), err
+	}
+	return float32(0), err
+}
+
+func readFloat64(r io.Reader) (float64, error) {
+	s, err := readString(r)
+	if err == nil {
+		v, err := strconv.ParseFloat(s, 64)
+		return v, err
+	}
+	return float64(0), err
+}
+
+func readInt32(r io.Reader) (int32, error) {
+	s, err := readString(r)
+	if err == nil {
+		v, err := strconv.ParseInt(s, 10, 32)
+		return int32(v), err
+	}
+	return int32(0), err
+}
+
+func readInt64(r io.Reader) (int64, error) {
+	s, err := readString(r)
+	if err == nil {
+		v, err := strconv.ParseInt(s, 10, 64)
+		return v, err
+	}
+	return int64(0), err
+}
+
+func readString(r io.Reader) (string, error) {
+	b, err := ioutil.ReadAll(r)
+	return string(b), err
 }
 
 func containsInt(ints []int, n int) bool {

--- a/autorest/utility_test.go
+++ b/autorest/utility_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -133,6 +134,165 @@ func TestEnsureStrings(t *testing.T) {
 	}
 }
 
+func Test_readBool(t *testing.T) {
+	m := map[string]bool{
+		"true":  true,
+		"True":  true,
+		"false": false,
+		"False": false,
+	}
+	for s, expected := range m {
+		b, err := readBool(strings.NewReader(s))
+		if err != nil {
+			t.Errorf("autorest: readBool returned an unexpected error -- %v", err)
+		}
+		if b != expected {
+			t.Errorf("autorest: readBool failed to parse value -- expected %v, received %v", expected, b)
+		}
+	}
+}
+
+func Test_readBoolFailsWithInvalidString(t *testing.T) {
+	_, err := readBool(strings.NewReader("Not a Boolean"))
+	if err == nil {
+		t.Errorf("autorest: readBool failed to return an error for an invalid string")
+	}
+}
+
+func Test_readBoolFailsWithBadReader(t *testing.T) {
+	r := mocks.NewBody("Some content")
+	r.Close()
+	_, err := readBool(r)
+	if err == nil {
+		t.Errorf("autorest: readBool failed to return an error with an invalid io.Reader")
+	}
+}
+
+func Test_readFloat32(t *testing.T) {
+	for _, ch := range []byte{'e', 'E', 'f', 'g', 'G'} {
+		f1 := float32(123456.789)
+		f2, err := readFloat32(strings.NewReader(strconv.FormatFloat(float64(f1), ch, -1, 32)))
+		if err != nil {
+			t.Errorf("autorest: readFloat32 returned an unexpected error for fmt %c -- %v", ch, err)
+		}
+		if f1 != f2 {
+			t.Errorf("autorest: readFloat32 failed to parse value using fmt %v -- expected %v, received %v", ch, f2, f1)
+		}
+	}
+}
+
+func Test_readFloat32FailsWithInvalidString(t *testing.T) {
+	_, err := readFloat32(strings.NewReader("Not a Float32"))
+	if err == nil {
+		t.Errorf("autorest: readFloat32 failed to return an error for an invalid string")
+	}
+}
+
+func Test_readFloat32FailsWithBadReader(t *testing.T) {
+	r := mocks.NewBody("Some content")
+	r.Close()
+	_, err := readFloat32(r)
+	if err == nil {
+		t.Errorf("autorest: readFloat32 failed to return an error with an invalid io.Reader")
+	}
+}
+
+func Test_readFloat64(t *testing.T) {
+	for _, ch := range []byte{'e', 'E', 'f', 'g', 'G'} {
+		f1 := float64(123456.789)
+		f2, err := readFloat64(strings.NewReader(strconv.FormatFloat(float64(f1), ch, -1, 64)))
+		if err != nil {
+			t.Errorf("autorest: readFloat64 returned an unexpected error for fmt %c -- %v", ch, err)
+		}
+		if f1 != f2 {
+			t.Errorf("autorest: readFloat64 failed to parse value using fmt %v -- expected %v, received %v", ch, f2, f1)
+		}
+	}
+}
+
+func Test_readFloat64FailsWithInvalidString(t *testing.T) {
+	_, err := readFloat64(strings.NewReader("Not a Float64"))
+	if err == nil {
+		t.Errorf("autorest: readFloat64 failed to return an error for an invalid string")
+	}
+}
+
+func Test_readFloat64FailsWithBadReader(t *testing.T) {
+	r := mocks.NewBody("Some content")
+	r.Close()
+	_, err := readFloat64(r)
+	if err == nil {
+		t.Errorf("autorest: readFloat64 failed to return an error with an invalid io.Reader")
+	}
+}
+
+func Test_readInt32(t *testing.T) {
+	for _, i1 := range []int32{-123, 123} {
+		i2, err := readInt32(strings.NewReader(strconv.FormatInt(int64(i1), 10)))
+		if err != nil {
+			t.Errorf("autorest: readFloat64 returned an unexpected error for %v -- %v", i1, err)
+		}
+		if i1 != i2 {
+			t.Errorf("autorest: readFloat64 failed to parse value -- expected %v, received %v", i2, i1)
+		}
+	}
+}
+
+func Test_readInt32FailsWithInvalidString(t *testing.T) {
+	_, err := readInt32(strings.NewReader("Not an Integer"))
+	if err == nil {
+		t.Errorf("autorest: readInt32 failed to return an error for an invalid string")
+	}
+}
+
+func Test_readInt32FailsWithBadReader(t *testing.T) {
+	r := mocks.NewBody("Some content")
+	r.Close()
+	_, err := readInt32(r)
+	if err == nil {
+		t.Errorf("autorest: readInt32 failed to return an error with an invalid io.Reader")
+	}
+}
+
+func Test_readInt64(t *testing.T) {
+	for _, i1 := range []int64{-123, 123} {
+		i2, err := readInt64(strings.NewReader(strconv.FormatInt(int64(i1), 10)))
+		if err != nil {
+			t.Errorf("autorest: readFloat64 returned an unexpected error for %v -- %v", i1, err)
+		}
+		if i1 != i2 {
+			t.Errorf("autorest: readFloat64 failed to parse value -- expected %v, received %v", i2, i1)
+		}
+	}
+}
+
+func Test_readInt64FailsWithInvalidString(t *testing.T) {
+	_, err := readInt64(strings.NewReader("Not an Integer"))
+	if err == nil {
+		t.Errorf("autorest: readInt64 failed to return an error for an invalid string")
+	}
+}
+
+func Test_readInt64FailsWithBadReader(t *testing.T) {
+	r := mocks.NewBody("Some content")
+	r.Close()
+	_, err := readInt64(r)
+	if err == nil {
+		t.Errorf("autorest: readInt64 failed to return an error with an invalid io.Reader")
+	}
+}
+
+func Test_readString(t *testing.T) {
+	s1 := "The string to return"
+	s2, err := readString(strings.NewReader(s1))
+	if err != nil {
+		t.Errorf("autorest: readString returned an error reading %v -- %v", s1, err)
+	}
+	if s1 != s2 {
+		t.Errorf("autorest: readString failed to read a string -- expected %v, received %v", s2, s1)
+	}
+}
+
 func doEnsureBodyClosed(t *testing.T) SendDecorator {
 	return func(s Sender) Sender {
 		return SenderFunc(func(r *http.Request) (*http.Response, error) {
@@ -161,18 +321,6 @@ func (mfa mockFailingAuthorizer) WithAuthorization() PrepareDecorator {
 	}
 }
 
-func withMessage(output *string, msg string) SendDecorator {
-	return func(s Sender) Sender {
-		return SenderFunc(func(r *http.Request) (*http.Response, error) {
-			resp, err := s.Do(r)
-			if err == nil {
-				*output += msg
-			}
-			return resp, err
-		})
-	}
-}
-
 type mockInspector struct {
 	wasInvoked bool
 }
@@ -191,6 +339,18 @@ func (mi *mockInspector) ByInspecting() RespondDecorator {
 		return ResponderFunc(func(resp *http.Response) error {
 			mi.wasInvoked = true
 			return r.Respond(resp)
+		})
+	}
+}
+
+func withMessage(output *string, msg string) SendDecorator {
+	return func(s Sender) Sender {
+		return SenderFunc(func(r *http.Request) (*http.Response, error) {
+			resp, err := s.Do(r)
+			if err == nil {
+				*output += msg
+			}
+			return resp, err
 		})
 	}
 }

--- a/autorest/version.go
+++ b/autorest/version.go
@@ -5,8 +5,8 @@ import (
 )
 
 const (
-	major        = "3"
-	minor        = "1"
+	major        = "5"
+	minor        = "0"
 	patch        = "0"
 	tag          = ""
 	semVerFormat = "%s.%s.%s%s"

--- a/autorest/version_test.go
+++ b/autorest/version_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestVersion(t *testing.T) {
-	v := "3.1.0"
+	v := "5.0.0"
 	if Version() != v {
 		t.Errorf("autorest: Version failed to return the expected version -- expected %s, received %s",
 			v, Version())


### PR DESCRIPTION
Added RepondDecorators to unmarshall primitive types
Corrected invocation of Prepare inspector / authorizer

Signed-off-by: Brendan Dixon <brendand@microsoft.com>