### PR TITLE
Refactoring for unchecked errors

### DIFF
--- a/autorest/azure/persist.go
+++ b/autorest/azure/persist.go
@@ -40,7 +40,7 @@ func SaveToken(path string, mode os.FileMode, token Token) error {
 	}
 	tempPath := newFile.Name()
 
-	if json.NewEncoder(newFile).Encode(token); err != nil {
+	if err := json.NewEncoder(newFile).Encode(token); err != nil {
 		return fmt.Errorf("failed to encode token to file (%s) while saving token: %v", tempPath, err)
 	}
 	if err := newFile.Close(); err != nil {

--- a/autorest/client.go
+++ b/autorest/client.go
@@ -2,6 +2,7 @@ package autorest
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
@@ -53,7 +54,9 @@ func (li LoggingInspector) WithInspection() PrepareDecorator {
 			defer r.Body.Close()
 
 			r.Body = ioutil.NopCloser(io.TeeReader(r.Body, &body))
-			r.Write(&b)
+			if err := r.Write(&b); err != nil {
+				return nil, fmt.Errorf("Failed to write response: %v", err)
+			}
 
 			li.Logger.Printf(requestFormat, b.String())
 
@@ -76,7 +79,9 @@ func (li LoggingInspector) ByInspecting() RespondDecorator {
 			defer resp.Body.Close()
 
 			resp.Body = ioutil.NopCloser(io.TeeReader(resp.Body, &body))
-			resp.Write(&b)
+			if err := resp.Write(&b); err != nil {
+				return fmt.Errorf("Failed to write response: %v", err)
+			}
 
 			li.Logger.Printf(responseFormat, b.String())
 

--- a/autorest/client_test.go
+++ b/autorest/client_test.go
@@ -35,9 +35,10 @@ func TestLoggingInspectorWithInspectionEmitsErrors(t *testing.T) {
 	li := LoggingInspector{Logger: log.New(&b, "", 0)}
 	c.RequestInspector = li.WithInspection()
 
-	r.Body.Close()
-	Prepare(r,
-		c.WithInspection())
+	if _, err := Prepare(r,
+		c.WithInspection()); err != nil {
+		t.Error(err)
+	}
 
 	if len(b.String()) <= 0 {
 		t.Error("autorest: LoggingInspector#WithInspection did not record Request to the log")
@@ -81,9 +82,10 @@ func TestLoggingInspectorByInspectingEmitsErrors(t *testing.T) {
 	li := LoggingInspector{Logger: log.New(&b, "", 0)}
 	c.ResponseInspector = li.ByInspecting()
 
-	r.Body.Close()
-	Respond(r,
-		c.ByInspecting())
+	if err := Respond(r,
+		c.ByInspecting()); err != nil {
+		t.Fatal(err)
+	}
 
 	if len(b.String()) <= 0 {
 		t.Error("autorest: LoggingInspector#ByInspection did not record Response to the log")

--- a/autorest/responder.go
+++ b/autorest/responder.go
@@ -95,7 +95,9 @@ func ByClosing() RespondDecorator {
 		return ResponderFunc(func(resp *http.Response) error {
 			err := r.Respond(resp)
 			if resp != nil && resp.Body != nil {
-				resp.Body.Close()
+				if err := resp.Body.Close(); err != nil {
+					return fmt.Errorf("Error closing the response body: %v", err)
+				}
 			}
 			return err
 		})
@@ -109,7 +111,9 @@ func ByClosingIfError() RespondDecorator {
 		return ResponderFunc(func(resp *http.Response) error {
 			err := r.Respond(resp)
 			if err != nil && resp != nil && resp.Body != nil {
-				resp.Body.Close()
+				if err := resp.Body.Close(); err != nil {
+					return fmt.Errorf("Error closing the response body: %v", err)
+				}
 			}
 			return err
 		})


### PR DESCRIPTION
Some cleanup:

- Fixed a bug in persist.go with missing error check
- DelayForBackoff was unnecessarily using an error type
  and was allocating a channel when nil ch would do just fine
- Fixed some eager mock-response closings and added error checks
  previously shadowing the body copying errors.

Signed-off-by: Ahmet Alp Balkan <ahmetalpbalkan@gmail.com>