### PR TITLE
Add Azure Environments; Use OAuthConfig throughout

### DIFF
--- a/autorest/azure/config.go
+++ b/autorest/azure/config.go
@@ -1,0 +1,13 @@
+package azure
+
+import (
+	"net/url"
+)
+
+// OAuthConfig represents the endpoints needed
+// in OAuth operations
+type OAuthConfig struct {
+	AuthorizeEndpoint  url.URL
+	TokenEndpoint      url.URL
+	DeviceCodeEndpoint url.URL
+}

--- a/autorest/azure/devicetoken_test.go
+++ b/autorest/azure/devicetoken_test.go
@@ -17,6 +17,11 @@ const (
 	TestTenantID = "SomeTenantID"
 )
 
+var (
+	testOAuthConfig, _ = PublicCloud.OAuthConfigForTenant(TestTenantID)
+	TestOAuthConfig    = *testOAuthConfig
+)
+
 const MockDeviceCodeResponse = `
 {
 	"device_code": "10000-40-1234567890",
@@ -44,7 +49,7 @@ func TestDeviceCodeIncludesResource(t *testing.T) {
 	sender.EmitStatus("OK", 200)
 	client := &autorest.Client{Sender: sender}
 
-	code, err := InitiateDeviceAuth(client, TestClientID, TestTenantID, TestResource)
+	code, err := InitiateDeviceAuth(client, TestOAuthConfig, TestClientID, TestResource)
 	if err != nil {
 		t.Errorf("azure: unexpected error initiating device auth")
 	}
@@ -60,7 +65,7 @@ func TestDeviceCodeReturnsErrorIfSendingFails(t *testing.T) {
 	sender.SetError(fmt.Errorf("this is an error"))
 	client := &autorest.Client{Sender: sender}
 
-	_, err := InitiateDeviceAuth(client, TestClientID, TestTenantID, TestResource)
+	_, err := InitiateDeviceAuth(client, TestOAuthConfig, TestClientID, TestResource)
 	if err == nil || !strings.Contains(err.Error(), errCodeSendingFails) {
 		t.Errorf("azure: failed to get correct error expected(%s) actual(%s)", errCodeSendingFails, err.Error())
 	}
@@ -72,7 +77,7 @@ func TestDeviceCodeReturnsErrorIfBadRequest(t *testing.T) {
 	sender.SetResponse(mocks.NewResponseWithBodyAndStatus(body, 400, "Bad Request"))
 	client := &autorest.Client{Sender: sender}
 
-	_, err := InitiateDeviceAuth(client, TestClientID, TestTenantID, TestResource)
+	_, err := InitiateDeviceAuth(client, TestOAuthConfig, TestClientID, TestResource)
 	if err == nil || !strings.Contains(err.Error(), errCodeHandlingFails) {
 		t.Errorf("azure: failed to get correct error expected(%s) actual(%s)", errCodeHandlingFails, err.Error())
 	}
@@ -89,7 +94,7 @@ func TestDeviceCodeReturnsErrorIfCannotDeserializeDeviceCode(t *testing.T) {
 	sender.SetResponse(mocks.NewResponseWithBodyAndStatus(body, 200, "OK"))
 	client := &autorest.Client{Sender: sender}
 
-	_, err := InitiateDeviceAuth(client, TestClientID, TestTenantID, TestResource)
+	_, err := InitiateDeviceAuth(client, TestOAuthConfig, TestClientID, TestResource)
 	if err == nil || !strings.Contains(err.Error(), errCodeHandlingFails) {
 		t.Errorf("azure: failed to get correct error expected(%s) actual(%s)", errCodeHandlingFails, err.Error())
 	}
@@ -104,7 +109,6 @@ func deviceCode() *DeviceCode {
 	json.Unmarshal([]byte(MockDeviceCodeResponse), &deviceCode)
 	deviceCode.Resource = TestResource
 	deviceCode.ClientID = TestClientID
-	deviceCode.TenantID = TestTenantID
 	return &deviceCode
 }
 

--- a/autorest/azure/environments.go
+++ b/autorest/azure/environments.go
@@ -1,0 +1,111 @@
+package azure
+
+import (
+	"fmt"
+	"net/url"
+)
+
+const (
+	activeDirectoryAPIVersion = "1.0"
+)
+
+// Environment represents a set of endpoints for each of Azure's Clouds.
+type Environment struct {
+	Name                      string
+	ManagementPortalURL       string
+	PublishSettingsURL        string
+	ServiceManagementEndpoint string
+	ResourceManagerEndpoint   string
+	ActiveDirectoryEndpoint   string
+	GalleryEndpoint           string
+	KeyVaultEndpoint          string
+	GraphEndpoint             string
+	StorageEndpointSuffix     string
+	SQLDatabaseDNSSuffix      string
+	TrafficManagerDNSSuffix   string
+	KeyVaultDNSSuffix         string
+	ServiceBusEndpointSuffix  string
+}
+
+var (
+	// PublicCloud is the default public Azure cloud environment
+	PublicCloud = Environment{
+		Name:                      "AzurePublicCloud",
+		ManagementPortalURL:       "https://manage.windowsazure.com/",
+		PublishSettingsURL:        "https://manage.windowsazure.com/publishsettings/index",
+		ServiceManagementEndpoint: "https://management.core.windows.net/",
+		ResourceManagerEndpoint:   "https://management.azure.com/",
+		ActiveDirectoryEndpoint:   "https://login.microsoftonline.com/",
+		GalleryEndpoint:           "https://gallery.azure.com/",
+		KeyVaultEndpoint:          "https://vault.azure.net/",
+		GraphEndpoint:             "https://graph.windows.net/",
+		StorageEndpointSuffix:     "core.windows.net",
+		SQLDatabaseDNSSuffix:      "database.windows.net",
+		TrafficManagerDNSSuffix:   "trafficmanager.net",
+		KeyVaultDNSSuffix:         "vault.azure.net",
+		ServiceBusEndpointSuffix:  "servicebus.azure.com",
+	}
+
+	// USGovernmentCloud is the cloud environment for the US Government
+	USGovernmentCloud = Environment{
+		Name:                      "AzureUSGovernmentCloud",
+		ManagementPortalURL:       "https://manage.windowsazure.us/",
+		PublishSettingsURL:        "https://manage.windowsazure.us/publishsettings/index",
+		ServiceManagementEndpoint: "https://management.core.usgovcloudapi.net/",
+		ResourceManagerEndpoint:   "https://management.usgovcloudapi.net",
+		ActiveDirectoryEndpoint:   "https://login.microsoftonline.com/",
+		GalleryEndpoint:           "https://gallery.usgovcloudapi.net/",
+		KeyVaultEndpoint:          "https://vault.azure.net/",
+		GraphEndpoint:             "https://graph.usgovcloudapi.net/",
+		StorageEndpointSuffix:     "core.usgovcloudapi.net",
+		SQLDatabaseDNSSuffix:      "database.usgovcloudapi.net",
+		TrafficManagerDNSSuffix:   "trafficmanager.net",
+		KeyVaultDNSSuffix:         "vault.azure.net",
+		ServiceBusEndpointSuffix:  "servicebus.usgovcloudapi.net",
+	}
+
+	// ChinaCloud is the cloud environment operated in China
+	ChinaCloud = Environment{
+		Name:                      "AzureChinaCloud",
+		ManagementPortalURL:       "https://manage.chinacloudapi.com/",
+		PublishSettingsURL:        "https://manage.chinacloudapi.com/publishsettings/index",
+		ServiceManagementEndpoint: "https://management.core.chinacloudapi.cn/",
+		ResourceManagerEndpoint:   "https://management.chinacloudapi.cn/",
+		ActiveDirectoryEndpoint:   "https://login.chinacloudapi.cn/?api-version=1.0",
+		GalleryEndpoint:           "https://gallery.chinacloudapi.cn/",
+		KeyVaultEndpoint:          "https://vault.azure.net/",
+		GraphEndpoint:             "https://graph.chinacloudapi.cn/",
+		StorageEndpointSuffix:     "core.chinacloudapi.cn",
+		SQLDatabaseDNSSuffix:      "database.chinacloudapi.cn",
+		TrafficManagerDNSSuffix:   "trafficmanager.cn",
+		KeyVaultDNSSuffix:         "vault.azure.net",
+		ServiceBusEndpointSuffix:  "servicebus.chinacloudapi.net",
+	}
+)
+
+// OAuthConfigForTenant returns an OAuthConfig with tenant specific urls
+func (env Environment) OAuthConfigForTenant(tenantID string) (*OAuthConfig, error) {
+	template := "%s/oauth2/%s?api-version=%s"
+	u, err := url.Parse(env.ActiveDirectoryEndpoint)
+	if err != nil {
+		return nil, err
+	}
+	authorizeURL, err := u.Parse(fmt.Sprintf(template, tenantID, "authorize", activeDirectoryAPIVersion))
+	if err != nil {
+		return nil, err
+	}
+	tokenURL, err := u.Parse(fmt.Sprintf(template, tenantID, "token", activeDirectoryAPIVersion))
+	if err != nil {
+		return nil, err
+	}
+	deviceCodeURL, err := u.Parse(fmt.Sprintf(template, tenantID, "devicecode", activeDirectoryAPIVersion))
+	if err != nil {
+		return nil, err
+	}
+
+	return &OAuthConfig{
+		AuthorizeEndpoint:  *authorizeURL,
+		TokenEndpoint:      *tokenURL,
+		DeviceCodeEndpoint: *deviceCodeURL,
+	}, nil
+}

--- a/autorest/azure/environments_test.go
+++ b/autorest/azure/environments_test.go
@@ -1,0 +1,30 @@
+package azure
+
+import (
+	"testing"
+)
+
+func TestOAuthConfigForTenant(t *testing.T) {
+	az := PublicCloud
+
+	config, err := az.OAuthConfigForTenant("tenant-id-test")
+	if err != nil {
+		t.Errorf("autorest/azure: Unexpected error while retrieving oauth configuration for tenant: %v.", err)
+	}
+
+	expected := "https://login.microsoftonline.com/tenant-id-test/oauth2/authorize?api-version=1.0"
+	if config.AuthorizeEndpoint.String() != expected {
+		t.Errorf("autorest/azure: Incorrect authorize url for Tenant from Environment. expected(%s). actual(%s).", expected, config.AuthorizeEndpoint)
+	}
+
+	expected = "https://login.microsoftonline.com/tenant-id-test/oauth2/token?api-version=1.0"
+	if config.TokenEndpoint.String() != expected {
+		t.Errorf("autorest/azure: Incorrect authorize url for Tenant from Environment. expected(%s). actual(%s).", expected, config.TokenEndpoint)
+	}
+
+	expected = "https://login.microsoftonline.com/tenant-id-test/oauth2/devicecode?api-version=1.0"
+	if config.DeviceCodeEndpoint.String() != expected {
+		t.Errorf("autorest/azure: Incorrect devicecode url for Tenant from Environment. expected(%s). actual(%s).", expected, config.DeviceCodeEndpoint)
+	}
+
+}

--- a/autorest/azure/token_test.go
+++ b/autorest/azure/token_test.go
@@ -171,10 +171,9 @@ func TestServicePrincipalTokenRefreshSetsURL(t *testing.T) {
 		(func() autorest.SendDecorator {
 			return func(s autorest.Sender) autorest.Sender {
 				return autorest.SenderFunc(func(r *http.Request) (*http.Response, error) {
-					u := fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/token?api-version=1.0", spt.tenantID)
-					if r.URL.String() != u {
+					if r.URL.String() != TestOAuthConfig.TokenEndpoint.String() {
 						t.Errorf("azure: ServicePrincipalToken#Refresh did not correctly set the URL -- expected %v, received %v",
-							u, r.URL)
+							TestOAuthConfig.TokenEndpoint, r.URL)
 					}
 					return mocks.NewResponse(), nil
 				})
@@ -476,14 +475,14 @@ func setTokenToExpireIn(t *Token, expireIn time.Duration) *Token {
 }
 
 func newServicePrincipalToken(callbacks ...TokenRefreshCallback) *ServicePrincipalToken {
-	spt, _ := NewServicePrincipalToken("id", "secret", "tenentId", "resource", callbacks...)
+	spt, _ := NewServicePrincipalToken(TestOAuthConfig, "id", "secret", "resource", callbacks...)
 	return spt
 }
 
 func newServicePrincipalTokenManual() *ServicePrincipalToken {
 	token := newToken()
 	token.RefreshToken = "refreshtoken"
-	spt, _ := NewServicePrincipalTokenFromManualToken("id", "tenantId", "resource", *token)
+	spt, _ := NewServicePrincipalTokenFromManualToken(TestOAuthConfig, "id", "resource", *token)
 	return spt
 }
 
@@ -500,6 +499,6 @@ func newServicePrincipalTokenCertificate() *ServicePrincipalToken {
 	}
 	certificate, err := x509.ParseCertificate(certificateBytes)
 
-	spt, _ := NewServicePrincipalTokenFromCertificate("id", certificate, privateKey, "tenentId", "resource")
+	spt, _ := NewServicePrincipalTokenFromCertificate(TestOAuthConfig, "id", certificate, privateKey, "resource")
 	return spt
 }


### PR DESCRIPTION
new types: 
* OAuthConfig (represents the three oauth endpoints, tenant-specific) 
* Environment (represents the various endpoints for an azure cloud [public, usgov, china]).

After this change, SPT doesn't know about tenant-id (an Azure specific thing) and instead takes an "OAuthConfig" with urls that are already tenant-specific as the user requests. This makes our client more similar to other OAuth clients. See the `example.go` to see how this changes usage.

This is breaking change, but it's also needed to support anything other than the Azure public cloud.

