### PR TITLE
Correct handling of malformed JSON and polling for Azure asynchronous operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # CHANGELOG
 
+## v7.0.0
+- Reverted to only unmarshalling JSON, corrected handling of RFC3339 time strings
+- Added ByCopying responder with supporting TeeReadCloser
+- Rewrote Azure asynchronous handling
+
+The `json.Decoder` does not catch bad data as thoroughly as `json.Unmarshal`. Since
+`encoding/json` successfully deserializes all core types, and extended types normally provide
+their custom JSON serialization handlers, the code has been reverted back to using
+`json.Unmarshal`. The original change to use `json.Decode` was made to reduce duplicate
+code; there is no loss of function, and there is a gain in accuracy, by reverting.
+
+Additionally, Azure services indicate requests to be polled by multiple means. The existing code
+only checked for one of those (that is, the presence of the `Azure-AsyncOperation` header).
+The new code correctly covers all cases and aligns with the other Azure SDKs.
+
 ## v6.1.0
 - Introduced `date.ByUnmarshallingJSONDate` and `date.ByUnmarshallingJSONTime` to enable JSON encoded values.
 

--- a/autorest/azure/async.go
+++ b/autorest/azure/async.go
@@ -1,8 +1,11 @@
 package azure
 
 import (
+	"bytes"
 	"fmt"
+	"io/ioutil"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/Azure/go-autorest/autorest"
@@ -10,150 +13,242 @@ import (
 )
 
 const (
-	// HeaderAsyncOperation is the Azure header providing the URL from which to obtain the
-	// OperationResource for an asynchronous (aka long running) operation.
-	HeaderAsyncOperation = "Azure-AsyncOperation"
+	headerAsyncOperation = "Azure-AsyncOperation"
 )
 
 const (
-	// OperationCanceled says the underlying operation was canceled.
-	OperationCanceled string = "Canceled"
-	// OperationFailed says the underlying operation failed.
-	OperationFailed string = "Failed"
-	// OperationSucceeded says the underlying opertion succeeded.
-	OperationSucceeded string = "Succeeded"
+	methodDelete = "DELETE"
+	methodPatch  = "PATCH"
+	methodPost   = "POST"
+	methodPut    = "PUT"
+
+	operationInProgress string = "InProgress"
+	operationCanceled   string = "Canceled"
+	operationFailed     string = "Failed"
+	operationSucceeded  string = "Succeeded"
 )
 
-// OperationError provides additional detail when an operation fails or is canceled.
-type OperationError struct {
-	// Code provides an invariant error code useful for troubleshooting, aggregration, and analysis.
-	Code string `json:"code"`
-	// Message indicates what error occurred and what can be done to address the issue.
-	Message string `json:"message"`
+// DoPollForAsynchronous returns a SendDecorator that polls if the http.Response is for an Azure
+// long-running operation. It will delay between requests for the duration specified in the
+// RetryAfter header or, if the header is absent, the passed delay. Polling may be canceled by
+// closing the optional channel on the http.Request.
+func DoPollForAsynchronous(delay time.Duration) autorest.SendDecorator {
+	return func(s autorest.Sender) autorest.Sender {
+		return autorest.SenderFunc(func(r *http.Request) (resp *http.Response, err error) {
+			resp, err = s.Do(r)
+			if err != nil {
+				return resp, err
+			}
+
+			// Note:
+			// 	newPollingState maps the operation status -- retrieved from either a provisioningState
+			// 	field, the status field of an OperationResource, or inferred from the HTTP status code --
+			// 	into a well-known states. Since the process begins from the initial request, the state
+			//	always comes from either a the provisioningState returned or is inferred from the HTTP
+			//	status code. Subsequent requests will return an Azure OperationResource object if the
+			//	service returns the Azure-AsyncOperation header. The boolean, isAzureAsyncOperation,
+			//	conveys to newPollingState if it should expect a provisioningState field or an
+			//	OperationResource object.
+			//
+
+			// Ensure a cancel channel exists since the loop requires it and it is optional.
+			if resp.Request.Cancel == nil {
+				resp.Request.Cancel = make(chan struct{})
+			}
+
+			isAzureAsyncOperation := false
+			ps := pollingState{state: operationFailed}
+			for err == nil {
+				ps, err = newPollingState(resp, isAzureAsyncOperation)
+				if err != nil {
+					break
+				}
+				if ps.hasTerminated() {
+					if !ps.hasSucceeded() {
+						err = autorest.NewError("azure", "DoPollForAsynchronous", "Polling terminated with status '%s'", ps.state)
+					}
+					break
+				}
+
+				r, err = newPollingRequest(resp, &isAzureAsyncOperation)
+				if err != nil {
+					return resp, err
+				}
+
+				resp, err = autorest.SendWithSender(s, r,
+					autorest.AfterDelay(autorest.GetRetryAfter(resp, delay)))
+			}
+
+			return resp, err
+		})
+	}
 }
 
-// Error implements the error interface returnin a string containing the code and message.
-func (oe OperationError) Error() string {
-	return fmt.Sprintf("Azure Operation Error: Code=%q Message=%q", oe.Code, oe.Message)
+func getAsyncOperation(resp *http.Response) string {
+	return resp.Header.Get(http.CanonicalHeaderKey(headerAsyncOperation))
 }
 
-// OperationResource defines a resource describing the state of a long-running operation.
-type OperationResource struct {
-	// Id is the identifier used in a GET for the underlying resource.
-	ID string `json:"id"`
-	// Name matches the last segment of the Id field (typically system generated).
-	Name string `json:"name"`
-	// Status provides the state of the operation. Non-terminal states vary by resource;
-	Status string `json:"status"`
-	// Properties, on operation success, optionally contains per-service / per-resource values.
-	Properties map[string]interface{} `json:"properties"`
-	// Error provides additional detail if the operation is canceled or failed.
-	OperationError OperationError `json:"error"`
-	// StartTime optionally provides the time the operation started.
-	StartTime date.Time `json:"startTime"`
-	// EndTime optionally provides the time the operation completed.
-	EndTime date.Time `json:"endTime"`
-	// PercentComplete optionally provides the percent complete between 0 and 100.
-	PercentComplete float64 `json:"percentComplete"`
+func hasSucceeded(state string) bool {
+	return state == operationSucceeded
 }
 
-// HasSucceeded returns true if the operation has succeeded; false otherwise.
-func (or OperationResource) HasSucceeded() bool {
-	return or.Status == OperationSucceeded
-}
-
-// HasTerminated returns true if the operation has terminated; false otherwise.
-func (or OperationResource) HasTerminated() bool {
-	switch or.Status {
-	case OperationCanceled, OperationFailed, OperationSucceeded:
+func hasTerminated(state string) bool {
+	switch state {
+	case operationCanceled, operationFailed, operationSucceeded:
 		return true
 	default:
 		return false
 	}
 }
 
-// GetError returns an error if the operation was canceled or failed and nil otherwise.
-func (or OperationResource) GetError() error {
-	switch or.Status {
-	case OperationCanceled, OperationFailed:
-		return or.OperationError
-	default:
-		return nil
+type provisioningTracker interface {
+	state() string
+	hasSucceeded() bool
+	hasTerminated() bool
+}
+
+type operationError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+func (oe operationError) Error() string {
+	return fmt.Sprintf("Azure Operation Error: Code=%q Message=%q", oe.Code, oe.Message)
+}
+
+type operationResource struct {
+	ID              string                 `json:"id"`
+	Name            string                 `json:"name"`
+	Status          string                 `json:"status"`
+	Properties      map[string]interface{} `json:"properties"`
+	OperationError  operationError         `json:"error"`
+	StartTime       date.Time              `json:"startTime"`
+	EndTime         date.Time              `json:"endTime"`
+	PercentComplete float64                `json:"percentComplete"`
+}
+
+func (or operationResource) state() string {
+	return or.Status
+}
+
+func (or operationResource) hasSucceeded() bool {
+	return hasSucceeded(or.state())
+}
+
+func (or operationResource) hasTerminated() bool {
+	return hasTerminated(or.state())
+}
+
+type provisioningProperties struct {
+	ProvisioningState string `json:"provisioningState"`
+}
+
+type provisioningStatus struct {
+	Properties provisioningProperties `json:"properties"`
+}
+
+func (ps provisioningStatus) state() string {
+	return ps.Properties.ProvisioningState
+}
+
+func (ps provisioningStatus) hasSucceeded() bool {
+	return hasSucceeded(ps.state())
+}
+
+func (ps provisioningStatus) hasTerminated() bool {
+	return hasTerminated(ps.state())
+}
+
+type pollingState struct {
+	state   string
+	code    string
+	message string
+}
+
+func (ps pollingState) hasSucceeded() bool {
+	return hasSucceeded(ps.state)
+}
+
+func (ps pollingState) hasTerminated() bool {
+	return hasTerminated(ps.state)
+}
+
+func newPollingState(resp *http.Response, isAzureAsyncOperation bool) (pollingState, error) {
+	pollState := pollingState{state: operationFailed}
+
+	var pt provisioningTracker
+	if isAzureAsyncOperation {
+		pt = &operationResource{}
+	} else {
+		pt = &provisioningStatus{}
 	}
-}
 
-// GetAsyncOperation retrieves the long-running URL from which to retrieve the OperationResource.
-func GetAsyncOperation(resp *http.Response) string {
-	return resp.Header.Get(http.CanonicalHeaderKey(HeaderAsyncOperation))
-}
-
-// IsAsynchronousResponse returns true if the passed response indicates that the request will
-// complete asynchronously. Such responses have either an http.StatusCreated or an
-// http.StatusAccepted status code and provide the Azure-AsyncOperation header.
-func IsAsynchronousResponse(resp *http.Response) bool {
-	return autorest.ResponseHasStatusCode(resp, http.StatusCreated, http.StatusAccepted) &&
-		GetAsyncOperation(resp) != ""
-}
-
-// NewOperationResourceRequest allocates and returns a new http.Request to retrieve the
-// OperationResource for an asynchronous operation.
-func NewOperationResourceRequest(resp *http.Response, cancel <-chan struct{}) (*http.Request, error) {
-	location := GetAsyncOperation(resp)
-	if location == "" {
-		return nil, autorest.NewErrorWithResponse("azure", "NewOperationResourceRequest", resp, "Azure-AsyncOperation header missing from response that requires polling")
-	}
-
-	req, err := autorest.Prepare(&http.Request{Cancel: cancel},
-		autorest.AsGet(),
-		autorest.WithBaseURL(location))
+	b := &bytes.Buffer{}
+	err := autorest.Respond(resp,
+		autorest.ByCopying(b),
+		autorest.ByUnmarshallingJSON(pt),
+		autorest.ByClosing())
+	resp.Body = ioutil.NopCloser(b)
 	if err != nil {
-		return nil, autorest.NewErrorWithError(err, "azure", "NewOperationResourceRequest", nil, "Failure creating poll request to %s", location)
+		return pollState, err
 	}
 
-	return req, nil
+	// -- Terminal states apply regardless
+	// -- Unknown states are per-service inprogress states
+	// -- Otherwise, infer state from HTTP status code
+	if pt.hasTerminated() {
+		pollState.state = pt.state()
+	} else if pt.state() != "" {
+		pollState.state = operationInProgress
+	} else {
+		switch resp.StatusCode {
+		case http.StatusAccepted:
+			pollState.state = operationInProgress
+
+		case http.StatusNoContent, http.StatusCreated, http.StatusOK:
+			pollState.state = operationSucceeded
+
+		default:
+			pollState.state = operationFailed
+		}
+	}
+
+	return pollState, nil
 }
 
-// DoPollForAsynchronous returns a SendDecorator that polls if the http.Response is for an Azure
-// long-running operation. It will poll until the time passed is equal to or greater than
-// the supplied duration. It will delay between requests for the duration specified in the
-// RetryAfter header or, if the header is absent, the passed delay. Polling may be canceled by
-// closing the optional channel on the http.Request.
-func DoPollForAsynchronous(duration time.Duration, delay time.Duration) autorest.SendDecorator {
-	return func(s autorest.Sender) autorest.Sender {
-		return autorest.SenderFunc(func(r *http.Request) (resp *http.Response, err error) {
-			resp, err = s.Do(r)
-			if err != nil || !IsAsynchronousResponse(resp) {
-				return resp, err
-			}
-
-			r, err = NewOperationResourceRequest(resp, r.Cancel)
-			if err != nil {
-				return resp, autorest.NewErrorWithError(err, "azure", "DoPollForAsynchronous", resp, "Failure occurred creating OperationResource request")
-			}
-
-			or := &OperationResource{}
-			for err == nil && !or.HasTerminated() {
-				autorest.Respond(resp,
-					autorest.ByClosing())
-
-				resp, err = autorest.SendWithSender(s, r,
-					autorest.AfterDelay(autorest.GetRetryAfter(resp, delay)))
-				if err != nil {
-					return resp, autorest.NewErrorWithError(err, "azure", "DoPollForAsynchronous", resp, "Failure occurred retrieving OperationResource")
-				}
-
-				err = autorest.Respond(resp,
-					autorest.ByUnmarshallingJSON(or))
-				if err != nil {
-					return resp, autorest.NewErrorWithError(err, "azure", "DoPollForAsynchronous", resp, "Failure occurred unmarshalling an OperationResource")
-				}
-			}
-
-			if err == nil && or.HasTerminated() {
-				err = or.GetError()
-			}
-
-			return resp, err
-		})
+func newPollingRequest(resp *http.Response, isAzureAsyncOperation *bool) (*http.Request, error) {
+	req := resp.Request
+	if req == nil {
+		return nil, autorest.NewError("azure", "newPollingRequest", "Azure Polling Error - Original HTTP request is missing")
 	}
+
+	// Prefer the Azure-AsyncOperation header
+	uri := getAsyncOperation(resp)
+	*isAzureAsyncOperation = (uri != "")
+
+	// Else, use the Location header
+	if !*isAzureAsyncOperation {
+		uri = autorest.GetLocation(resp)
+	}
+
+	// Lastly, requests against an existing resource, use the last request URI
+	if uri == "" {
+		req.Method = strings.ToUpper(req.Method)
+		if req.Method == methodPatch || req.Method == methodPut {
+			uri = req.URL.String()
+		}
+	}
+
+	if uri == "" {
+		return nil, autorest.NewError("azure", "newPollingRequest", "Azure Polling Error - Unable to obtain polling URI for %s %s", req.Method, req.RequestURI)
+	}
+
+	reqPoll, err := autorest.Prepare(&http.Request{Cancel: req.Cancel},
+		autorest.AsGet(),
+		autorest.WithBaseURL(uri))
+	if err != nil {
+		return nil, autorest.NewErrorWithError(err, "azure", "newPollingRequest", nil, "Failure creating poll request to %s", uri)
+	}
+
+	return reqPoll, nil
 }

--- a/autorest/azure/azure_test.go
+++ b/autorest/azure/azure_test.go
@@ -238,11 +238,11 @@ func withAsyncResponseDecorator(n int) autorest.SendDecorator {
 				if i < n {
 					resp.StatusCode = http.StatusCreated
 					resp.Header = http.Header{}
-					resp.Header.Add(http.CanonicalHeaderKey(HeaderAsyncOperation), mocks.TestURL)
+					resp.Header.Add(http.CanonicalHeaderKey(headerAsyncOperation), mocks.TestURL)
 					i++
 				} else {
 					resp.StatusCode = http.StatusOK
-					resp.Header.Del(http.CanonicalHeaderKey(HeaderAsyncOperation))
+					resp.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
 				}
 			}
 			return resp, err

--- a/autorest/client.go
+++ b/autorest/client.go
@@ -103,6 +103,12 @@ type Client struct {
 	RequestInspector  PrepareDecorator
 	ResponseInspector RespondDecorator
 
+	// PollingDelay sets the polling frequency used in absence of a Retry-After HTTP header
+	PollingDelay time.Duration
+
+	// PollingDuration sets the maximum polling time after which an error is returned.
+	PollingDuration time.Duration
+
 	// UserAgent, if not empty, will be set as the HTTP User-Agent header on all requests sent
 	// through the Do method.
 	UserAgent string
@@ -111,7 +117,7 @@ type Client struct {
 // NewClientWithUserAgent returns an instance of a Client with the UserAgent set to the passed
 // string.
 func NewClientWithUserAgent(ua string) Client {
-	c := Client{}
+	c := Client{PollingDelay: DefaultPollingDelay, PollingDuration: DefaultPollingDuration}
 	c.UserAgent = ua
 	return c
 }

--- a/autorest/date/time.go
+++ b/autorest/date/time.go
@@ -4,6 +4,7 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -19,7 +20,8 @@ func ParseTime(date string) (d Time, err error) {
 }
 
 func parseTime(date string, format string) (Time, error) {
-	d, err := time.Parse(format, date)
+	// Note: Convert the date first to uppercase since RFC3339 allows lower-case "t" and "z".
+	d, err := time.Parse(format, strings.ToUpper(date))
 	return Time{Time: d}, err
 }
 

--- a/autorest/mocks/helpers.go
+++ b/autorest/mocks/helpers.go
@@ -21,6 +21,12 @@ const (
 
 	// TestURL is the URL used in tests.
 	TestURL = "https://microsoft.com/a/b/c/"
+
+	// TestAzureAsyncURL is a URL used in Azure asynchronous tests
+	TestAzureAsyncURL = "https://microsoft.com/a/b/c/async"
+
+	// TestLocationURL is a URL used in Azure asynchronous tests
+	TestLocationURL = "https://microsoft.com/a/b/c/location"
 )
 
 const (

--- a/autorest/mocks/mocks.go
+++ b/autorest/mocks/mocks.go
@@ -82,7 +82,9 @@ func (c *Sender) Do(r *http.Request) (resp *http.Response, err error) {
 	if len(c.responses) > 0 {
 		resp = c.responses[0]
 		if resp != nil {
-			resp.Body.(*Body).reset()
+			if b, ok := resp.Body.(*Body); ok {
+				b.reset()
+			}
 		}
 		c.repeatResponse[0]--
 		if c.repeatResponse[0] == 0 {
@@ -91,6 +93,9 @@ func (c *Sender) Do(r *http.Request) (resp *http.Response, err error) {
 		}
 	} else {
 		resp = NewResponse()
+	}
+	if resp != nil {
+		resp.Request = r
 	}
 
 	if c.emitErrorAfter > 0 {

--- a/autorest/responder.go
+++ b/autorest/responder.go
@@ -1,7 +1,11 @@
 package autorest
 
 import (
+	"bytes"
+	"encoding/json"
+	"encoding/xml"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 )
 
@@ -68,6 +72,20 @@ func ByIgnoring() RespondDecorator {
 	}
 }
 
+// ByCopying copies the contents of the http.Response Body into the passed bytes.Buffer as
+// the Body is read.
+func ByCopying(b *bytes.Buffer) RespondDecorator {
+	return func(r Responder) Responder {
+		return ResponderFunc(func(resp *http.Response) error {
+			err := r.Respond(resp)
+			if err == nil && resp != nil && resp.Body != nil {
+				resp.Body = TeeReadCloser(resp.Body, b)
+			}
+			return err
+		})
+	}
+}
+
 // ByClosing returns a RespondDecorator that first invokes the passed Responder after which it
 // closes the response body. Since the passed Responder is invoked prior to closing the response
 // body, the decorator may occur anywhere within the set.
@@ -97,116 +115,48 @@ func ByClosingIfError() RespondDecorator {
 	}
 }
 
-// ByUnmarshallingBool returns a RespondDecorator that decodes the http.Response Body into a bool
-// pointed to by b.
-func ByUnmarshallingBool(b *bool) RespondDecorator {
-	return func(r Responder) Responder {
-		return ResponderFunc(func(resp *http.Response) error {
-			err := r.Respond(resp)
-			if err == nil {
-				*b, err = readBool(resp.Body)
-			}
-			return err
-		})
-	}
-}
-
-// ByUnmarshallingFloat32 returns a RespondDecorator that decodes the http.Response Body into a
-// float32 pointed to by f.
-func ByUnmarshallingFloat32(f *float32) RespondDecorator {
-	return func(r Responder) Responder {
-		return ResponderFunc(func(resp *http.Response) error {
-			err := r.Respond(resp)
-			if err == nil {
-				*f, err = readFloat32(resp.Body)
-			}
-			return err
-		})
-	}
-}
-
-// ByUnmarshallingFloat64 returns a RespondDecorator that decodes the http.Response Body into a
-// float64 pointed to by f.
-func ByUnmarshallingFloat64(f *float64) RespondDecorator {
-	return func(r Responder) Responder {
-		return ResponderFunc(func(resp *http.Response) error {
-			err := r.Respond(resp)
-			if err == nil {
-				*f, err = readFloat64(resp.Body)
-			}
-			return err
-		})
-	}
-}
-
-// ByUnmarshallingInt32 returns a RespondDecorator that decodes the http.Response Body into an
-// int32 pointed to by i.
-func ByUnmarshallingInt32(i *int32) RespondDecorator {
-	return func(r Responder) Responder {
-		return ResponderFunc(func(resp *http.Response) error {
-			err := r.Respond(resp)
-			if err == nil {
-				*i, err = readInt32(resp.Body)
-			}
-			return err
-		})
-	}
-}
-
-// ByUnmarshallingInt64 returns a RespondDecorator that decodes the http.Response Body into an
-// int64 pointed to by i.
-func ByUnmarshallingInt64(i *int64) RespondDecorator {
-	return func(r Responder) Responder {
-		return ResponderFunc(func(resp *http.Response) error {
-			err := r.Respond(resp)
-			if err == nil {
-				*i, err = readInt64(resp.Body)
-			}
-			return err
-		})
-	}
-}
-
-// ByUnmarshallingString returns a RespondDecorator that decodes the http.Response Body into a
-// string pointed to by s.
-func ByUnmarshallingString(s *string) RespondDecorator {
-	return func(r Responder) Responder {
-		return ResponderFunc(func(resp *http.Response) error {
-			err := r.Respond(resp)
-			if err == nil {
-				*s, err = readString(resp.Body)
-			}
-			return err
-		})
-	}
-}
-
 // ByUnmarshallingJSON returns a RespondDecorator that decodes a JSON document returned in the
 // response Body into the value pointed to by v.
 func ByUnmarshallingJSON(v interface{}) RespondDecorator {
-	return byUnmarshallingAs(EncodedAsJSON, v)
-}
-
-// ByUnmarshallingXML returns a RespondDecorator that decodes a XML document returned in the
-// response Body into the value pointed to by v.
-func ByUnmarshallingXML(v interface{}) RespondDecorator {
-	return byUnmarshallingAs(EncodedAsXML, v)
-}
-
-func byUnmarshallingAs(encodedAs EncodedAs, v interface{}) RespondDecorator {
 	return func(r Responder) Responder {
 		return ResponderFunc(func(resp *http.Response) error {
 			err := r.Respond(resp)
 			if err == nil {
-				b, errDecode := CopyAndDecode(encodedAs, resp.Body, v)
-				if errDecode != nil {
-					err = fmt.Errorf("Error (%v) occurred decoding %s (\"%s\")", errDecode, encodedAs, b.String())
+				b, errInner := ioutil.ReadAll(resp.Body)
+				if errInner != nil {
+					err = fmt.Errorf("Error occurred reading http.Response#Body - Error = '%v'", errInner)
+				} else {
+					errInner = json.Unmarshal(b, v)
+					if errInner != nil {
+						err = fmt.Errorf("Error occurred unmarshalling JSON - Error = '%v' JSON = '%s'", errInner, string(b))
+					}
 				}
 			}
 			return err
 		})
 	}
+}
 
+// ByUnmarshallingXML returns a RespondDecorator that decodes a XML document returned in the
+// response Body into the value pointed to by v.
+func ByUnmarshallingXML(v interface{}) RespondDecorator {
+	return func(r Responder) Responder {
+		return ResponderFunc(func(resp *http.Response) error {
+			err := r.Respond(resp)
+			if err == nil {
+				b, errInner := ioutil.ReadAll(resp.Body)
+				if errInner != nil {
+					err = fmt.Errorf("Error occurred reading http.Response#Body - Error = '%v'", errInner)
+				} else {
+					errInner = xml.Unmarshal(b, v)
+					if errInner != nil {
+						err = fmt.Errorf("Error occurred unmarshalling Xml - Error = '%v' Xml = '%s'", errInner, string(b))
+					}
+				}
+			}
+			return err
+		})
+	}
 }
 
 // WithErrorUnlessStatusCode returns a RespondDecorator that emits an error unless the response

--- a/autorest/responder_test.go
+++ b/autorest/responder_test.go
@@ -1,10 +1,10 @@
 package autorest
 
 import (
+	"bytes"
 	"fmt"
 	"net/http"
 	"reflect"
-	"strconv"
 	"strings"
 	"testing"
 
@@ -131,6 +131,68 @@ func TestByIgnoring(t *testing.T) {
 		})(),
 		ByIgnoring(),
 		ByClosing())
+}
+
+func TestByCopying_Copies(t *testing.T) {
+	r := mocks.NewResponseWithContent(jsonT)
+	b := &bytes.Buffer{}
+
+	err := Respond(r,
+		ByCopying(b),
+		ByUnmarshallingJSON(&mocks.T{}),
+		ByClosing())
+	if err != nil {
+		t.Errorf("autorest: ByCopying returned an unexpected error -- %v", err)
+	}
+	if b.String() != jsonT {
+		t.Errorf("autorest: ByCopying failed to copy the bytes read")
+	}
+}
+
+func TestByCopying_ReturnsNestedErrors(t *testing.T) {
+	r := mocks.NewResponseWithContent(jsonT)
+
+	r.Body.Close()
+	err := Respond(r,
+		ByCopying(&bytes.Buffer{}),
+		ByUnmarshallingJSON(&mocks.T{}),
+		ByClosing())
+	if err == nil {
+		t.Errorf("autorest: ByCopying failed to return the expected error")
+	}
+}
+
+func TestByCopying_AcceptsNilReponse(t *testing.T) {
+	r := mocks.NewResponse()
+
+	Respond(r,
+		(func() RespondDecorator {
+			return func(r Responder) Responder {
+				return ResponderFunc(func(resp *http.Response) error {
+					resp.Body.Close()
+					r.Respond(nil)
+					return nil
+				})
+			}
+		})(),
+		ByCopying(&bytes.Buffer{}))
+}
+
+func TestByCopying_AcceptsNilBody(t *testing.T) {
+	r := mocks.NewResponse()
+
+	Respond(r,
+		(func() RespondDecorator {
+			return func(r Responder) Responder {
+				return ResponderFunc(func(resp *http.Response) error {
+					resp.Body.Close()
+					resp.Body = nil
+					r.Respond(resp)
+					return nil
+				})
+			}
+		})(),
+		ByCopying(&bytes.Buffer{}))
 }
 
 func TestByClosing(t *testing.T) {
@@ -265,164 +327,6 @@ func TestByClosingIfErrorDoesNotClosesIfNoErrorOccurs(t *testing.T) {
 	}
 }
 
-func Test_ByUnmarshallingBool(t *testing.T) {
-	m := map[string]bool{
-		"true":  true,
-		"True":  true,
-		"false": false,
-		"False": false,
-	}
-	for s, expected := range m {
-		var b bool
-		r := mocks.NewResponseWithContent(s)
-		err := Respond(r,
-			ByUnmarshallingBool(&b),
-			ByClosing())
-		if err != nil {
-			t.Errorf("autorest: ByUnmarshallingBool returned an unexpected error parsing %v -- %v", s, err)
-		}
-		if b != expected {
-			t.Errorf("autorest: ByUnmarshallingBool failed to correctly unmarshall -- expected %v, received %v", expected, b)
-		}
-	}
-}
-
-func Test_ByUnmarshallingBoolFailsWithInvalidString(t *testing.T) {
-	var b bool
-	r := mocks.NewResponseWithContent("Not a Boolean")
-	err := Respond(r,
-		ByUnmarshallingBool(&b),
-		ByClosing())
-	if err == nil {
-		t.Errorf("autorest: ByUnmarshallingBool failed to return an error for an invalid string")
-	}
-}
-
-func Test_ByUnmarshallingFloat32(t *testing.T) {
-	for _, ch := range []byte{'e', 'E', 'f', 'g', 'G'} {
-		var f1, f2 float32
-		f2 = float32(123456.789)
-		r := mocks.NewResponseWithContent(strconv.FormatFloat(float64(f2), ch, -1, 64))
-		err := Respond(r,
-			ByUnmarshallingFloat32(&f1),
-			ByClosing())
-		if err != nil {
-			t.Errorf("autorest: ByUnmarshallingFloat32 returned an unexpected error parsing format %c -- %v", ch, err)
-		}
-		if f1 != f2 {
-			t.Errorf("autorest: ByUnmarshallingFloat32 failed to correctly unmarshall -- expected %v, received %v", f2, f1)
-		}
-	}
-}
-
-func Test_ByUnmarshallingFloat32FailsWithInvalidString(t *testing.T) {
-	var f float32
-	r := mocks.NewResponseWithContent("Not a Float32")
-	err := Respond(r,
-		ByUnmarshallingFloat32(&f),
-		ByClosing())
-	if err == nil {
-		t.Errorf("autorest: ByUnmarshallingFloat32 failed to return an error for an invalid string")
-	}
-}
-
-func Test_ByUnmarshallingFloat64(t *testing.T) {
-	for _, ch := range []byte{'e', 'E', 'f', 'g', 'G'} {
-		var f1, f2 float64
-		f2 = float64(123456.789)
-		r := mocks.NewResponseWithContent(strconv.FormatFloat(float64(f2), ch, -1, 64))
-		err := Respond(r,
-			ByUnmarshallingFloat64(&f1),
-			ByClosing())
-		if err != nil {
-			t.Errorf("autorest: ByUnmarshallingFloat64 returned an unexpected error parsing format %c -- %v", ch, err)
-		}
-		if f1 != f2 {
-			t.Errorf("autorest: ByUnmarshallingFloat64 failed to correctly unmarshall -- expected %v, received %v", f2, f1)
-		}
-	}
-}
-
-func Test_ByUnmarshallingFloat64FailsWithInvalidString(t *testing.T) {
-	var f float64
-	r := mocks.NewResponseWithContent("Not a Float64")
-	err := Respond(r,
-		ByUnmarshallingFloat64(&f),
-		ByClosing())
-	if err == nil {
-		t.Errorf("autorest: ByUnmarshallingFloat64 failed to return an error for an invalid string")
-	}
-}
-
-func Test_ByUnmarshallingInt32(t *testing.T) {
-	for _, i2 := range []int32{-123456, 123456} {
-		var i1 int32
-		r := mocks.NewResponseWithContent(strconv.FormatInt(int64(i2), 10))
-		err := Respond(r,
-			ByUnmarshallingInt32(&i1),
-			ByClosing())
-		if err != nil {
-			t.Errorf("autorest: ByUnmarshallingInt32 returned an unexpected error -- %v", err)
-		}
-		if i1 != i2 {
-			t.Errorf("autorest: ByUnmarshallingInt32 failed to correctly unmarshall -- expected %v, received %v", i2, i1)
-		}
-	}
-}
-
-func Test_ByUnmarshallingInt32FailsWithInvalidString(t *testing.T) {
-	var i int32
-	r := mocks.NewResponseWithContent("Not an Integer")
-	err := Respond(r,
-		ByUnmarshallingInt32(&i),
-		ByClosing())
-	if err == nil {
-		t.Errorf("autorest: ByUnmarshallingInt32 failed to return an error for an invalid string")
-	}
-}
-
-func Test_ByUnmarshallingInt64(t *testing.T) {
-	for _, i2 := range []int64{-123456, 123456} {
-		var i1 int64
-		r := mocks.NewResponseWithContent(strconv.FormatInt(int64(i2), 10))
-		err := Respond(r,
-			ByUnmarshallingInt64(&i1),
-			ByClosing())
-		if err != nil {
-			t.Errorf("autorest: ByUnmarshallingInt64 returned an unexpected error -- %v", err)
-		}
-		if i1 != i2 {
-			t.Errorf("autorest: ByUnmarshallingInt64 failed to correctly unmarshall -- expected %v, received %v", i2, i1)
-		}
-	}
-}
-
-func Test_ByUnmarshallingInt64FailsWithInvalidString(t *testing.T) {
-	var i int64
-	r := mocks.NewResponseWithContent("Not an Integer")
-	err := Respond(r,
-		ByUnmarshallingInt64(&i),
-		ByClosing())
-	if err == nil {
-		t.Errorf("autorest: ByUnmarshallingInt64 failed to return an error for an invalid string")
-	}
-}
-
-func Test_ByUnmarshallingString(t *testing.T) {
-	var s1, s2 string
-	s2 = "Expected string"
-	r := mocks.NewResponseWithContent(s2)
-	err := Respond(r,
-		ByUnmarshallingString(&s1),
-		ByClosing())
-	if err != nil {
-		t.Errorf("autorest: ByUnmarshallingString returned an unexpected error -- %v", err)
-	}
-	if s1 != s2 {
-		t.Errorf("autorest: ByUnmarshallingString failed to correctly unmarshall -- expected %v, received %v", s2, s1)
-	}
-}
-
 func TestByUnmarshallingJSON(t *testing.T) {
 	v := &mocks.T{}
 	r := mocks.NewResponseWithContent(jsonT)
@@ -434,6 +338,19 @@ func TestByUnmarshallingJSON(t *testing.T) {
 	}
 	if v.Name != "Rob Pike" || v.Age != 42 {
 		t.Errorf("autorest: ByUnmarshallingJSON failed to properly unmarshal")
+	}
+}
+
+func TestByUnmarshallingJSON_HandlesReadErrors(t *testing.T) {
+	v := &mocks.T{}
+	r := mocks.NewResponseWithContent(jsonT)
+	r.Body.(*mocks.Body).Close()
+
+	err := Respond(r,
+		ByUnmarshallingJSON(v),
+		ByClosing())
+	if err == nil {
+		t.Errorf("autorest: ByUnmarshallingJSON failed to receive / respond to read error")
 	}
 }
 
@@ -460,6 +377,19 @@ func TestByUnmarshallingXML(t *testing.T) {
 	}
 	if v.Name != "Rob Pike" || v.Age != 42 {
 		t.Errorf("autorest: ByUnmarshallingXML failed to properly unmarshal")
+	}
+}
+
+func TestByUnmarshallingXML_HandlesReadErrors(t *testing.T) {
+	v := &mocks.T{}
+	r := mocks.NewResponseWithContent(xmlT)
+	r.Body.(*mocks.Body).Close()
+
+	err := Respond(r,
+		ByUnmarshallingXML(v),
+		ByClosing())
+	if err == nil {
+		t.Errorf("autorest: ByUnmarshallingXML failed to receive / respond to read error")
 	}
 }
 

--- a/autorest/utility.go
+++ b/autorest/utility.go
@@ -6,9 +6,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
-	"strconv"
 )
 
 // EncodedAs is a series of constants specifying various data encodings
@@ -48,53 +46,24 @@ func CopyAndDecode(encodedAs EncodedAs, r io.Reader, v interface{}) (bytes.Buffe
 	return b, NewDecoder(encodedAs, io.TeeReader(r, &b)).Decode(v)
 }
 
-func readBool(r io.Reader) (bool, error) {
-	s, err := readString(r)
-	if err == nil {
-		return strconv.ParseBool(s)
-	}
-	return false, err
+// TeeReadCloser returns a ReadCloser that writes to w what it reads from rc.
+// It utilizes io.TeeReader to copy the data read and has the same behavior when reading.
+// Further, when it is closed, it ensures that rc is closed as well.
+func TeeReadCloser(rc io.ReadCloser, w io.Writer) io.ReadCloser {
+	return &teeReadCloser{rc, io.TeeReader(rc, w)}
 }
 
-func readFloat32(r io.Reader) (float32, error) {
-	s, err := readString(r)
-	if err == nil {
-		v, err := strconv.ParseFloat(s, 32)
-		return float32(v), err
-	}
-	return float32(0), err
+type teeReadCloser struct {
+	rc io.ReadCloser
+	r  io.Reader
 }
 
-func readFloat64(r io.Reader) (float64, error) {
-	s, err := readString(r)
-	if err == nil {
-		v, err := strconv.ParseFloat(s, 64)
-		return v, err
-	}
-	return float64(0), err
+func (t *teeReadCloser) Read(p []byte) (int, error) {
+	return t.r.Read(p)
 }
 
-func readInt32(r io.Reader) (int32, error) {
-	s, err := readString(r)
-	if err == nil {
-		v, err := strconv.ParseInt(s, 10, 32)
-		return int32(v), err
-	}
-	return int32(0), err
-}
-
-func readInt64(r io.Reader) (int64, error) {
-	s, err := readString(r)
-	if err == nil {
-		v, err := strconv.ParseInt(s, 10, 64)
-		return v, err
-	}
-	return int64(0), err
-}
-
-func readString(r io.Reader) (string, error) {
-	b, err := ioutil.ReadAll(r)
-	return string(b), err
+func (t *teeReadCloser) Close() error {
+	return t.rc.Close()
 }
 
 func containsInt(ints []int, n int) bool {

--- a/autorest/version.go
+++ b/autorest/version.go
@@ -5,7 +5,7 @@ import (
 )
 
 const (
-	major        = "6"
+	major        = "7"
 	minor        = "0"
 	patch        = "0"
 	tag          = ""

--- a/autorest/version_test.go
+++ b/autorest/version_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestVersion(t *testing.T) {
-	v := "6.0.0"
+	v := "7.0.0"
 	if Version() != v {
 		t.Errorf("autorest: Version failed to return the expected version -- expected %s, received %s",
 			v, Version())


### PR DESCRIPTION
Removed type-specific unmarshalling code; reverted to using ```json.Unmarshal```.
Added ```ByCopying``` responder with supporting ```TeeReadCloser```.
Rewrote Azure asynchronous handling

Signed-off-by: Brendan Dixon <brendand@microsoft.com>