### PR TITLE
azure/token.go: Add RefreshExchange for Azure

### DIFF
--- a/autorest/azure/token.go
+++ b/autorest/azure/token.go
@@ -263,9 +263,18 @@ func (spt *ServicePrincipalToken) InvokeRefreshCallbacks(token Token) error {
 
 // Refresh obtains a fresh token for the Service Principal.
 func (spt *ServicePrincipalToken) Refresh() error {
+	return spt.refreshInternal(spt.resource)
+}
+
+// RefreshExchange refreshes the token, but for a different resource.
+func (spt *ServicePrincipalToken) RefreshExchange(resource string) error {
+	return spt.refreshInternal(resource)
+}
+
+func (spt *ServicePrincipalToken) refreshInternal(resource string) error {
 	v := url.Values{}
 	v.Set("client_id", spt.clientID)
-	v.Set("resource", spt.resource)
+	v.Set("resource", resource)
 
 	if spt.RefreshToken != "" {
 		v.Set("grant_type", OAuthGrantTypeRefreshToken)


### PR DESCRIPTION
This is needed to acquire access tokens to different `resource`s without re-initializing the auth flow each time. (Not so important for clientsecret/cert auth, but very important for device flow).