### PR TITLE
Reworked handling asynchronous and polled requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## v6.0.0
+- Completely reworked the handling of polled and asynchronous requests
+- Removed unnecessary routines
+- Reworked `mocks.Sender` to replay a series of `http.Response` objects
+- Added `PrepareDecorators` for primitive types (e.g., bool, int32)
+
+Handling polled and asynchronous requests is no longer part of `Client#Send`. Instead new
+`SendDecorators` implement different styles of polled behavior. See`autorest.DoPollForStatusCodes`
+and `azure.DoPollForAsynchronous` for examples.
+
 ## v5.0.0
 - Added new RespondDecorators unmarshalling primitive types
 - Corrected application of inspection and authorization PrependDecorators

--- a/autorest/autorest_test.go
+++ b/autorest/autorest_test.go
@@ -3,7 +3,6 @@ package autorest
 import (
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/Azure/go-autorest/autorest/mocks"
 )
@@ -24,54 +23,10 @@ func TestResponseHasStatusCodeNotPresent(t *testing.T) {
 	}
 }
 
-func TestResponseRequiresPollingIgnoresSuccess(t *testing.T) {
-	resp := mocks.NewResponse()
-
-	if ResponseRequiresPolling(resp) {
-		t.Error("autorest: ResponseRequiresPolling did not ignore a successful response")
-	}
-}
-
-func TestResponseRequiresPollingLeavesBodyOpen(t *testing.T) {
-	resp := mocks.NewResponse()
-
-	ResponseRequiresPolling(resp)
-	if !resp.Body.(*mocks.Body).IsOpen() {
-		t.Error("autorest: ResponseRequiresPolling closed the responise body while ignoring a successful response")
-	}
-}
-
-func TestResponseRequiresPollingDefaultsToAcceptedStatusCode(t *testing.T) {
-	resp := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
-	mocks.SetAcceptedHeaders(resp)
-
-	if !ResponseRequiresPolling(resp) {
-		t.Error("autorest: ResponseRequiresPolling failed to create a request for default 202 Accepted status code")
-	}
-}
-
-func TestResponseRequiresPollingReturnsFalseForUnexpectedStatusCodes(t *testing.T) {
-	resp := mocks.NewResponseWithStatus("500 InternalServerError", http.StatusInternalServerError)
-	mocks.SetAcceptedHeaders(resp)
-
-	if ResponseRequiresPolling(resp) {
-		t.Error("autorest: ResponseRequiresPolling did not return false when ignoring a status code")
-	}
-}
-
-func TestNewPollingRequestLeavesBodyOpenWhenLocationHeaderIsMissing(t *testing.T) {
-	resp := mocks.NewResponseWithStatus("500 InternalServerError", http.StatusInternalServerError)
-
-	NewPollingRequest(resp, Client{Authorizer: NullAuthorizer{}})
-	if !resp.Body.(*mocks.Body).IsOpen() {
-		t.Error("autorest: NewPollingRequest closed the http.Request Body when the Location header was missing")
-	}
-}
-
 func TestNewPollingRequestDoesNotReturnARequestWhenLocationHeaderIsMissing(t *testing.T) {
 	resp := mocks.NewResponseWithStatus("500 InternalServerError", http.StatusInternalServerError)
 
-	req, _ := NewPollingRequest(resp, Client{Authorizer: NullAuthorizer{}})
+	req, _ := NewPollingRequest(resp, nil)
 	if req != nil {
 		t.Error("autorest: NewPollingRequest returned an http.Request when the Location header was missing")
 	}
@@ -82,20 +37,9 @@ func TestNewPollingRequestReturnsAnErrorWhenPrepareFails(t *testing.T) {
 	mocks.SetAcceptedHeaders(resp)
 	resp.Header.Set(http.CanonicalHeaderKey(HeaderLocation), mocks.TestBadURL)
 
-	_, err := NewPollingRequest(resp, Client{})
+	_, err := NewPollingRequest(resp, nil)
 	if err == nil {
 		t.Error("autorest: NewPollingRequest failed to return an error when Prepare fails")
-	}
-}
-
-func TestNewPollingRequestLeavesBodyOpenWhenPrepareFails(t *testing.T) {
-	resp := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
-	mocks.SetAcceptedHeaders(resp)
-	resp.Header.Set(http.CanonicalHeaderKey(HeaderLocation), mocks.TestBadURL)
-
-	_, err := NewPollingRequest(resp, Client{Authorizer: NullAuthorizer{}})
-	if !resp.Body.(*mocks.Body).IsOpen() {
-		t.Errorf("autorest: NewPollingRequest closed the http.Request Body when Prepare returned an error (%v)", err)
 	}
 }
 
@@ -104,19 +48,9 @@ func TestNewPollingRequestDoesNotReturnARequestWhenPrepareFails(t *testing.T) {
 	mocks.SetAcceptedHeaders(resp)
 	resp.Header.Set(http.CanonicalHeaderKey(HeaderLocation), mocks.TestBadURL)
 
-	req, _ := NewPollingRequest(resp, Client{Authorizer: NullAuthorizer{}})
+	req, _ := NewPollingRequest(resp, nil)
 	if req != nil {
 		t.Error("autorest: NewPollingRequest returned an http.Request when Prepare failed")
-	}
-}
-
-func TestNewPollingRequestClosesTheResponseBody(t *testing.T) {
-	resp := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
-	mocks.SetAcceptedHeaders(resp)
-
-	NewPollingRequest(resp, Client{Authorizer: NullAuthorizer{}})
-	if resp.Body.(*mocks.Body).IsOpen() {
-		t.Error("autorest: NewPollingRequest failed to close the response body when creating a new request")
 	}
 }
 
@@ -124,7 +58,7 @@ func TestNewPollingRequestReturnsAGetRequest(t *testing.T) {
 	resp := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
 	mocks.SetAcceptedHeaders(resp)
 
-	req, _ := NewPollingRequest(resp, Client{Authorizer: NullAuthorizer{}})
+	req, _ := NewPollingRequest(resp, nil)
 	if req.Method != "GET" {
 		t.Errorf("autorest: NewPollingRequest did not create an HTTP GET request -- actual method %v", req.Method)
 	}
@@ -134,205 +68,59 @@ func TestNewPollingRequestProvidesTheURL(t *testing.T) {
 	resp := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
 	mocks.SetAcceptedHeaders(resp)
 
-	req, _ := NewPollingRequest(resp, Client{Authorizer: NullAuthorizer{}})
+	req, _ := NewPollingRequest(resp, nil)
 	if req.URL.String() != mocks.TestURL {
 		t.Errorf("autorest: NewPollingRequest did not create an HTTP with the expected URL -- received %v, expected %v", req.URL, mocks.TestURL)
 	}
 }
 
-func TestGetPollingLocation(t *testing.T) {
+func TestGetLocation(t *testing.T) {
 	resp := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
 	mocks.SetAcceptedHeaders(resp)
 
-	l := GetPollingLocation(resp)
+	l := GetLocation(resp)
 	if len(l) == 0 {
-		t.Errorf("autorest: GetPollingLocation failed to return Location header -- expected %v, received %v", mocks.TestURL, l)
+		t.Errorf("autorest: GetLocation failed to return Location header -- expected %v, received %v", mocks.TestURL, l)
 	}
 }
 
-func TestGetPollingLocationReturnsEmptyStringForMissingLocation(t *testing.T) {
+func TestGetLocationReturnsEmptyStringForMissingLocation(t *testing.T) {
 	resp := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
 
-	l := GetPollingLocation(resp)
+	l := GetLocation(resp)
 	if len(l) != 0 {
-		t.Errorf("autorest: GetPollingLocation return a value without a Location header -- received %v", l)
+		t.Errorf("autorest: GetLocation return a value without a Location header -- received %v", l)
 	}
 }
 
-func TestGetPollingDelay(t *testing.T) {
+func TestGetRetryAfter(t *testing.T) {
 	resp := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
 	mocks.SetAcceptedHeaders(resp)
 
-	d := GetPollingDelay(resp, DefaultPollingDelay)
+	d := GetRetryAfter(resp, DefaultPollingDelay)
 	if d != mocks.TestDelay {
-		t.Errorf("autorest: GetPollingDelay failed to returned the expected delay -- expected %v, received %v", mocks.TestDelay, d)
+		t.Errorf("autorest: GetRetryAfter failed to returned the expected delay -- expected %v, received %v", mocks.TestDelay, d)
 	}
 }
 
-func TestGetPollingDelayReturnsDefaultDelayIfRetryHeaderIsMissing(t *testing.T) {
+func TestGetRetryAfterReturnsDefaultDelayIfRetryHeaderIsMissing(t *testing.T) {
 	resp := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
 
-	d := GetPollingDelay(resp, DefaultPollingDelay)
+	d := GetRetryAfter(resp, DefaultPollingDelay)
 	if d != DefaultPollingDelay {
-		t.Errorf("autorest: GetPollingDelay failed to returned the default delay for a missing Retry-After header -- expected %v, received %v",
+		t.Errorf("autorest: GetRetryAfter failed to returned the default delay for a missing Retry-After header -- expected %v, received %v",
 			DefaultPollingDelay, d)
 	}
 }
 
-func TestGetPollingDelayReturnsDefaultDelayIfRetryHeaderIsMalformed(t *testing.T) {
+func TestGetRetryAfterReturnsDefaultDelayIfRetryHeaderIsMalformed(t *testing.T) {
 	resp := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
 	mocks.SetAcceptedHeaders(resp)
 	resp.Header.Set(http.CanonicalHeaderKey(HeaderRetryAfter), "a very bad non-integer value")
 
-	d := GetPollingDelay(resp, DefaultPollingDelay)
+	d := GetRetryAfter(resp, DefaultPollingDelay)
 	if d != DefaultPollingDelay {
-		t.Errorf("autorest: GetPollingDelay failed to returned the default delay for a malformed Retry-After header -- expected %v, received %v",
+		t.Errorf("autorest: GetRetryAfter failed to returned the default delay for a malformed Retry-After header -- expected %v, received %v",
 			DefaultPollingDelay, d)
-	}
-}
-
-func TestPollForAttemptsStops(t *testing.T) {
-	client := mocks.NewSender()
-	client.EmitErrors(-1)
-
-	resp := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
-	mocks.SetAcceptedHeaders(resp)
-
-	req, _ := NewPollingRequest(resp, Client{Authorizer: NullAuthorizer{}})
-
-	PollForAttempts(client, req, time.Duration(0), 5)
-	if client.Attempts() < 5 || client.Attempts() > 5 {
-		t.Errorf("autorest: PollForAttempts stopped incorrectly -- expected %v attempts, actual attempts were %v", 5, client.Attempts())
-	}
-}
-
-func TestPollForDurationsStops(t *testing.T) {
-	client := mocks.NewSender()
-	client.EmitErrors(-1)
-
-	d := 10 * time.Millisecond
-	resp := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
-	mocks.SetAcceptedHeaders(resp)
-
-	req, _ := NewPollingRequest(resp, Client{Authorizer: NullAuthorizer{}})
-
-	start := time.Now()
-	PollForDuration(client, req, time.Duration(0), d)
-	if time.Now().Sub(start) < d {
-		t.Error("autorest: PollForDuration stopped too soon")
-	}
-}
-
-func TestPollForDurationsStopsWithinReason(t *testing.T) {
-	client := mocks.NewSender()
-	client.EmitErrors(-1)
-
-	d := 10 * time.Millisecond
-	resp := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
-	mocks.SetAcceptedHeaders(resp)
-	mocks.SetRetryHeader(resp, d)
-	client.SetResponse(resp)
-
-	req, _ := NewPollingRequest(resp, Client{Authorizer: NullAuthorizer{}})
-
-	start := time.Now()
-	PollForDuration(client, req, time.Duration(0), d)
-	if time.Now().Sub(start) > (time.Duration(5.0) * d) {
-		t.Error("autorest: PollForDuration took too long to stop -- exceeded 5 times expected duration")
-	}
-}
-
-func TestPollingHonorsDelay(t *testing.T) {
-	client := mocks.NewSender()
-	client.EmitErrors(-1)
-
-	d1 := 10 * time.Millisecond
-	resp := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
-	mocks.SetAcceptedHeaders(resp)
-	mocks.SetRetryHeader(resp, d1)
-	client.SetResponse(resp)
-
-	req, _ := NewPollingRequest(resp, Client{Authorizer: NullAuthorizer{}})
-
-	start := time.Now()
-	PollForAttempts(client, req, time.Duration(0), 2)
-	d2 := time.Now().Sub(start)
-	if d2 < d1 {
-		t.Errorf("autorest: Polling failed to honor delay -- expected %v, actual %v", d1.Seconds(), d2.Seconds())
-	}
-}
-
-func TestPollingReturnsErrorForExpectedStatusCode(t *testing.T) {
-	client := mocks.NewSender()
-
-	resp := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
-	mocks.SetAcceptedHeaders(resp)
-	client.SetResponse(resp)
-
-	req, _ := NewPollingRequest(resp, Client{Authorizer: NullAuthorizer{}})
-
-	resp, err := PollForAttempts(client, req, time.Duration(0), 1, http.StatusAccepted)
-	if err == nil {
-		t.Error("autorest: Polling failed to emit error for known status code")
-	}
-}
-
-func TestPollingReturnsNoErrorForUnexpectedStatusCode(t *testing.T) {
-	client := mocks.NewSender()
-	client.EmitStatus("500 InternalServerError", http.StatusInternalServerError)
-
-	resp := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
-	mocks.SetAcceptedHeaders(resp)
-
-	req, _ := NewPollingRequest(resp, Client{Authorizer: NullAuthorizer{}})
-
-	resp, err := PollForAttempts(client, req, time.Duration(0), 1, http.StatusAccepted)
-	if err != nil {
-		t.Error("autorest: Polling emitted error for unknown status code")
-	}
-}
-
-func TestPollingReturnsDefaultsToAcceptedStatusCode(t *testing.T) {
-	client := mocks.NewSender()
-
-	resp := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
-	mocks.SetAcceptedHeaders(resp)
-	client.SetResponse(resp)
-
-	req, _ := NewPollingRequest(resp, Client{Authorizer: NullAuthorizer{}})
-
-	resp, err := PollForAttempts(client, req, time.Duration(0), 1)
-	if err == nil {
-		t.Error("autorest: Polling failed to default to HTTP 202")
-	}
-}
-
-func TestPollingLeavesFinalBodyOpen(t *testing.T) {
-	client := mocks.NewSender()
-	client.EmitStatus("500 InternalServerError", http.StatusInternalServerError)
-
-	resp := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
-	mocks.SetAcceptedHeaders(resp)
-
-	req, _ := NewPollingRequest(resp, Client{Authorizer: NullAuthorizer{}})
-
-	resp, _ = PollForAttempts(client, req, time.Duration(0), 1)
-	if !resp.Body.(*mocks.Body).IsOpen() {
-		t.Error("autorest: Polling unexpectedly closed the response body")
-	}
-}
-
-func TestDecorateForPollingCloseBodyOnEachAttempt(t *testing.T) {
-	client := mocks.NewSender()
-
-	resp := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
-	mocks.SetAcceptedHeaders(resp)
-	client.SetResponse(resp)
-
-	req, _ := NewPollingRequest(resp, Client{Authorizer: NullAuthorizer{}})
-	resp, _ = PollForAttempts(client, req, time.Duration(0), 5)
-	if resp.Body.(*mocks.Body).CloseAttempts() < 5 {
-		t.Errorf("autorest: decorateForPolling failed to close the response Body between requests -- expected %v, received %v",
-			5, resp.Body.(*mocks.Body).CloseAttempts())
 	}
 }

--- a/autorest/azure/async.go
+++ b/autorest/azure/async.go
@@ -1,0 +1,154 @@
+package azure
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/date"
+)
+
+const (
+	// HeaderAsyncOperation is the Azure header providing the URL from which to obtain the
+	// OperationResource for an asynchronous (aka long running) operation.
+	HeaderAsyncOperation = "Azure-AsyncOperation"
+)
+
+const (
+	// OperationCanceled says the underlying operation was canceled.
+	OperationCanceled string = "Canceled"
+	// OperationFailed says the underlying operation failed.
+	OperationFailed string = "Failed"
+	// OperationSucceeded says the underlying opertion succeeded.
+	OperationSucceeded string = "Succeeded"
+)
+
+// OperationError provides additional detail when an operation fails or is canceled.
+type OperationError struct {
+	// Code provides an invariant error code useful for troubleshooting, aggregration, and analysis.
+	Code string `json:"code"`
+	// Message indicates what error occurred and what can be done to address the issue.
+	Message string `json:"message"`
+}
+
+// Error implements the error interface returnin a string containing the code and message.
+func (oe OperationError) Error() string {
+	return fmt.Sprintf("Azure Operation Error: Code=%q Message=%q", oe.Code, oe.Message)
+}
+
+// OperationResource defines a resource describing the state of a long-running operation.
+type OperationResource struct {
+	// Id is the identifier used in a GET for the underlying resource.
+	ID string `json:"id"`
+	// Name matches the last segment of the Id field (typically system generated).
+	Name string `json:"name"`
+	// Status provides the state of the operation. Non-terminal states vary by resource;
+	Status string `json:"status"`
+	// Properties, on operation success, optionally contains per-service / per-resource values.
+	Properties map[string]interface{} `json:"properties"`
+	// Error provides additional detail if the operation is canceled or failed.
+	OperationError OperationError `json:"error"`
+	// StartTime optionally provides the time the operation started.
+	StartTime date.Time `json:"startTime"`
+	// EndTime optionally provides the time the operation completed.
+	EndTime date.Time `json:"endTime"`
+	// PercentComplete optionally provides the percent complete between 0 and 100.
+	PercentComplete float64 `json:"percentComplete"`
+}
+
+// HasTerminated returns true if the operation has terminated; false otherwise.
+func (or OperationResource) HasTerminated() bool {
+	switch or.Status {
+	case OperationCanceled, OperationFailed, OperationSucceeded:
+		return true
+	default:
+		return false
+	}
+}
+
+// Error returns an error if the operation was canceled or failed and nil otherwise.
+func (or OperationResource) Error() string {
+	switch or.Status {
+	case OperationCanceled, OperationFailed:
+		return or.OperationError.Error()
+	default:
+		return ""
+	}
+}
+
+// GetAsyncOperation retrieves the long-running URL from which to retrieve the OperationResource.
+func GetAsyncOperation(resp *http.Response) string {
+	return resp.Header.Get(http.CanonicalHeaderKey(HeaderAsyncOperation))
+}
+
+// IsAsynchronousResponse returns true if the passed response indicates that the request will
+// complete asynchronously. Such responses have either an http.StatusCreated or an
+// http.StatusAccepted status code and provide the Azure-AsyncOperation header.
+func IsAsynchronousResponse(resp *http.Response) bool {
+	return autorest.ResponseHasStatusCode(resp, http.StatusCreated, http.StatusAccepted) &&
+		GetAsyncOperation(resp) != ""
+}
+
+// NewOperationResourceRequest allocates and returns a new http.Request to retrieve the
+// OperationResource for an asynchronous operation.
+func NewOperationResourceRequest(resp *http.Response, cancel <-chan struct{}) (*http.Request, error) {
+	location := GetAsyncOperation(resp)
+	if location == "" {
+		return nil, autorest.NewErrorWithResponse("azure", "NewOperationResourceRequest", resp, "Azure-AsyncOperation header missing from response that requires polling")
+	}
+
+	req, err := autorest.Prepare(&http.Request{Cancel: cancel},
+		autorest.AsGet(),
+		autorest.WithBaseURL(location))
+	if err != nil {
+		return nil, autorest.NewErrorWithError(err, "azure", "NewOperationResourceRequest", nil, "Failure creating poll request to %s", location)
+	}
+
+	return req, nil
+}
+
+// DoPollForAsynchronous returns a SendDecorator that polls if the http.Response is for an Azure
+// long-running operation. It will poll until the time passed is equal to or greater than
+// the supplied duration. It will delay between requests for the duration specified in the
+// RetryAfter header or, if the header is absent, the passed delay. Polling may be canceled by
+// closing the optional channel on the http.Request.
+func DoPollForAsynchronous(duration time.Duration, delay time.Duration) autorest.SendDecorator {
+	return func(s autorest.Sender) autorest.Sender {
+		return autorest.SenderFunc(func(r *http.Request) (resp *http.Response, err error) {
+			resp, err = s.Do(r)
+			if err != nil || !IsAsynchronousResponse(resp) {
+				return resp, err
+			}
+
+			r, err = NewOperationResourceRequest(resp, r.Cancel)
+			if err != nil {
+				return resp, autorest.NewErrorWithError(err, "azure", "DoPollForAsynchronous", resp, "Failure occurred creating OperationResource request")
+			}
+
+			or := &OperationResource{}
+			for err == nil && !or.HasTerminated() {
+				autorest.Respond(resp,
+					autorest.ByClosing())
+
+				resp, err = autorest.SendWithSender(s, r,
+					autorest.AfterDelay(autorest.GetRetryAfter(resp, delay)))
+				if err != nil {
+					return resp, autorest.NewErrorWithError(err, "azure", "DoPollForAsynchronous", resp, "Failure occurred retrieving OperationResource")
+				}
+
+				err = autorest.Respond(resp,
+					autorest.ByUnmarshallingJSON(or))
+				if err != nil {
+					return resp, autorest.NewErrorWithError(err, "azure", "DoPollForAsynchronous", resp, "Failure occurred unmarshalling an OperationResource")
+				}
+			}
+
+			if err == nil && or.HasTerminated() {
+				err = or
+			}
+
+			return resp, err
+		})
+	}
+}

--- a/autorest/azure/async_test.go
+++ b/autorest/azure/async_test.go
@@ -1,0 +1,480 @@
+package azure
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/mocks"
+)
+
+func TestGetAsyncOperation_ReturnsAzureAsyncOperationHeader(t *testing.T) {
+	r := newAsynchronousResponse()
+
+	if GetAsyncOperation(r) != mocks.TestURL {
+		t.Errorf("azure: GetAsyncOperation failed to extract the Azure-AsyncOperation header -- expected %v, received %v", mocks.TestURL, GetAsyncOperation(r))
+	}
+}
+
+func TestGetAsyncOperation_ReturnsEmptyStringIfHeaderIsAbsent(t *testing.T) {
+	r := mocks.NewResponse()
+
+	if len(GetAsyncOperation(r)) != 0 {
+		t.Errorf("azure: GetAsyncOperation failed to return empty string when the Azure-AsyncOperation header is absent -- received %v", GetAsyncOperation(r))
+	}
+}
+
+func TestIsAsynchronousResponse_ReturnsTrueForLongRunningResponse(t *testing.T) {
+	r := newAsynchronousResponse()
+
+	if !IsAsynchronousResponse(r) {
+		t.Errorf("azure: IsAsynchronousResponse returned false for a long-running response")
+	}
+}
+
+func TestIsAsynchronousResponse_ReturnsFalseIfStatusCodeIsNotCreated(t *testing.T) {
+	r := newAsynchronousResponse()
+	r.StatusCode = http.StatusOK
+
+	if IsAsynchronousResponse(r) {
+		t.Errorf("azure: IsAsynchronousResponse returned true for a response without a 201 status code")
+	}
+}
+
+func TestIsAsynchronousResponse_ReturnsFalseIfAsyncHeaderIsAbsent(t *testing.T) {
+	r := newAsynchronousResponse()
+	r.Header.Del(HeaderAsyncOperation)
+
+	if IsAsynchronousResponse(r) {
+		t.Errorf("azure: IsAsynchronousResponse returned true for a response without an Azure-AsyncOperation header")
+	}
+}
+
+func TestNewOperationResourceRequest_LeavesBodyOpen(t *testing.T) {
+	r := newAsynchronousResponse()
+
+	NewOperationResourceRequest(r, nil)
+	if !r.Body.(*mocks.Body).IsOpen() {
+		t.Error("azure: NewOperationResourceRequest closed the http.Request Body when the Azure-AsyncOperation header was missing")
+	}
+}
+
+func TestNewOperationResourceRequest_DoesNotReturnARequestWhenAzureAsyncOperationHeaderIsMissing(t *testing.T) {
+	r := newAsynchronousResponse()
+	r.Header.Del(HeaderAsyncOperation)
+
+	req, _ := NewOperationResourceRequest(r, nil)
+	if req != nil {
+		t.Error("azure: NewOperationResourceRequest returned an http.Request when the Azure-AsyncOperation header was missing")
+	}
+}
+
+func TestNewOperationResourceRequest_ReturnsAnErrorWhenPrepareFails(t *testing.T) {
+	r := newAsynchronousResponse()
+	r.Header.Set(http.CanonicalHeaderKey(HeaderAsyncOperation), mocks.TestBadURL)
+
+	_, err := NewOperationResourceRequest(r, nil)
+	if err == nil {
+		t.Error("azure: NewOperationResourceRequest failed to return an error when Prepare fails")
+	}
+}
+
+func TestNewOperationResourceRequest_DoesNotReturnARequestWhenPrepareFails(t *testing.T) {
+	r := newAsynchronousResponse()
+	r.Header.Set(http.CanonicalHeaderKey(HeaderAsyncOperation), mocks.TestBadURL)
+
+	req, _ := NewOperationResourceRequest(r, nil)
+	if req != nil {
+		t.Error("azure: NewOperationResourceRequest returned an http.Request when Prepare failed")
+	}
+}
+
+func TestNewOperationResourceRequest_ReturnsAGetRequest(t *testing.T) {
+	r := newAsynchronousResponse()
+
+	req, _ := NewOperationResourceRequest(r, nil)
+	if req.Method != "GET" {
+		t.Errorf("azure: NewOperationResourceRequest did not create an HTTP GET request -- actual method %v", req.Method)
+	}
+}
+
+func TestNewOperationResourceRequest_ProvidesTheURL(t *testing.T) {
+	r := newAsynchronousResponse()
+
+	req, _ := NewOperationResourceRequest(r, nil)
+	if req.URL.String() != mocks.TestURL {
+		t.Errorf("azure: NewOperationResourceRequest did not create an HTTP with the expected URL -- received %v, expected %v", req.URL, mocks.TestURL)
+	}
+}
+
+func TestOperationError_ErrorReturnsAString(t *testing.T) {
+	s := (OperationError{Code: "server code", Message: "server error"}).Error()
+	if s == "" {
+		t.Errorf("azure: OperationError#Error failed to return an error")
+	}
+	if !strings.Contains(s, "server code") || !strings.Contains(s, "server error") {
+		t.Errorf("azure: OperationError#ToError returned a malformed error -- error(%v)", s)
+	}
+}
+
+func TestOperationResource_HasTerminatedReturnsTrueIfCanceled(t *testing.T) {
+	if !(OperationResource{Status: OperationCanceled}).HasTerminated() {
+		t.Errorf("azure: OperationResource#HasTerminated failed to return true for a canceled operation")
+	}
+}
+
+func TestOperationResource_HasTerminatedReturnsTrueIfFailed(t *testing.T) {
+	if !(OperationResource{Status: OperationFailed}).HasTerminated() {
+		t.Errorf("azure: OperationResource#HasTerminated failed to return true for a failed operation")
+	}
+}
+
+func TestOperationResource_HasTerminatedReturnsTrueIfSuccessful(t *testing.T) {
+	if !(OperationResource{Status: OperationSucceeded}).HasTerminated() {
+		t.Errorf("azure: OperationResource#HasTerminated failed to return true for a successful operation")
+	}
+}
+
+func TestOperationResource_HasTerminatedReturnsFalseNotTerminated(t *testing.T) {
+	if (OperationResource{Status: "UnknownStatus"}).HasTerminated() {
+		t.Errorf("azure: OperationResource#HasTerminated returned true for a non-terminal operation")
+	}
+}
+
+func TestOperationResource_ErrorReturnsErrorIfCanceled(t *testing.T) {
+	if (OperationResource{Status: OperationCanceled}).Error() == "" {
+		t.Errorf("azure: OperationResource#GetError failed to return an error for canceled operations")
+	}
+}
+
+func TestOperationResource_ErrorReturnsErrorIfFailed(t *testing.T) {
+	if (OperationResource{Status: OperationFailed}).Error() == "" {
+		t.Errorf("azure: OperationResource#GetError failed to return an error for failed operations")
+	}
+}
+
+func TestOperationResource_ErrorDoesReturnUnlessFailedOrCanceled(t *testing.T) {
+	if (OperationResource{Status: OperationSucceeded}).Error() != "" {
+		t.Errorf("azure: OperationResource#GetError return an error for operation that was not canceled or failed")
+	}
+}
+
+func TestDoPollForAsynchronous_IgnoresUnspecifiedStatusCodes(t *testing.T) {
+	client := mocks.NewSender()
+
+	r, _ := autorest.SendWithSender(client, mocks.NewRequest(),
+		DoPollForAsynchronous(time.Duration(0), time.Duration(0)))
+
+	if client.Attempts() != 1 {
+		t.Errorf("azure: DoPollForAsynchronous polled for unspecified status code")
+	}
+
+	autorest.Respond(r,
+		autorest.ByClosing())
+}
+
+func TestDoPollForAsynchronous_PollsForSpecifiedStatusCodes(t *testing.T) {
+	client := mocks.NewSender()
+	client.AppendResponse(newAsynchronousResponse())
+
+	r, _ := autorest.SendWithSender(client, mocks.NewRequest(),
+		DoPollForAsynchronous(time.Millisecond, time.Millisecond))
+
+	if client.Attempts() != 2 {
+		t.Errorf("azure: DoPollForAsynchronous failed to poll for specified status code")
+	}
+
+	autorest.Respond(r,
+		autorest.ByClosing())
+}
+
+func TestDoPollForAsynchronous_CanBeCanceled(t *testing.T) {
+	cancel := make(chan struct{})
+	delay := 5 * time.Second
+
+	client := mocks.NewSender()
+	client.AppendResponse(newAsynchronousResponse())
+	client.AppendAndRepeatResponse(newOperationResourceResponse("Busy"), -1)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	start := time.Now()
+	go func() {
+		wg.Done()
+		r, _ := autorest.SendWithSender(client, mocks.NewRequest(),
+			DoPollForAsynchronous(time.Millisecond, time.Millisecond))
+		autorest.Respond(r,
+			autorest.ByClosing())
+	}()
+	wg.Wait()
+	close(cancel)
+	time.Sleep(5 * time.Millisecond)
+	if time.Since(start) >= delay {
+		t.Errorf("azure: DoPollForAsynchronous failed to cancel")
+	}
+}
+
+func TestDoPollForAsynchronous_ClosesAllNonreturnedResponseBodiesWhenPolling(t *testing.T) {
+	r1 := newAsynchronousResponse()
+	r2 := newOperationResourceResponse("busy")
+	r3 := newOperationResourceResponse(OperationSucceeded)
+
+	client := mocks.NewSender()
+	client.AppendResponse(r1)
+	client.AppendAndRepeatResponse(r2, 2)
+	client.AppendResponse(r3)
+
+	r, _ := autorest.SendWithSender(client, mocks.NewRequest(),
+		DoPollForAsynchronous(time.Millisecond, time.Millisecond))
+
+	if r1.Body.(*mocks.Body).IsOpen() || r2.Body.(*mocks.Body).CloseAttempts() < 2 {
+		t.Errorf("azure: DoPollForAsynchronous did not close unreturned response bodies")
+	}
+
+	autorest.Respond(r,
+		autorest.ByClosing())
+}
+
+func TestDoPollForAsynchronous_LeavesLastResponseBodyOpen(t *testing.T) {
+	r1 := newAsynchronousResponse()
+	r2 := newOperationResourceResponse("busy")
+	r3 := newOperationResourceResponse(OperationSucceeded)
+
+	client := mocks.NewSender()
+	client.AppendResponse(r1)
+	client.AppendAndRepeatResponse(r2, 2)
+	client.AppendResponse(r3)
+
+	r, _ := autorest.SendWithSender(client, mocks.NewRequest(),
+		DoPollForAsynchronous(time.Millisecond, time.Millisecond))
+
+	if !r.Body.(*mocks.Body).IsOpen() {
+		t.Errorf("azure: DoPollForAsynchronous did not leave open the body of the last response")
+	}
+
+	autorest.Respond(r,
+		autorest.ByClosing())
+}
+
+func TestDoPollForAsynchronous_DoesNotPollIfCreatingOperationRequestFails(t *testing.T) {
+	r1 := newAsynchronousResponse()
+	mocks.SetResponseHeader(r1, http.CanonicalHeaderKey(HeaderAsyncOperation), mocks.TestBadURL)
+	r2 := newOperationResourceResponse("busy")
+
+	client := mocks.NewSender()
+	client.AppendResponse(r1)
+	client.AppendAndRepeatResponse(r2, 2)
+
+	r, _ := autorest.SendWithSender(client, mocks.NewRequest(),
+		DoPollForAsynchronous(time.Millisecond, time.Millisecond))
+
+	if client.Attempts() > 1 {
+		t.Errorf("azure: DoPollForAsynchronous polled with an invalidly formed operation request")
+	}
+
+	autorest.Respond(r,
+		autorest.ByClosing())
+}
+
+func TestDoPollForAsynchronous_StopsPollingAfterAnError(t *testing.T) {
+	r1 := newAsynchronousResponse()
+	r2 := newOperationResourceResponse("busy")
+
+	client := mocks.NewSender()
+	client.AppendResponse(r1)
+	client.AppendAndRepeatResponse(r2, 2)
+	client.SetError(fmt.Errorf("Faux Error"))
+	client.SetEmitErrorAfter(2)
+
+	r, _ := autorest.SendWithSender(client, mocks.NewRequest(),
+		DoPollForAsynchronous(time.Millisecond, time.Millisecond))
+
+	if client.Attempts() > 3 {
+		t.Errorf("azure: DoPollForAsynchronous failed to stop polling after receiving an error")
+	}
+
+	autorest.Respond(r,
+		autorest.ByClosing())
+}
+
+func TestDoPollForAsynchronous_ReturnsPollingError(t *testing.T) {
+	client := mocks.NewSender()
+	client.AppendAndRepeatResponse(newAsynchronousResponse(), 5)
+	client.SetError(fmt.Errorf("Faux Error"))
+	client.SetEmitErrorAfter(1)
+
+	r, err := autorest.SendWithSender(client, mocks.NewRequest(),
+		DoPollForAsynchronous(time.Millisecond, time.Millisecond))
+
+	if err == nil {
+		t.Errorf("azure: DoPollForAsynchronous failed to return error from polling")
+	}
+
+	autorest.Respond(r,
+		autorest.ByClosing())
+}
+
+func TestDoPollForAsynchronous_PollsUntilOperationResourceHasTerminated(t *testing.T) {
+	r1 := newAsynchronousResponse()
+	r2 := newOperationResourceResponse("busy")
+	r3 := newOperationResourceResponse(OperationCanceled)
+
+	client := mocks.NewSender()
+	client.AppendResponse(r1)
+	client.AppendAndRepeatResponse(r2, 2)
+	client.AppendAndRepeatResponse(r3, 1)
+
+	r, _ := autorest.SendWithSender(client, mocks.NewRequest(),
+		DoPollForAsynchronous(time.Millisecond, time.Millisecond))
+
+	if client.Attempts() < 4 {
+		t.Errorf("azure: DoPollForAsynchronous stopped polling before receiving a terminated OperationResource")
+	}
+
+	autorest.Respond(r,
+		autorest.ByClosing())
+}
+
+func TestDoPollForAsynchronous_StopsPollingWhenOperationResourceHasTerminated(t *testing.T) {
+	r1 := newAsynchronousResponse()
+	r2 := newOperationResourceResponse("busy")
+	r3 := newOperationResourceResponse(OperationCanceled)
+
+	client := mocks.NewSender()
+	client.AppendResponse(r1)
+	client.AppendAndRepeatResponse(r2, 2)
+	client.AppendAndRepeatResponse(r3, 2)
+
+	r, _ := autorest.SendWithSender(client, mocks.NewRequest(),
+		DoPollForAsynchronous(time.Millisecond, time.Millisecond))
+
+	if client.Attempts() > 4 {
+		t.Errorf("azure: DoPollForAsynchronous failed to stop after receiving a terminated OperationResource")
+	}
+
+	autorest.Respond(r,
+		autorest.ByClosing())
+}
+
+func TestDoPollForAsynchronous_ReturnsAnErrorForCanceledOperations(t *testing.T) {
+	r1 := newAsynchronousResponse()
+	r2 := newOperationResourceResponse("busy")
+	r3 := newOperationResourceErrorResponse(OperationCanceled)
+
+	client := mocks.NewSender()
+	client.AppendResponse(r1)
+	client.AppendAndRepeatResponse(r2, 2)
+	client.AppendAndRepeatResponse(r3, 1)
+
+	r, err := autorest.SendWithSender(client, mocks.NewRequest(),
+		DoPollForAsynchronous(time.Millisecond, time.Millisecond))
+
+	if err == nil || !strings.Contains(fmt.Sprintf("%v", err), "BadArgument") {
+		t.Errorf("azure: DoPollForAsynchronous failed to return an appropriate error for a canceled OperationResource")
+	}
+
+	autorest.Respond(r,
+		autorest.ByClosing())
+}
+
+func TestDoPollForAsynchronous_ReturnsAnErrorForFailedOperations(t *testing.T) {
+	r1 := newAsynchronousResponse()
+	r2 := newOperationResourceResponse("busy")
+	r3 := newOperationResourceErrorResponse(OperationFailed)
+
+	client := mocks.NewSender()
+	client.AppendResponse(r1)
+	client.AppendAndRepeatResponse(r2, 2)
+	client.AppendAndRepeatResponse(r3, 1)
+
+	r, err := autorest.SendWithSender(client, mocks.NewRequest(),
+		DoPollForAsynchronous(time.Millisecond, time.Millisecond))
+
+	if err == nil || !strings.Contains(fmt.Sprintf("%v", err), "BadArgument") {
+		t.Errorf("azure: DoPollForAsynchronous failed to return an appropriate error for a canceled OperationResource")
+	}
+
+	autorest.Respond(r,
+		autorest.ByClosing())
+}
+
+func TestDoPollForAsynchronous_StopsPollingIfItReceivesAnInvalidOperationResource(t *testing.T) {
+	r1 := newAsynchronousResponse()
+	r2 := newOperationResourceResponse("busy")
+	r3 := mocks.NewResponseWithContent(operationResourceIllegal)
+	r4 := newOperationResourceResponse(OperationSucceeded)
+
+	client := mocks.NewSender()
+	client.AppendResponse(r1)
+	client.AppendAndRepeatResponse(r2, 2)
+	client.AppendAndRepeatResponse(r3, 1)
+	client.AppendAndRepeatResponse(r4, 1)
+
+	r, err := autorest.SendWithSender(client, mocks.NewRequest(),
+		DoPollForAsynchronous(time.Millisecond, time.Millisecond))
+
+	if client.Attempts() > 4 {
+		t.Errorf("azure: DoPollForAsynchronous failed to polling after receiving an invalid OperationResource")
+	}
+	if err == nil {
+		t.Errorf("azure: DoPollForAsynchronous failed to return an error after receving an invalid OperationResource")
+	}
+
+	autorest.Respond(r,
+		autorest.ByClosing())
+}
+
+func newAsynchronousResponse() *http.Response {
+	r := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
+	mocks.SetResponseHeader(r, http.CanonicalHeaderKey(HeaderAsyncOperation), mocks.TestURL)
+	mocks.SetRetryHeader(r, retryDelay)
+	return r
+}
+
+const (
+	operationResourceIllegal = `
+	This is not JSON and should fail...badly.
+`
+
+	operationResourceFormat = `
+	{
+		"id": "/subscriptions/id/locations/westus/operationsStatus/sameguid",
+		"name": "sameguid",
+		"status" : "%s",
+		"startTime" : "2006-01-02T15:04:05Z",
+		"endTime" : "2006-01-02T16:04:05Z",
+		"percentComplete" : 50.00,
+
+		"properties" : {}
+	}
+`
+
+	operationResourceErrorFormat = `
+	{
+		"id": "/subscriptions/id/locations/westus/operationsStatus/sameguid",
+		"name": "sameguid",
+		"status" : "%s",
+		"startTime" : "2006-01-02T15:04:05Z",
+		"endTime" : "2006-01-02T16:04:05Z",
+		"percentComplete" : 50.00,
+
+		"properties" : {},
+		"error" : {
+			"code" : "BadArgument",
+			"message" : "The provided database 'foo' has an invalid username."
+		}
+	}
+`
+)
+
+func newOperationResourceResponse(status string) *http.Response {
+	return mocks.NewResponseWithContent(fmt.Sprintf(operationResourceFormat, status))
+}
+
+func newOperationResourceErrorResponse(status string) *http.Response {
+	return mocks.NewResponseWithContent(fmt.Sprintf(operationResourceErrorFormat, status))
+}

--- a/autorest/azure/azure.go
+++ b/autorest/azure/azure.go
@@ -10,16 +10,11 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strconv"
-	"time"
 
 	"github.com/Azure/go-autorest/autorest"
 )
 
 const (
-	// HeaderAsyncOperation is the Azure header containing the location to poll for long-running
-	// operations.
-	HeaderAsyncOperation = "Azure-AsyncOperation"
-
 	// HeaderClientID is the Azure extension header to set a user-specified request ID.
 	HeaderClientID = "x-ms-client-request-id"
 
@@ -129,57 +124,6 @@ func ExtractClientID(resp *http.Response) string {
 // x-ms-request-id header.
 func ExtractRequestID(resp *http.Response) string {
 	return autorest.ExtractHeaderValue(HeaderRequestID, resp)
-}
-
-// GetAsyncOperation retrieves the long-running URL to poll from the passed response.
-func GetAsyncOperation(resp *http.Response) string {
-	return resp.Header.Get(http.CanonicalHeaderKey(HeaderAsyncOperation))
-}
-
-// ResponseIsLongRunning returns true if the passed response is for an Azure long-running operation.
-func ResponseIsLongRunning(resp *http.Response) bool {
-	return autorest.ResponseRequiresPolling(resp, http.StatusCreated) && GetAsyncOperation(resp) != ""
-}
-
-// NewAsyncPollingRequest allocates and returns a new http.Request to poll an Azure long-running
-// operation. If it successfully creates the request, it will also close the body of the passed
-// response, otherwise the body remains open.
-func NewAsyncPollingRequest(resp *http.Response, c autorest.Client) (*http.Request, error) {
-	location := GetAsyncOperation(resp)
-	if location == "" {
-		return nil, autorest.NewErrorWithResponse("azure", "NewAsyncPollingRequest", resp, "Azure-AsyncOperation header missing from response that requires polling")
-	}
-
-	req, err := autorest.Prepare(&http.Request{},
-		autorest.AsGet(),
-		autorest.WithBaseURL(location))
-	if err != nil {
-		return nil, autorest.NewErrorWithError(err, "azure", "NewAsyncPollingRequest", nil, "Failure creating poll request to %s", location)
-	}
-
-	autorest.Respond(resp,
-		c.ByInspecting(),
-		autorest.ByClosing())
-
-	return req, nil
-}
-
-// WithAsyncPolling will poll until the completion of an Azure long-running operation. The delay
-// time between requests is taken from the HTTP Retry-After header, if present, or the passed
-// delay otherwise. Polling may be canceled by signaling on the optional http.Request channel.
-func WithAsyncPolling(defaultDelay time.Duration) autorest.SendDecorator {
-	return func(s autorest.Sender) autorest.Sender {
-		return autorest.SenderFunc(func(r *http.Request) (*http.Response, error) {
-			resp, err := s.Do(r)
-			for err == nil && ResponseIsLongRunning(resp) {
-				err = autorest.DelayForBackoff(autorest.GetPollingDelay(resp, defaultDelay), 1, r.Cancel)
-				if err == nil {
-					resp, err = s.Do(r)
-				}
-			}
-			return resp, err
-		})
-	}
 }
 
 // WithErrorUnlessStatusCode returns a RespondDecorator that emits an

--- a/autorest/azure/azure_test.go
+++ b/autorest/azure/azure_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"reflect"
 	"strconv"
-	"sync"
 	"testing"
 	"time"
 
@@ -31,7 +30,7 @@ func ExampleWithClientID() {
 	c := autorest.Client{Sender: mocks.NewSender()}
 	c.RequestInspector = WithReturningClientID(uuid)
 
-	c.Send(req)
+	autorest.SendWithSender(c, req)
 	fmt.Printf("Inspector added the %s header with the value %s\n",
 		HeaderClientID, req.Header.Get(HeaderClientID))
 	fmt.Printf("Inspector added the %s header with the value %s\n",
@@ -221,210 +220,6 @@ func TestWithErrorUnlessStatusCode_FoundAzureError(t *testing.T) {
 
 }
 
-func TestGetAsyncOperation_ReturnsAzureAsyncOperationHeader(t *testing.T) {
-	r := newLongRunningResponse()
-
-	if GetAsyncOperation(r) != mocks.TestURL {
-		t.Errorf("azure: GetAsyncOperation failed to extract the Azure-AsyncOperation header -- expected %v, received %v", mocks.TestURL, GetAsyncOperation(r))
-	}
-}
-
-func TestGetAsyncOperation_ReturnsEmptyStringIfHeaderIsAbsent(t *testing.T) {
-	r := mocks.NewResponse()
-
-	if len(GetAsyncOperation(r)) != 0 {
-		t.Errorf("azure: GetAsyncOperation failed to return empty string when the Azure-AsyncOperation header is absent -- received %v", GetAsyncOperation(r))
-	}
-}
-
-func TestReponseIsLongRunning_ReturnsTrueForLongRunningResponse(t *testing.T) {
-	r := newLongRunningResponse()
-
-	if !ResponseIsLongRunning(r) {
-		t.Errorf("azure: ResponseIsLongRunning returned false for a long-running response")
-	}
-}
-
-func TestResponseIsLongRunning_ReturnsFalseIfStatusCodeIsNotCreated(t *testing.T) {
-	r := newLongRunningResponse()
-	r.StatusCode = http.StatusOK
-
-	if ResponseIsLongRunning(r) {
-		t.Errorf("azure: ResponseIsLongRunning returned true for a response without a 201 status code")
-	}
-}
-
-func TestResponseIsLongRunning_ReturnsFalseIfAsyncHeaderIsAbsent(t *testing.T) {
-	r := newLongRunningResponse()
-	r.Header.Del(HeaderAsyncOperation)
-
-	if ResponseIsLongRunning(r) {
-		t.Errorf("azure: ResponseIsLongRunning returned true for a response without an Azure-AsyncOperation header")
-	}
-}
-
-func TestNewAsyncPollingRequest_LeavesBodyOpenWhenAzureAsyncOperationHeaderIsMissing(t *testing.T) {
-	r := newLongRunningResponse()
-	r.Header.Del(HeaderAsyncOperation)
-
-	NewAsyncPollingRequest(r, autorest.Client{Authorizer: autorest.NullAuthorizer{}})
-	if !r.Body.(*mocks.Body).IsOpen() {
-		t.Error("azure: NewAsyncPollingRequest closed the http.Request Body when the Azure-AsyncOperation header was missing")
-	}
-}
-
-func TestNewAsyncPollingRequest_DoesNotReturnARequestWhenAzureAsyncOperationHeaderIsMissing(t *testing.T) {
-	r := newLongRunningResponse()
-	r.Header.Del(HeaderAsyncOperation)
-
-	req, _ := NewAsyncPollingRequest(r, autorest.Client{Authorizer: autorest.NullAuthorizer{}})
-	if req != nil {
-		t.Error("azure: NewAsyncPollingRequest returned an http.Request when the Azure-AsyncOperation header was missing")
-	}
-}
-
-func TestNewAsyncPollingRequest_ReturnsAnErrorWhenPrepareFails(t *testing.T) {
-	r := newLongRunningResponse()
-	r.Header.Set(http.CanonicalHeaderKey(HeaderAsyncOperation), mocks.TestBadURL)
-
-	_, err := NewAsyncPollingRequest(r, autorest.Client{Authorizer: mockFailingAuthorizer{}})
-	if err == nil {
-		t.Error("azure: NewAsyncPollingRequest failed to return an error when Prepare fails")
-	}
-}
-
-func TestNewAsyncPollingRequest_LeavesBodyOpenWhenPrepareFails(t *testing.T) {
-	r := newLongRunningResponse()
-	r.Header.Set(http.CanonicalHeaderKey(HeaderAsyncOperation), "")
-
-	_, err := NewAsyncPollingRequest(r, autorest.Client{Authorizer: autorest.NullAuthorizer{}})
-	if !r.Body.(*mocks.Body).IsOpen() {
-		t.Errorf("azure: NewAsyncPollingRequest closed the http.Request Body when Prepare returned an error (%v)", err)
-	}
-}
-
-func TestNewAsyncPollingRequest_DoesNotReturnARequestWhenPrepareFails(t *testing.T) {
-	r := newLongRunningResponse()
-	r.Header.Set(http.CanonicalHeaderKey(HeaderAsyncOperation), mocks.TestBadURL)
-
-	req, _ := NewAsyncPollingRequest(r, autorest.Client{Authorizer: autorest.NullAuthorizer{}})
-	if req != nil {
-		t.Error("azure: NewAsyncPollingRequest returned an http.Request when Prepare failed")
-	}
-}
-
-func TestNewAsyncPollingRequest_ClosesTheResponseBody(t *testing.T) {
-	r := newLongRunningResponse()
-
-	NewAsyncPollingRequest(r, autorest.Client{Authorizer: autorest.NullAuthorizer{}})
-	if r.Body.(*mocks.Body).IsOpen() {
-		t.Error("azure: NewAsyncPollingRequest failed to close the response body when creating a new request")
-	}
-}
-
-func TestNewAsyncPollingRequest_ReturnsAGetRequest(t *testing.T) {
-	r := newLongRunningResponse()
-
-	req, _ := NewAsyncPollingRequest(r, autorest.Client{Authorizer: autorest.NullAuthorizer{}})
-	if req.Method != "GET" {
-		t.Errorf("azure: NewAsyncPollingRequest did not create an HTTP GET request -- actual method %v", req.Method)
-	}
-}
-
-func TestNewAsyncPollingRequest_ProvidesTheURL(t *testing.T) {
-	r := newLongRunningResponse()
-
-	req, _ := NewAsyncPollingRequest(r, autorest.Client{Authorizer: autorest.NullAuthorizer{}})
-	if req.URL.String() != mocks.TestURL {
-		t.Errorf("azure: NewAsyncPollingRequest did not create an HTTP with the expected URL -- received %v, expected %v", req.URL, mocks.TestURL)
-	}
-}
-
-func TestWithAsyncPolling_Waits(t *testing.T) {
-	resp := newLongRunningResponse()
-
-	client := mocks.NewSender()
-	client.SetResponse(resp)
-
-	req, _ := NewAsyncPollingRequest(resp, autorest.DefaultClient)
-
-	tt := time.Now()
-	r, _ := autorest.SendWithSender(client, req,
-		withAsyncResponseDecorator(2),
-		WithAsyncPolling(retryDelay))
-	s := time.Since(tt)
-	if s < retryDelay {
-		t.Error("azure: WithAsyncPolling failed to wait for at least the specified duration")
-	}
-
-	autorest.Respond(r,
-		autorest.ByClosing())
-}
-
-func TestWithAsyncPolling_Polls(t *testing.T) {
-	resp := newLongRunningResponse()
-
-	client := mocks.NewSender()
-	client.SetResponse(resp)
-
-	req, _ := NewAsyncPollingRequest(resp, autorest.DefaultClient)
-
-	r, _ := autorest.SendWithSender(client, req,
-		withAsyncResponseDecorator(2),
-		WithAsyncPolling(retryDelay))
-	if client.Attempts() != 3 {
-		t.Errorf("azure: WithAsyncPolling failed to poll -- expected %v, actual %v", 2, client.Attempts())
-	}
-
-	autorest.Respond(r,
-		autorest.ByClosing())
-}
-
-func TestWithAsyncPolling_DoesNotPollForNormalResponses(t *testing.T) {
-	client := mocks.NewSender()
-
-	r, _ := autorest.SendWithSender(client, mocks.NewRequest(),
-		WithAsyncPolling(retryDelay))
-	if client.Attempts() != 1 {
-		t.Error("azure: WithAsyncPolling polled for a non-long-running Response")
-	}
-
-	autorest.Respond(r,
-		autorest.ByClosing())
-}
-
-func TestWithAsyncPolling_CancelsWhenSignaled(t *testing.T) {
-	resp := newLongRunningResponse()
-	mocks.SetRetryHeader(resp, longDelay)
-
-	client := mocks.NewSender()
-	client.SetResponse(resp)
-
-	req, _ := NewAsyncPollingRequest(resp, autorest.DefaultClient)
-	cancel := make(chan struct{})
-	req.Cancel = cancel
-
-	tt := time.Now()
-	var r *http.Response
-	wg := sync.WaitGroup{}
-	wg.Add(1)
-	go func() {
-		wg.Done()
-		r, _ = autorest.SendWithSender(client, req,
-			WithAsyncPolling(longDelay))
-	}()
-	wg.Wait()
-	close(cancel)
-	time.Sleep(10 * time.Millisecond)
-	s := time.Since(tt)
-	if s >= longDelay {
-		t.Errorf("azure: WithAsyncPolling failed to cancel polling")
-	}
-
-	autorest.Respond(r,
-		autorest.ByClosing())
-}
-
 func withErrorPrepareDecorator(e *error) autorest.PrepareDecorator {
 	return func(p autorest.Preparer) autorest.Preparer {
 		return autorest.PreparerFunc(func(r *http.Request) (*http.Request, error) {
@@ -453,15 +248,6 @@ func withAsyncResponseDecorator(n int) autorest.SendDecorator {
 			return resp, err
 		})
 	}
-}
-
-func newLongRunningResponse() *http.Response {
-	r := mocks.NewResponse()
-	r.Header = http.Header{}
-	mocks.SetRetryHeader(r, retryDelay)
-	r.Header.Add(http.CanonicalHeaderKey(HeaderAsyncOperation), mocks.TestURL)
-	r.StatusCode = http.StatusCreated
-	return r
 }
 
 type mockAuthorizer struct{}

--- a/autorest/azure/devicetoken.go
+++ b/autorest/azure/devicetoken.go
@@ -91,7 +91,7 @@ func InitiateDeviceAuth(client *autorest.Client, oauthConfig OAuthConfig, client
 		}),
 	)
 
-	resp, err := client.Send(req)
+	resp, err := autorest.SendWithSender(client, req)
 	if err != nil {
 		return nil, fmt.Errorf("%s %s: %s", logPrefix, errCodeSendingFails, err)
 	}
@@ -129,7 +129,7 @@ func CheckForUserCompletion(client *autorest.Client, code *DeviceCode) (*Token, 
 		}),
 	)
 
-	resp, err := client.Send(req)
+	resp, err := autorest.SendWithSender(client, req)
 	if err != nil {
 		return nil, fmt.Errorf("%s %s: %s", logPrefix, errTokenSendingFails, err)
 	}

--- a/autorest/azure/devicetoken_test.go
+++ b/autorest/azure/devicetoken_test.go
@@ -45,8 +45,7 @@ const MockDeviceTokenResponse = `{
 
 func TestDeviceCodeIncludesResource(t *testing.T) {
 	sender := mocks.NewSender()
-	sender.EmitContent(MockDeviceCodeResponse)
-	sender.EmitStatus("OK", 200)
+	sender.AppendResponse(mocks.NewResponseWithContent(MockDeviceCodeResponse))
 	client := &autorest.Client{Sender: sender}
 
 	code, err := InitiateDeviceAuth(client, TestOAuthConfig, TestClientID, TestResource)
@@ -61,7 +60,6 @@ func TestDeviceCodeIncludesResource(t *testing.T) {
 
 func TestDeviceCodeReturnsErrorIfSendingFails(t *testing.T) {
 	sender := mocks.NewSender()
-	sender.EmitErrors(1)
 	sender.SetError(fmt.Errorf("this is an error"))
 	client := &autorest.Client{Sender: sender}
 
@@ -74,7 +72,7 @@ func TestDeviceCodeReturnsErrorIfSendingFails(t *testing.T) {
 func TestDeviceCodeReturnsErrorIfBadRequest(t *testing.T) {
 	sender := mocks.NewSender()
 	body := mocks.NewBody("doesn't matter")
-	sender.SetResponse(mocks.NewResponseWithBodyAndStatus(body, 400, "Bad Request"))
+	sender.AppendResponse(mocks.NewResponseWithBodyAndStatus(body, 400, "Bad Request"))
 	client := &autorest.Client{Sender: sender}
 
 	_, err := InitiateDeviceAuth(client, TestOAuthConfig, TestClientID, TestResource)
@@ -91,7 +89,7 @@ func TestDeviceCodeReturnsErrorIfCannotDeserializeDeviceCode(t *testing.T) {
 	gibberishJSON := strings.Replace(MockDeviceCodeResponse, "expires_in", "\":, :gibberish", -1)
 	sender := mocks.NewSender()
 	body := mocks.NewBody(gibberishJSON)
-	sender.SetResponse(mocks.NewResponseWithBodyAndStatus(body, 200, "OK"))
+	sender.AppendResponse(mocks.NewResponseWithBodyAndStatus(body, 200, "OK"))
 	client := &autorest.Client{Sender: sender}
 
 	_, err := InitiateDeviceAuth(client, TestOAuthConfig, TestClientID, TestResource)
@@ -115,7 +113,7 @@ func deviceCode() *DeviceCode {
 func TestDeviceTokenReturns(t *testing.T) {
 	sender := mocks.NewSender()
 	body := mocks.NewBody(MockDeviceTokenResponse)
-	sender.SetResponse(mocks.NewResponseWithBodyAndStatus(body, 200, "OK"))
+	sender.AppendResponse(mocks.NewResponseWithBodyAndStatus(body, 200, "OK"))
 	client := &autorest.Client{Sender: sender}
 
 	_, err := WaitForUserCompletion(client, deviceCode())
@@ -130,7 +128,6 @@ func TestDeviceTokenReturns(t *testing.T) {
 
 func TestDeviceTokenReturnsErrorIfSendingFails(t *testing.T) {
 	sender := mocks.NewSender()
-	sender.EmitErrors(1)
 	sender.SetError(fmt.Errorf("this is an error"))
 	client := &autorest.Client{Sender: sender}
 
@@ -143,7 +140,7 @@ func TestDeviceTokenReturnsErrorIfSendingFails(t *testing.T) {
 func TestDeviceTokenReturnsErrorIfServerError(t *testing.T) {
 	sender := mocks.NewSender()
 	body := mocks.NewBody("")
-	sender.SetResponse(mocks.NewResponseWithBodyAndStatus(body, 500, "Internal Server Error"))
+	sender.AppendResponse(mocks.NewResponseWithBodyAndStatus(body, 500, "Internal Server Error"))
 	client := &autorest.Client{Sender: sender}
 
 	_, err := WaitForUserCompletion(client, deviceCode())
@@ -160,7 +157,7 @@ func TestDeviceTokenReturnsErrorIfCannotDeserializeDeviceToken(t *testing.T) {
 	gibberishJSON := strings.Replace(MockDeviceTokenResponse, "expires_in", ";:\"gibberish", -1)
 	sender := mocks.NewSender()
 	body := mocks.NewBody(gibberishJSON)
-	sender.SetResponse(mocks.NewResponseWithBodyAndStatus(body, 200, "OK"))
+	sender.AppendResponse(mocks.NewResponseWithBodyAndStatus(body, 200, "OK"))
 	client := &autorest.Client{Sender: sender}
 
 	_, err := WaitForUserCompletion(client, deviceCode())
@@ -180,7 +177,7 @@ func errorDeviceTokenResponse(message string) string {
 func TestDeviceTokenReturnsErrorIfAuthorizationPending(t *testing.T) {
 	sender := mocks.NewSender()
 	body := mocks.NewBody(errorDeviceTokenResponse("authorization_pending"))
-	sender.SetResponse(mocks.NewResponseWithBodyAndStatus(body, 400, "Bad Request"))
+	sender.AppendResponse(mocks.NewResponseWithBodyAndStatus(body, 400, "Bad Request"))
 	client := &autorest.Client{Sender: sender}
 
 	_, err := CheckForUserCompletion(client, deviceCode())
@@ -196,7 +193,7 @@ func TestDeviceTokenReturnsErrorIfAuthorizationPending(t *testing.T) {
 func TestDeviceTokenReturnsErrorIfSlowDown(t *testing.T) {
 	sender := mocks.NewSender()
 	body := mocks.NewBody(errorDeviceTokenResponse("slow_down"))
-	sender.SetResponse(mocks.NewResponseWithBodyAndStatus(body, 400, "Bad Request"))
+	sender.AppendResponse(mocks.NewResponseWithBodyAndStatus(body, 400, "Bad Request"))
 	client := &autorest.Client{Sender: sender}
 
 	_, err := CheckForUserCompletion(client, deviceCode())
@@ -255,7 +252,7 @@ func TestDeviceTokenSucceedsWithIntermediateSlowDown(t *testing.T) {
 func TestDeviceTokenReturnsErrorIfAccessDenied(t *testing.T) {
 	sender := mocks.NewSender()
 	body := mocks.NewBody(errorDeviceTokenResponse("access_denied"))
-	sender.SetResponse(mocks.NewResponseWithBodyAndStatus(body, 400, "Bad Request"))
+	sender.AppendResponse(mocks.NewResponseWithBodyAndStatus(body, 400, "Bad Request"))
 	client := &autorest.Client{Sender: sender}
 
 	_, err := WaitForUserCompletion(client, deviceCode())
@@ -271,7 +268,7 @@ func TestDeviceTokenReturnsErrorIfAccessDenied(t *testing.T) {
 func TestDeviceTokenReturnsErrorIfCodeExpired(t *testing.T) {
 	sender := mocks.NewSender()
 	body := mocks.NewBody(errorDeviceTokenResponse("code_expired"))
-	sender.SetResponse(mocks.NewResponseWithBodyAndStatus(body, 400, "Bad Request"))
+	sender.AppendResponse(mocks.NewResponseWithBodyAndStatus(body, 400, "Bad Request"))
 	client := &autorest.Client{Sender: sender}
 
 	_, err := WaitForUserCompletion(client, deviceCode())
@@ -287,7 +284,7 @@ func TestDeviceTokenReturnsErrorIfCodeExpired(t *testing.T) {
 func TestDeviceTokenReturnsErrorForUnknownError(t *testing.T) {
 	sender := mocks.NewSender()
 	body := mocks.NewBody(errorDeviceTokenResponse("unknown_error"))
-	sender.SetResponse(mocks.NewResponseWithBodyAndStatus(body, 400, "Bad Request"))
+	sender.AppendResponse(mocks.NewResponseWithBodyAndStatus(body, 400, "Bad Request"))
 	client := &autorest.Client{Sender: sender}
 
 	_, err := WaitForUserCompletion(client, deviceCode())

--- a/autorest/azure/example/main.go
+++ b/autorest/azure/example/main.go
@@ -162,7 +162,7 @@ func printResourceGroups(client *autorest.Client) error {
 		autorest.WithPathParameters(p),
 		autorest.WithQueryParameters(q))
 
-	resp, err := client.Send(req)
+	resp, err := autorest.SendWithSender(client, req)
 	if err != nil {
 		return err
 	}

--- a/autorest/azure/token_test.go
+++ b/autorest/azure/token_test.go
@@ -198,7 +198,6 @@ func testServicePrincipalTokenRefreshSetsBody(t *testing.T, spt *ServicePrincipa
 				})
 			}
 		})())
-	fmt.Println(spt == nil)
 	spt.SetSender(s)
 	spt.Refresh()
 }
@@ -264,7 +263,7 @@ func TestServicePrincipalTokenRefreshPropagatesErrors(t *testing.T) {
 	spt := newServicePrincipalToken()
 
 	c := mocks.NewSender()
-	c.EmitErrors(1)
+	c.SetError(fmt.Errorf("Faux Error"))
 	spt.SetSender(c)
 
 	err := spt.Refresh()
@@ -277,7 +276,7 @@ func TestServicePrincipalTokenRefreshReturnsErrorIfNotOk(t *testing.T) {
 	spt := newServicePrincipalToken()
 
 	c := mocks.NewSender()
-	c.EmitStatus("401 NotAuthorized", 401)
+	c.AppendResponse(mocks.NewResponseWithStatus("401 NotAuthorized", 401))
 	spt.SetSender(c)
 
 	err := spt.Refresh()
@@ -393,7 +392,7 @@ func TestRefreshCallback(t *testing.T) {
 
 	sender := mocks.NewSender()
 	j := newTokenJSON(expiresOn, "resource")
-	sender.EmitContent(j)
+	sender.AppendResponse(mocks.NewResponseWithContent(j))
 	spt.SetSender(sender)
 	spt.Refresh()
 
@@ -412,7 +411,7 @@ func TestRefreshCallbackErrorPropagates(t *testing.T) {
 
 	sender := mocks.NewSender()
 	j := newTokenJSON(expiresOn, "resource")
-	sender.EmitContent(j)
+	sender.AppendResponse(mocks.NewResponseWithContent(j))
 	spt.SetSender(sender)
 	err := spt.Refresh()
 

--- a/autorest/client.go
+++ b/autorest/client.go
@@ -10,26 +10,11 @@ import (
 )
 
 const (
-	// DefaultPollingDelay is the default delay between polling requests (only used if the
-	// http.Request lacks a well-formed Retry-After header).
+	// DefaultPollingDelay is a reasonable delay between polling requests.
 	DefaultPollingDelay = 60 * time.Second
 
-	// DefaultPollingDuration is the default total polling duration.
+	// DefaultPollingDuration is a reasonable total polling duration.
 	DefaultPollingDuration = 15 * time.Minute
-)
-
-// PollingMode sets how, if at all, clients composed with Client will poll.
-type PollingMode string
-
-const (
-	// PollUntilAttempts polling mode polls until reaching a maximum number of attempts.
-	PollUntilAttempts PollingMode = "poll-until-attempts"
-
-	// PollUntilDuration polling mode polls until a specified time.Duration has passed.
-	PollUntilDuration PollingMode = "poll-until-duration"
-
-	// DoNotPoll disables polling.
-	DoNotPoll PollingMode = "not-at-all"
 )
 
 const (
@@ -42,6 +27,12 @@ const (
 ===================================================== HTTP Response End
 `
 )
+
+// Response serves as the base for all responses from generated clients. It provides access to the
+// last http.Response.
+type Response struct {
+	*http.Response `json:"-"`
+}
 
 // LoggingInspector implements request and response inspectors that log the full request and
 // response to a supplied log.
@@ -95,17 +86,9 @@ func (li LoggingInspector) ByInspecting() RespondDecorator {
 	}
 }
 
-var (
-	// DefaultClient is the base from which generated clients should create a Client instance. Users
-	// can then established widely used Client defaults by replacing or modifying the DefaultClient
-	// before instantiating a generated client.
-	DefaultClient = Client{PollingMode: PollUntilDuration, PollingDuration: DefaultPollingDuration}
-)
-
 // Client is the base for autorest generated clients. It provides default, "do nothing"
 // implementations of an Authorizer, RequestInspector, and ResponseInspector. It also returns the
-// standard, undecorated http.Client as a default Sender. Lastly, it supports basic request polling,
-// limited to a maximum number of attempts or a specified duration.
+// standard, undecorated http.Client as a default Sender.
 //
 // Generated clients should also use Error (see NewError and NewErrorWithError) for errors and
 // return responses that compose with Response.
@@ -120,100 +103,26 @@ type Client struct {
 	RequestInspector  PrepareDecorator
 	ResponseInspector RespondDecorator
 
-	PollingMode     PollingMode
-	PollingAttempts int
-	PollingDuration time.Duration
-
 	// UserAgent, if not empty, will be set as the HTTP User-Agent header on all requests sent
 	// through the Do method.
 	UserAgent string
 }
 
-// NewClientWithUserAgent returns an instance of the DefaultClient with the UserAgent set to the
-// passed string.
+// NewClientWithUserAgent returns an instance of a Client with the UserAgent set to the passed
+// string.
 func NewClientWithUserAgent(ua string) Client {
-	c := DefaultClient
+	c := Client{}
 	c.UserAgent = ua
 	return c
 }
 
-// IsPollingAllowed returns an error if the client allows polling and the passed http.Response
-// requires it, otherwise it returns nil.
-func (c Client) IsPollingAllowed(resp *http.Response, codes ...int) error {
-	if c.DoNotPoll() && ResponseRequiresPolling(resp, codes...) {
-		return NewErrorWithResponse("autorest/Client", "IsPollingAllowed", resp, "Response to %s requires polling but polling is disabled",
-			resp.Request.URL)
-	}
-	return nil
-}
-
-// PollAsNeeded is a convenience method that will poll if the passed http.Response requires it.
-func (c Client) PollAsNeeded(resp *http.Response, codes ...int) (*http.Response, error) {
-	if !ResponseRequiresPolling(resp, codes...) {
-		return resp, nil
-	}
-
-	if c.DoNotPoll() {
-		return resp, NewErrorWithResponse("autorest/Client", "PollAsNeeded", resp, "Polling for %s is required, but polling is disabled",
-			resp.Request.URL)
-	}
-
-	req, err := NewPollingRequest(resp, c)
-	if err != nil {
-		return resp, NewErrorWithError(err, "autorest/Client", "PollAsNeeded", resp, "Unable to create polling request for response to %s",
-			resp.Request.URL)
-	}
-
-	Prepare(req,
-		c.WithInspection())
-
-	if c.PollForAttempts() {
-		return PollForAttempts(c, req, DefaultPollingDelay, c.PollingAttempts, codes...)
-	}
-	return PollForDuration(c, req, DefaultPollingDelay, c.PollingDuration, codes...)
-}
-
-// DoNotPoll returns true if the client should not poll, false otherwise.
-func (c Client) DoNotPoll() bool {
-	return len(c.PollingMode) == 0 || c.PollingMode == DoNotPoll
-}
-
-// PollForAttempts returns true if the PollingMode is set to ForAttempts, false otherwise.
-func (c Client) PollForAttempts() bool {
-	return c.PollingMode == PollUntilAttempts
-}
-
-// PollForDuration return true if the PollingMode is set to ForDuration, false otherwise.
-func (c Client) PollForDuration() bool {
-	return c.PollingMode == PollUntilDuration
-}
-
-// Send sends the passed http.Request after applying authorization. It will poll if the client
-// allows polling and the http.Response status code requires it. It will close the http.Response
-// Body if the request returns an error.
-func (c Client) Send(req *http.Request) (*http.Response, error) {
-	resp, err := SendWithSender(c, req)
-	if err == nil {
-		err = c.IsPollingAllowed(resp)
-		if err == nil {
-			resp, err = c.PollAsNeeded(resp)
-		}
-	}
-
-	if err != nil {
-		Respond(resp,
-			ByClosing())
-	}
-
-	return resp, err
-}
-
-// Do implements the Sender interface by invoking the active Sender. If Sender is not set, it uses
-// a new instance of http.Client. In both cases it will, if UserAgent is set, apply set the
-// User-Agent header.
+// Do implements the Sender interface by invoking the active Sender after applying authorization.
+// If Sender is not set, it uses a new instance of http.Client. In both cases it will, if UserAgent
+// is set, apply set the User-Agent header.
 func (c Client) Do(r *http.Request) (*http.Response, error) {
-	if len(c.UserAgent) > 0 {
-		r, _ = Prepare(r, WithUserAgent(c.UserAgent))
+	if r.UserAgent() == "" {
+		r, _ = Prepare(r,
+			WithUserAgent(c.UserAgent))
 	}
 	r, err := Prepare(r,
 		c.WithInspection(),
@@ -221,7 +130,12 @@ func (c Client) Do(r *http.Request) (*http.Response, error) {
 	if err != nil {
 		return nil, NewErrorWithError(err, "autorest/Client", "Do", nil, "Preparing request failed")
 	}
-	return c.sender().Do(r)
+
+	resp, err := c.sender().Do(r)
+	Respond(resp,
+		c.ByInspecting())
+
+	return resp, err
 }
 
 // sender returns the Sender to which to send requests.
@@ -262,21 +176,4 @@ func (c Client) ByInspecting() RespondDecorator {
 		return ByIgnoring()
 	}
 	return c.ResponseInspector
-}
-
-// Response serves as the base for all responses from generated clients. It provides access to the
-// last http.Response.
-type Response struct {
-	*http.Response `json:"-"`
-}
-
-// GetPollingDelay extracts the polling delay from the Retry-After header of the response. If
-// the header is absent or is malformed, it will return the supplied default delay time.Duration.
-func (r Response) GetPollingDelay(defaultDelay time.Duration) time.Duration {
-	return GetPollingDelay(r.Response, defaultDelay)
-}
-
-// GetPollingLocation retrieves the polling URL from the Location header of the response.
-func (r Response) GetPollingLocation() string {
-	return GetPollingLocation(r.Response)
 }

--- a/autorest/client_test.go
+++ b/autorest/client_test.go
@@ -116,318 +116,11 @@ func TestNewClientWithUserAgent(t *testing.T) {
 	}
 }
 
-func TestNewClientWithUserAgentDoesNotModifyDefaultClient(t *testing.T) {
-	ua := randomString(32)
-	c := NewClientWithUserAgent(ua)
-
-	if c.UserAgent == DefaultClient.UserAgent {
-		t.Errorf("autorest: NewClientWithUserAgent pollutes the DefaultClient")
-	}
-}
-
-func TestClientIsPollingAllowed(t *testing.T) {
-	c := Client{PollingMode: PollUntilAttempts}
-	r := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
-
-	err := c.IsPollingAllowed(r)
-	if err != nil {
-		t.Errorf("autorest: Client#IsPollingAllowed returned an error for an http.Response that requires polling (%v)", err)
-	}
-}
-
-func TestClientIsPollingAllowedIgnoresOk(t *testing.T) {
-	c := Client{PollingMode: PollUntilAttempts}
-	r := mocks.NewResponse()
-
-	err := c.IsPollingAllowed(r)
-	if err != nil {
-		t.Error("autorest: Client#IsPollingAllowed returned an error for an http.Response that does not require polling")
-	}
-}
-
-func TestClientIsPollingAllowedIgnoresDisabledForIgnoredStatusCode(t *testing.T) {
-	c := Client{PollingMode: PollUntilAttempts}
-	r := mocks.NewResponseWithStatus("400 BadRequest", http.StatusBadRequest)
-
-	err := c.IsPollingAllowed(r)
-	if err != nil {
-		t.Errorf("autorest: Client#IsPollingAllowed returned an error for an http.Response that requires polling (%v)", err)
-	}
-}
-
-func TestClientIsPollingAllowedIgnoredPollingMode(t *testing.T) {
-	c := Client{PollingMode: DoNotPoll}
-	r := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
-
-	err := c.IsPollingAllowed(r)
-	if err == nil {
-		t.Error("autorest: Client#IsPollingAllowed failed to return an error when polling is disabled")
-	}
-}
-
-func TestClientPollAsNeededIgnoresOk(t *testing.T) {
-	c := Client{}
-	s := mocks.NewSender()
-	c.Sender = s
-	r := mocks.NewResponse()
-
-	resp, err := c.PollAsNeeded(r)
-	if err != nil {
-		t.Errorf("autorest: Client#PollAsNeeded failed when given a successful HTTP request (%v)", err)
-	}
-	if s.Attempts() > 0 {
-		t.Error("autorest: Client#PollAsNeeded attempted to poll a successful HTTP request")
-	}
-
-	Respond(resp,
-		ByClosing())
-}
-
-func TestClientPollAsNeededLeavesBodyOpen(t *testing.T) {
-	c := Client{}
-	c.Sender = mocks.NewSender()
-	r := mocks.NewResponse()
-
-	resp, err := c.PollAsNeeded(r)
-	if err != nil {
-		t.Errorf("autorest: Client#PollAsNeeded failed when given a successful HTTP request (%v)", err)
-	}
-	if !resp.Body.(*mocks.Body).IsOpen() {
-		t.Error("autorest: Client#PollAsNeeded unexpectedly closed the response body")
-	}
-
-	Respond(resp,
-		ByClosing())
-}
-
-func TestClientPollAsNeededReturnsErrorWhenPollingDisabled(t *testing.T) {
-	c := Client{}
-	c.Sender = mocks.NewSender()
-	c.PollingMode = DoNotPoll
-
-	r := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
-	mocks.SetAcceptedHeaders(r)
-
-	_, err := c.PollAsNeeded(r)
-	if err == nil {
-		t.Error("autorest: Client#PollAsNeeded failed to return an error when polling was disabled but required")
-	}
-
-	Respond(r,
-		ByClosing())
-}
-
-func TestClientPollAsNeededAllowsInspectionOfRequest(t *testing.T) {
-	c := Client{}
-	c.Sender = mocks.NewSender()
-	c.PollingMode = PollUntilAttempts
-	c.PollingAttempts = 1
-
-	mi := &mockInspector{}
-	c.RequestInspector = mi.WithInspection()
-
-	r := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
-	mocks.SetAcceptedHeaders(r)
-
-	c.PollAsNeeded(r)
-	if !mi.wasInvoked {
-		t.Error("autorest: Client#PollAsNeeded failed to allow inspection of polling request")
-	}
-
-	Respond(r,
-		ByClosing())
-}
-
-func TestClientPollAsNeededReturnsErrorIfUnableToCreateRequest(t *testing.T) {
-	c := Client{}
-	c.Authorizer = mockFailingAuthorizer{}
-	c.Sender = mocks.NewSender()
-	c.PollingMode = PollUntilAttempts
-	c.PollingAttempts = 1
-
-	r := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
-	mocks.SetAcceptedHeaders(r)
-	mocks.SetLocationHeader(r, "                                 ")
-
-	_, err := c.PollAsNeeded(r)
-	if err == nil {
-		t.Error("autorest: Client#PollAsNeeded failed to return error when unable to create request")
-	}
-
-	Respond(r,
-		ByClosing())
-}
-
-func TestClientPollAsNeededPollsForAttempts(t *testing.T) {
-	c := Client{}
-	c.PollingMode = PollUntilAttempts
-	c.PollingAttempts = 5
-
-	s := mocks.NewSender()
-	s.EmitStatus("202 Accepted", http.StatusAccepted)
-	c.Sender = s
-
-	r := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
-	mocks.SetAcceptedHeaders(r)
-	s.SetResponse(r)
-
-	resp, _ := c.PollAsNeeded(r)
-	if s.Attempts() != 5 {
-		t.Errorf("autorest: Client#PollAsNeeded did not poll the expected number of attempts -- expected %v, actual %v",
-			c.PollingAttempts, s.Attempts())
-	}
-
-	Respond(resp,
-		ByClosing())
-}
-
-func TestClientPollAsNeededPollsForDuration(t *testing.T) {
-	c := Client{}
-	c.PollingMode = PollUntilDuration
-	c.PollingDuration = 10 * time.Millisecond
-
-	s := mocks.NewSender()
-	s.EmitStatus("202 Accepted", http.StatusAccepted)
-	c.Sender = s
-
-	r := mocks.NewResponseWithStatus("202 Accepted", http.StatusAccepted)
-	mocks.SetAcceptedHeaders(r)
-	s.SetResponse(r)
-
-	d1 := 10 * time.Millisecond
-	start := time.Now()
-	resp, _ := c.PollAsNeeded(r)
-	d2 := time.Now().Sub(start)
-	if d2 < d1 {
-		t.Errorf("autorest: Client#PollAsNeeded did not poll for the expected duration -- expected %v, actual %v",
-			d1.Seconds(), d2.Seconds())
-	}
-
-	Respond(resp,
-		ByClosing())
-}
-
-func TestClientDoNotPoll(t *testing.T) {
-	c := Client{}
-
-	if !c.DoNotPoll() {
-		t.Errorf("autorest: Client requested polling by default, expected no polling (%v)", c.PollingMode)
-	}
-}
-
-func TestClientDoNotPollForAttempts(t *testing.T) {
-	c := Client{}
-	c.PollingMode = PollUntilAttempts
-
-	if c.DoNotPoll() {
-		t.Errorf("autorest: Client failed to request polling after polling mode set to %s", c.PollingMode)
-	}
-}
-
-func TestClientDoNotPollForDuration(t *testing.T) {
-	c := Client{}
-	c.PollingMode = PollUntilDuration
-
-	if c.DoNotPoll() {
-		t.Errorf("autorest: Client failed to request polling after polling mode set to %s", c.PollingMode)
-	}
-}
-
-func TestClientPollForAttempts(t *testing.T) {
-	c := Client{}
-	c.PollingMode = PollUntilAttempts
-
-	if !c.PollForAttempts() {
-		t.Errorf("autorest: Client#SetPollingMode failed to set polling by attempts -- polling mode set to %s", c.PollingMode)
-	}
-}
-
-func TestClientPollForDuration(t *testing.T) {
-	c := Client{}
-	c.PollingMode = PollUntilDuration
-
-	if !c.PollForDuration() {
-		t.Errorf("autorest: Client#SetPollingMode failed to set polling for duration -- polling mode set to %s", c.PollingMode)
-	}
-}
-
 func TestClientSenderReturnsHttpClientByDefault(t *testing.T) {
 	c := Client{}
 
 	if fmt.Sprintf("%T", c.sender()) != "*http.Client" {
 		t.Error("autorest: Client#sender failed to return http.Client by default")
-	}
-}
-
-func TestClientSendReturnsPrepareError(t *testing.T) {
-	r := mocks.NewRequest()
-	s := mocks.NewSender()
-	c := Client{Authorizer: mockFailingAuthorizer{}, Sender: s}
-
-	_, err := c.Send(r)
-	if err == nil {
-		t.Error("autorest: Client#Send failed to return an error the Prepare error")
-	}
-}
-
-func TestClientSendSends(t *testing.T) {
-	r := mocks.NewRequest()
-	s := mocks.NewSender()
-	c := Client{Sender: s}
-
-	c.Send(r)
-	if s.Attempts() <= 0 {
-		t.Error("autorest: Client#Send failed to invoke the Sender")
-	}
-}
-
-func TestClientSendDefaultsToUsingStatusCodeOK(t *testing.T) {
-	r := mocks.NewRequest()
-	s := mocks.NewSender()
-	c := Client{Authorizer: mockAuthorizer{}, Sender: s}
-
-	_, err := c.Send(r)
-	if err != nil {
-		t.Errorf("autorest: Client#Send returned an error for Status Code OK -- %v",
-			err)
-	}
-}
-
-func TestClientSendClosesReponseBodyWhenReturningError(t *testing.T) {
-	s := mocks.NewSender()
-	s.EmitErrors(1)
-	r := mocks.NewResponse()
-	s.SetResponse(r)
-	c := Client{Sender: s}
-
-	c.Send(mocks.NewRequest())
-	if r.Body.(*mocks.Body).IsOpen() {
-		t.Error("autorest: Client#Send failed to close the response body when returning an error")
-	}
-}
-
-func TestClientSendPollsIfNeeded(t *testing.T) {
-	r := mocks.NewRequest()
-	s := mocks.NewSender()
-	s.SetPollAttempts(5)
-	c := Client{Sender: s, PollingMode: PollUntilAttempts, PollingAttempts: 10}
-
-	c.Send(r)
-	if s.Attempts() != (5 + 1) {
-		t.Errorf("autorest: Client#Send failed to poll the expected number of times -- attempts %d",
-			s.Attempts())
-	}
-}
-
-func TestClientSendDoesNotPollIfUnnecessary(t *testing.T) {
-	r := mocks.NewRequest()
-	s := mocks.NewSender()
-	c := Client{Sender: s, PollingMode: PollUntilAttempts, PollingAttempts: 10}
-
-	c.Send(r)
-	if s.Attempts() != 1 {
-		t.Errorf("autorest: Client#Send unexpectedly polled -- attempts %d",
-			s.Attempts())
 	}
 }
 
@@ -455,15 +148,15 @@ func TestClientDoInvokesSender(t *testing.T) {
 }
 
 func TestClientDoSetsUserAgent(t *testing.T) {
-	c := Client{UserAgent: "UserAgent"}
+	ua := "UserAgent"
+	c := Client{UserAgent: ua}
 	r := mocks.NewRequest()
 
 	c.Do(r)
 
-	if r.Header.Get(http.CanonicalHeaderKey(headerUserAgent)) != "UserAgent" {
+	if r.UserAgent() != ua {
 		t.Errorf("autorest: Client#Do failed to correctly set User-Agent header: %s=%s",
-			http.CanonicalHeaderKey(headerUserAgent),
-			r.Header.Get(http.CanonicalHeaderKey(headerUserAgent)))
+			http.CanonicalHeaderKey(headerUserAgent), r.UserAgent())
 	}
 }
 
@@ -480,7 +173,7 @@ func TestClientDoSetsAuthorization(t *testing.T) {
 	}
 }
 
-func TestClientDoInvokesInspector(t *testing.T) {
+func TestClientDoInvokesRequestInspector(t *testing.T) {
 	r := mocks.NewRequest()
 	s := mocks.NewSender()
 	i := &mockInspector{}
@@ -489,6 +182,42 @@ func TestClientDoInvokesInspector(t *testing.T) {
 	c.Do(r)
 	if !i.wasInvoked {
 		t.Error("autorest: Client#Send failed to invoke the RequestInspector")
+	}
+}
+
+func TestClientDoInvokesResponseInspector(t *testing.T) {
+	r := mocks.NewRequest()
+	s := mocks.NewSender()
+	i := &mockInspector{}
+	c := Client{ResponseInspector: i.ByInspecting(), Sender: s}
+
+	c.Do(r)
+	if !i.wasInvoked {
+		t.Error("autorest: Client#Send failed to invoke the ResponseInspector")
+	}
+}
+
+func TestClientDoReturnsErrorIfPrepareFails(t *testing.T) {
+	c := Client{}
+	s := mocks.NewSender()
+	c.Authorizer = mockFailingAuthorizer{}
+	c.Sender = s
+
+	_, err := c.Do(&http.Request{})
+	if err == nil {
+		t.Errorf("autorest: Client#Do failed to return an error when Prepare failed")
+	}
+}
+
+func TestClientDoDoesNotSendIfPrepareFails(t *testing.T) {
+	c := Client{}
+	s := mocks.NewSender()
+	c.Authorizer = mockFailingAuthorizer{}
+	c.Sender = s
+
+	c.Do(&http.Request{})
+	if s.Attempts() > 0 {
+		t.Error("autorest: Client#Do failed to invoke the Sender")
 	}
 }
 
@@ -568,42 +297,6 @@ func TestClientByInspectingSetsDefault(t *testing.T) {
 
 	if !reflect.DeepEqual(r, &http.Response{}) {
 		t.Error("autorest: Client#ByInspecting failed to provide a default ResponseInspector")
-	}
-}
-
-func TestResponseGetPollingDelay(t *testing.T) {
-	d1 := 10 * time.Second
-
-	r := mocks.NewResponse()
-	mocks.SetRetryHeader(r, d1)
-	ar := Response{Response: r}
-
-	d2 := ar.GetPollingDelay(time.Duration(0))
-	if d1 != d2 {
-		t.Errorf("autorest: Response#GetPollingDelay failed to return the correct delay -- expected %v, received %v",
-			d1, d2)
-	}
-}
-
-func TestResponseGetPollingDelayReturnsDefault(t *testing.T) {
-	ar := Response{Response: mocks.NewResponse()}
-
-	d1 := 10 * time.Second
-	d2 := ar.GetPollingDelay(d1)
-	if d1 != d2 {
-		t.Errorf("autorest: Response#GetPollingDelay failed to return the default delay -- expected %v, received %v",
-			d1, d2)
-	}
-}
-
-func TestResponseGetPollingLocation(t *testing.T) {
-	r := mocks.NewResponse()
-	mocks.SetLocationHeader(r, mocks.TestURL)
-	ar := Response{Response: r}
-
-	if ar.GetPollingLocation() != mocks.TestURL {
-		t.Errorf("autorest: Response#GetPollingLocation failed to return correct URL -- expected %v, received %v",
-			mocks.TestURL, ar.GetPollingLocation())
 	}
 }
 

--- a/autorest/preparer.go
+++ b/autorest/preparer.go
@@ -195,6 +195,51 @@ func WithFormData(v url.Values) PrepareDecorator {
 	}
 }
 
+// WithBool returns a PrepareDecorator that encodes the passed bool into the body of the request
+// and sets the Content-Length header.
+func WithBool(v bool) PrepareDecorator {
+	return WithString(fmt.Sprintf("%v", v))
+}
+
+// WithFloat32 returns a PrepareDecorator that encodes the passed float32 into the body of the
+// request and sets the Content-Length header.
+func WithFloat32(v float32) PrepareDecorator {
+	return WithString(fmt.Sprintf("%v", v))
+}
+
+// WithFloat64 returns a PrepareDecorator that encodes the passed float64 into the body of the
+// request and sets the Content-Length header.
+func WithFloat64(v float64) PrepareDecorator {
+	return WithString(fmt.Sprintf("%v", v))
+}
+
+// WithInt32 returns a PrepareDecorator that encodes the passed int32 into the body of the request
+// and sets the Content-Length header.
+func WithInt32(v int32) PrepareDecorator {
+	return WithString(fmt.Sprintf("%v", v))
+}
+
+// WithInt64 returns a PrepareDecorator that encodes the passed int64 into the body of the request
+// and sets the Content-Length header.
+func WithInt64(v int64) PrepareDecorator {
+	return WithString(fmt.Sprintf("%v", v))
+}
+
+// WithString returns a PrepareDecorator that encodes the passed string into the body of the request
+// and sets the Content-Length header.
+func WithString(v string) PrepareDecorator {
+	return func(p Preparer) Preparer {
+		return PreparerFunc(func(r *http.Request) (*http.Request, error) {
+			r, err := p.Prepare(r)
+			if err == nil {
+				r.ContentLength = int64(len(v))
+				r.Body = ioutil.NopCloser(strings.NewReader(v))
+			}
+			return r, err
+		})
+	}
+}
+
 // WithJSON returns a PrepareDecorator that encodes the data passed as JSON into the body of the
 // request and sets the Content-Length header.
 func WithJSON(v interface{}) PrepareDecorator {

--- a/autorest/preparer_test.go
+++ b/autorest/preparer_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
+	"strconv"
 	"testing"
 
 	"github.com/Azure/go-autorest/autorest/mocks"
@@ -324,11 +325,12 @@ func TestWithBearerAuthorization(t *testing.T) {
 }
 
 func TestWithUserAgent(t *testing.T) {
-	r, err := Prepare(mocks.NewRequest(), WithUserAgent("User Agent Go"))
+	ua := "User Agent Go"
+	r, err := Prepare(mocks.NewRequest(), WithUserAgent(ua))
 	if err != nil {
 		fmt.Printf("ERROR: %v", err)
 	}
-	if r.Header.Get(headerUserAgent) != "User Agent Go" {
+	if r.UserAgent() != ua || r.Header.Get(headerUserAgent) != ua {
 		t.Errorf("autorest: WithUserAgent failed to add header (%s=%s)", headerUserAgent, r.Header.Get(headerUserAgent))
 	}
 }
@@ -414,6 +416,137 @@ func TestWithFormDataSetsContentLength(t *testing.T) {
 
 	if r.ContentLength != int64(len(b)) {
 		t.Errorf("autorest:WithFormData set Content-Length to %v, expected %v", r.ContentLength, len(b))
+	}
+}
+
+func TestWithBool_SetsTheBody(t *testing.T) {
+	r, err := Prepare(&http.Request{},
+		WithBool(false))
+	if err != nil {
+		t.Errorf("autorest: WithBool failed with error (%v)", err)
+	}
+
+	s, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		t.Errorf("autorest: WithBool failed with error (%v)", err)
+	}
+
+	if r.ContentLength != int64(len(fmt.Sprintf("%v", false))) {
+		t.Errorf("autorest: WithBool set Content-Length to %v, expected %v", r.ContentLength, int64(len(fmt.Sprintf("%v", false))))
+	}
+
+	v, err := strconv.ParseBool(string(s))
+	if err != nil || v {
+		t.Errorf("autorest: WithBool incorrectly encoded the boolean as %v", s)
+	}
+}
+
+func TestWithFloat32_SetsTheBody(t *testing.T) {
+	r, err := Prepare(&http.Request{},
+		WithFloat32(42.0))
+	if err != nil {
+		t.Errorf("autorest: WithFloat32 failed with error (%v)", err)
+	}
+
+	s, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		t.Errorf("autorest: WithFloat32 failed with error (%v)", err)
+	}
+
+	if r.ContentLength != int64(len(fmt.Sprintf("%v", 42.0))) {
+		t.Errorf("autorest: WithFloat32 set Content-Length to %v, expected %v", r.ContentLength, int64(len(fmt.Sprintf("%v", 42.0))))
+	}
+
+	v, err := strconv.ParseFloat(string(s), 32)
+	if err != nil || float32(v) != float32(42.0) {
+		t.Errorf("autorest: WithFloat32 incorrectly encoded the boolean as %v", s)
+	}
+}
+
+func TestWithFloat64_SetsTheBody(t *testing.T) {
+	r, err := Prepare(&http.Request{},
+		WithFloat64(42.0))
+	if err != nil {
+		t.Errorf("autorest: WithFloat64 failed with error (%v)", err)
+	}
+
+	s, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		t.Errorf("autorest: WithFloat64 failed with error (%v)", err)
+	}
+
+	if r.ContentLength != int64(len(fmt.Sprintf("%v", 42.0))) {
+		t.Errorf("autorest: WithFloat64 set Content-Length to %v, expected %v", r.ContentLength, int64(len(fmt.Sprintf("%v", 42.0))))
+	}
+
+	v, err := strconv.ParseFloat(string(s), 64)
+	if err != nil || v != float64(42.0) {
+		t.Errorf("autorest: WithFloat64 incorrectly encoded the boolean as %v", s)
+	}
+}
+
+func TestWithInt32_SetsTheBody(t *testing.T) {
+	r, err := Prepare(&http.Request{},
+		WithInt32(42))
+	if err != nil {
+		t.Errorf("autorest: WithInt32 failed with error (%v)", err)
+	}
+
+	s, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		t.Errorf("autorest: WithInt32 failed with error (%v)", err)
+	}
+
+	if r.ContentLength != int64(len(fmt.Sprintf("%v", 42))) {
+		t.Errorf("autorest: WithInt32 set Content-Length to %v, expected %v", r.ContentLength, int64(len(fmt.Sprintf("%v", 42))))
+	}
+
+	v, err := strconv.ParseInt(string(s), 10, 32)
+	if err != nil || int32(v) != int32(42) {
+		t.Errorf("autorest: WithInt32 incorrectly encoded the boolean as %v", s)
+	}
+}
+
+func TestWithInt64_SetsTheBody(t *testing.T) {
+	r, err := Prepare(&http.Request{},
+		WithInt64(42))
+	if err != nil {
+		t.Errorf("autorest: WithInt64 failed with error (%v)", err)
+	}
+
+	s, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		t.Errorf("autorest: WithInt64 failed with error (%v)", err)
+	}
+
+	if r.ContentLength != int64(len(fmt.Sprintf("%v", 42))) {
+		t.Errorf("autorest: WithInt64 set Content-Length to %v, expected %v", r.ContentLength, int64(len(fmt.Sprintf("%v", 42))))
+	}
+
+	v, err := strconv.ParseInt(string(s), 10, 64)
+	if err != nil || v != int64(42) {
+		t.Errorf("autorest: WithInt64 incorrectly encoded the boolean as %v", s)
+	}
+}
+
+func TestWithString_SetsTheBody(t *testing.T) {
+	r, err := Prepare(&http.Request{},
+		WithString("value"))
+	if err != nil {
+		t.Errorf("autorest: WithString failed with error (%v)", err)
+	}
+
+	s, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		t.Errorf("autorest: WithString failed with error (%v)", err)
+	}
+
+	if r.ContentLength != int64(len("value")) {
+		t.Errorf("autorest: WithString set Content-Length to %v, expected %v", r.ContentLength, int64(len("value")))
+	}
+
+	if string(s) != "value" {
+		t.Errorf("autorest: WithString incorrectly encoded the string as %v", s)
 	}
 }
 

--- a/autorest/utility_test.go
+++ b/autorest/utility_test.go
@@ -100,6 +100,20 @@ func TestContainsIntDoesNotFindValue(t *testing.T) {
 	}
 }
 
+func TestContainsIntAcceptsEmptyList(t *testing.T) {
+	ints := make([]int, 10)
+	if containsInt(ints, 42) {
+		t.Errorf("autorest: containsInt failed to handle an empty list")
+	}
+}
+
+func TestContainsIntAcceptsNilList(t *testing.T) {
+	var ints []int
+	if containsInt(ints, 42) {
+		t.Errorf("autorest: containsInt failed to handle an nil list")
+	}
+}
+
 func TestEscapeStrings(t *testing.T) {
 	m := map[string]string{
 		"string": "a long string with = odd characters",

--- a/autorest/version.go
+++ b/autorest/version.go
@@ -5,7 +5,7 @@ import (
 )
 
 const (
-	major        = "5"
+	major        = "6"
 	minor        = "0"
 	patch        = "0"
 	tag          = ""

--- a/autorest/version_test.go
+++ b/autorest/version_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestVersion(t *testing.T) {
-	v := "5.0.0"
+	v := "6.0.0"
 	if Version() != v {
 		t.Errorf("autorest: Version failed to return the expected version -- expected %s, received %s",
 			v, Version())


### PR DESCRIPTION
This PR *significantly* changes how `go-autorest` handles polling. By using `SendDecorators` it can now address specific cases (such as handling Azure long-running operations).

Signed-off-by: Brendan Dixon <brendand@microsoft.com>