### PR TITLE
Close temp file on token persist

### DIFF
--- a/autorest/azure/persist.go
+++ b/autorest/azure/persist.go
@@ -43,6 +43,9 @@ func SaveToken(path string, mode os.FileMode, token Token) error {
 	if json.NewEncoder(newFile).Encode(token); err != nil {
 		return fmt.Errorf("failed to encode token to file (%s) while saving token: %v", tempPath, err)
 	}
+	if err := newFile.Close(); err != nil {
+		return fmt.Errorf("failed to close temp file %s: %v", tempPath, err)
+	}
 
 	// Atomic replace to avoid multi-writer file corruptions
 	if err := os.Rename(tempPath, path); err != nil {


### PR DESCRIPTION
Fixes the

    "The process cannot access the file because it is being used by another process." 

issue on windows.

![image](https://cloud.githubusercontent.com/assets/159209/13409303/35aee5b0-dee7-11e5-9c30-25d0967334f9.png)

@colemickens 

