### PR TITLE
Corrected DoPollForAsynchronous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # CHANGELOG
 
+## v7.0.2
+- Corrected DoPollForAsynchronous to continue using the polling method first discovered
+
 ## v7.0.1
 - Fixed empty JSON input error in ByUnmarshallingJSON
 - Fixed polling support for GET calls
 - Changed format name from TimeRfc1123 to TimeRFC1123
-
 
 ## v7.0.0
 - Added ByCopying responder with supporting TeeReadCloser


### PR DESCRIPTION
Corrected DoPollForAsynchronous to use the first discovered polling method.

Signed-off-by: Brendan Dixon <brendand@microsoft.com>