### PR TITLE
Replace t.Error with t.Fatal

### DIFF
--- a/autorest/autorest_test.go
+++ b/autorest/autorest_test.go
@@ -11,7 +11,7 @@ func TestResponseHasStatusCode(t *testing.T) {
 	codes := []int{http.StatusOK, http.StatusAccepted}
 	resp := &http.Response{StatusCode: http.StatusAccepted}
 	if !ResponseHasStatusCode(resp, codes...) {
-		t.Errorf("autorest: ResponseHasStatusCode failed to find %v in %v", resp.StatusCode, codes)
+		t.Fatalf("autorest: ResponseHasStatusCode failed to find %v in %v", resp.StatusCode, codes)
 	}
 }
 
@@ -19,7 +19,7 @@ func TestResponseHasStatusCodeNotPresent(t *testing.T) {
 	codes := []int{http.StatusOK, http.StatusAccepted}
 	resp := &http.Response{StatusCode: http.StatusInternalServerError}
 	if ResponseHasStatusCode(resp, codes...) {
-		t.Errorf("autorest: ResponseHasStatusCode unexpectedly found %v in %v", resp.StatusCode, codes)
+		t.Fatalf("autorest: ResponseHasStatusCode unexpectedly found %v in %v", resp.StatusCode, codes)
 	}
 }
 
@@ -28,7 +28,7 @@ func TestNewPollingRequestDoesNotReturnARequestWhenLocationHeaderIsMissing(t *te
 
 	req, _ := NewPollingRequest(resp, nil)
 	if req != nil {
-		t.Error("autorest: NewPollingRequest returned an http.Request when the Location header was missing")
+		t.Fatal("autorest: NewPollingRequest returned an http.Request when the Location header was missing")
 	}
 }
 
@@ -39,7 +39,7 @@ func TestNewPollingRequestReturnsAnErrorWhenPrepareFails(t *testing.T) {
 
 	_, err := NewPollingRequest(resp, nil)
 	if err == nil {
-		t.Error("autorest: NewPollingRequest failed to return an error when Prepare fails")
+		t.Fatal("autorest: NewPollingRequest failed to return an error when Prepare fails")
 	}
 }
 
@@ -50,7 +50,7 @@ func TestNewPollingRequestDoesNotReturnARequestWhenPrepareFails(t *testing.T) {
 
 	req, _ := NewPollingRequest(resp, nil)
 	if req != nil {
-		t.Error("autorest: NewPollingRequest returned an http.Request when Prepare failed")
+		t.Fatal("autorest: NewPollingRequest returned an http.Request when Prepare failed")
 	}
 }
 
@@ -60,7 +60,7 @@ func TestNewPollingRequestReturnsAGetRequest(t *testing.T) {
 
 	req, _ := NewPollingRequest(resp, nil)
 	if req.Method != "GET" {
-		t.Errorf("autorest: NewPollingRequest did not create an HTTP GET request -- actual method %v", req.Method)
+		t.Fatalf("autorest: NewPollingRequest did not create an HTTP GET request -- actual method %v", req.Method)
 	}
 }
 
@@ -70,7 +70,7 @@ func TestNewPollingRequestProvidesTheURL(t *testing.T) {
 
 	req, _ := NewPollingRequest(resp, nil)
 	if req.URL.String() != mocks.TestURL {
-		t.Errorf("autorest: NewPollingRequest did not create an HTTP with the expected URL -- received %v, expected %v", req.URL, mocks.TestURL)
+		t.Fatalf("autorest: NewPollingRequest did not create an HTTP with the expected URL -- received %v, expected %v", req.URL, mocks.TestURL)
 	}
 }
 
@@ -80,7 +80,7 @@ func TestGetLocation(t *testing.T) {
 
 	l := GetLocation(resp)
 	if len(l) == 0 {
-		t.Errorf("autorest: GetLocation failed to return Location header -- expected %v, received %v", mocks.TestURL, l)
+		t.Fatalf("autorest: GetLocation failed to return Location header -- expected %v, received %v", mocks.TestURL, l)
 	}
 }
 
@@ -89,7 +89,7 @@ func TestGetLocationReturnsEmptyStringForMissingLocation(t *testing.T) {
 
 	l := GetLocation(resp)
 	if len(l) != 0 {
-		t.Errorf("autorest: GetLocation return a value without a Location header -- received %v", l)
+		t.Fatalf("autorest: GetLocation return a value without a Location header -- received %v", l)
 	}
 }
 
@@ -99,7 +99,7 @@ func TestGetRetryAfter(t *testing.T) {
 
 	d := GetRetryAfter(resp, DefaultPollingDelay)
 	if d != mocks.TestDelay {
-		t.Errorf("autorest: GetRetryAfter failed to returned the expected delay -- expected %v, received %v", mocks.TestDelay, d)
+		t.Fatalf("autorest: GetRetryAfter failed to returned the expected delay -- expected %v, received %v", mocks.TestDelay, d)
 	}
 }
 
@@ -108,7 +108,7 @@ func TestGetRetryAfterReturnsDefaultDelayIfRetryHeaderIsMissing(t *testing.T) {
 
 	d := GetRetryAfter(resp, DefaultPollingDelay)
 	if d != DefaultPollingDelay {
-		t.Errorf("autorest: GetRetryAfter failed to returned the default delay for a missing Retry-After header -- expected %v, received %v",
+		t.Fatalf("autorest: GetRetryAfter failed to returned the default delay for a missing Retry-After header -- expected %v, received %v",
 			DefaultPollingDelay, d)
 	}
 }
@@ -120,7 +120,7 @@ func TestGetRetryAfterReturnsDefaultDelayIfRetryHeaderIsMalformed(t *testing.T) 
 
 	d := GetRetryAfter(resp, DefaultPollingDelay)
 	if d != DefaultPollingDelay {
-		t.Errorf("autorest: GetRetryAfter failed to returned the default delay for a malformed Retry-After header -- expected %v, received %v",
+		t.Fatalf("autorest: GetRetryAfter failed to returned the default delay for a malformed Retry-After header -- expected %v, received %v",
 			DefaultPollingDelay, d)
 	}
 }

--- a/autorest/azure/async_test.go
+++ b/autorest/azure/async_test.go
@@ -16,7 +16,7 @@ func TestGetAsyncOperation_ReturnsAzureAsyncOperationHeader(t *testing.T) {
 	r := newAsynchronousResponse()
 
 	if getAsyncOperation(r) != mocks.TestAzureAsyncURL {
-		t.Errorf("azure: getAsyncOperation failed to extract the Azure-AsyncOperation header -- expected %v, received %v", mocks.TestURL, getAsyncOperation(r))
+		t.Fatalf("azure: getAsyncOperation failed to extract the Azure-AsyncOperation header -- expected %v, received %v", mocks.TestURL, getAsyncOperation(r))
 	}
 }
 
@@ -24,133 +24,133 @@ func TestGetAsyncOperation_ReturnsEmptyStringIfHeaderIsAbsent(t *testing.T) {
 	r := mocks.NewResponse()
 
 	if len(getAsyncOperation(r)) != 0 {
-		t.Errorf("azure: getAsyncOperation failed to return empty string when the Azure-AsyncOperation header is absent -- received %v", getAsyncOperation(r))
+		t.Fatalf("azure: getAsyncOperation failed to return empty string when the Azure-AsyncOperation header is absent -- received %v", getAsyncOperation(r))
 	}
 }
 
 func TestHasSucceeded_ReturnsTrueForSuccess(t *testing.T) {
 	if !hasSucceeded(operationSucceeded) {
-		t.Error("azure: hasSucceeded failed to return true for success")
+		t.Fatal("azure: hasSucceeded failed to return true for success")
 	}
 }
 
 func TestHasSucceeded_ReturnsFalseOtherwise(t *testing.T) {
 	if hasSucceeded("not a success string") {
-		t.Error("azure: hasSucceeded returned true for a non-success")
+		t.Fatal("azure: hasSucceeded returned true for a non-success")
 	}
 }
 
 func TestHasTerminated_ReturnsTrueForValidTerminationStates(t *testing.T) {
 	for _, state := range []string{operationSucceeded, operationCanceled, operationFailed} {
 		if !hasTerminated(state) {
-			t.Errorf("azure: hasTerminated failed to return true for the '%s' state", state)
+			t.Fatalf("azure: hasTerminated failed to return true for the '%s' state", state)
 		}
 	}
 }
 
 func TestHasTerminated_ReturnsFalseForUnknownStates(t *testing.T) {
 	if hasTerminated("not a known state") {
-		t.Error("azure: hasTerminated returned true for an unknown state")
+		t.Fatal("azure: hasTerminated returned true for an unknown state")
 	}
 }
 
 func TestOperationError_ErrorReturnsAString(t *testing.T) {
 	s := (ServiceError{Code: "server code", Message: "server error"}).Error()
 	if s == "" {
-		t.Errorf("azure: operationError#Error failed to return an error")
+		t.Fatalf("azure: operationError#Error failed to return an error")
 	}
 	if !strings.Contains(s, "server code") || !strings.Contains(s, "server error") {
-		t.Errorf("azure: operationError#Error returned a malformed error -- error='%v'", s)
+		t.Fatalf("azure: operationError#Error returned a malformed error -- error='%v'", s)
 	}
 }
 
 func TestOperationResource_StateReturnsState(t *testing.T) {
 	if (operationResource{Status: "state"}).state() != "state" {
-		t.Errorf("azure: operationResource#state failed to return the correct state")
+		t.Fatalf("azure: operationResource#state failed to return the correct state")
 	}
 }
 
 func TestOperationResource_HasSucceededReturnsFalseIfNotSuccess(t *testing.T) {
 	if (operationResource{Status: "not a success string"}).hasSucceeded() {
-		t.Errorf("azure: operationResource#hasSucceeded failed to return false for a canceled operation")
+		t.Fatalf("azure: operationResource#hasSucceeded failed to return false for a canceled operation")
 	}
 }
 
 func TestOperationResource_HasSucceededReturnsTrueIfSuccessful(t *testing.T) {
 	if !(operationResource{Status: operationSucceeded}).hasSucceeded() {
-		t.Errorf("azure: operationResource#hasSucceeded failed to return true for a successful operation")
+		t.Fatalf("azure: operationResource#hasSucceeded failed to return true for a successful operation")
 	}
 }
 
 func TestOperationResource_HasTerminatedReturnsTrueForKnownStates(t *testing.T) {
 	for _, state := range []string{operationSucceeded, operationCanceled, operationFailed} {
 		if !(operationResource{Status: state}).hasTerminated() {
-			t.Errorf("azure: operationResource#hasTerminated failed to return true for the '%s' state", state)
+			t.Fatalf("azure: operationResource#hasTerminated failed to return true for the '%s' state", state)
 		}
 	}
 }
 
 func TestOperationResource_HasTerminatedReturnsFalseForUnknownStates(t *testing.T) {
 	if (operationResource{Status: "not a known state"}).hasTerminated() {
-		t.Errorf("azure: operationResource#hasTerminated returned true for a non-terminal operation")
+		t.Fatalf("azure: operationResource#hasTerminated returned true for a non-terminal operation")
 	}
 }
 
 func TestProvisioningStatus_StateReturnsState(t *testing.T) {
 	if (provisioningStatus{Properties: provisioningProperties{"state"}}).state() != "state" {
-		t.Errorf("azure: provisioningStatus#state failed to return the correct state")
+		t.Fatalf("azure: provisioningStatus#state failed to return the correct state")
 	}
 }
 
 func TestProvisioningStatus_HasSucceededReturnsFalseIfNotSuccess(t *testing.T) {
 	if (provisioningStatus{Properties: provisioningProperties{"not a success string"}}).hasSucceeded() {
-		t.Errorf("azure: provisioningStatus#hasSucceeded failed to return false for a canceled operation")
+		t.Fatalf("azure: provisioningStatus#hasSucceeded failed to return false for a canceled operation")
 	}
 }
 
 func TestProvisioningStatus_HasSucceededReturnsTrueIfSuccessful(t *testing.T) {
 	if !(provisioningStatus{Properties: provisioningProperties{operationSucceeded}}).hasSucceeded() {
-		t.Errorf("azure: provisioningStatus#hasSucceeded failed to return true for a successful operation")
+		t.Fatalf("azure: provisioningStatus#hasSucceeded failed to return true for a successful operation")
 	}
 }
 
 func TestProvisioningStatus_HasTerminatedReturnsTrueForKnownStates(t *testing.T) {
 	for _, state := range []string{operationSucceeded, operationCanceled, operationFailed} {
 		if !(provisioningStatus{Properties: provisioningProperties{state}}).hasTerminated() {
-			t.Errorf("azure: provisioningStatus#hasTerminated failed to return true for the '%s' state", state)
+			t.Fatalf("azure: provisioningStatus#hasTerminated failed to return true for the '%s' state", state)
 		}
 	}
 }
 
 func TestProvisioningStatus_HasTerminatedReturnsFalseForUnknownStates(t *testing.T) {
 	if (provisioningStatus{Properties: provisioningProperties{"not a known state"}}).hasTerminated() {
-		t.Errorf("azure: provisioningStatus#hasTerminated returned true for a non-terminal operation")
+		t.Fatalf("azure: provisioningStatus#hasTerminated returned true for a non-terminal operation")
 	}
 }
 
 func TestPollingState_HasSucceededReturnsFalseIfNotSuccess(t *testing.T) {
 	if (pollingState{state: "not a success string"}).hasSucceeded() {
-		t.Errorf("azure: pollingState#hasSucceeded failed to return false for a canceled operation")
+		t.Fatalf("azure: pollingState#hasSucceeded failed to return false for a canceled operation")
 	}
 }
 
 func TestPollingState_HasSucceededReturnsTrueIfSuccessful(t *testing.T) {
 	if !(pollingState{state: operationSucceeded}).hasSucceeded() {
-		t.Errorf("azure: pollingState#hasSucceeded failed to return true for a successful operation")
+		t.Fatalf("azure: pollingState#hasSucceeded failed to return true for a successful operation")
 	}
 }
 
 func TestPollingState_HasTerminatedReturnsTrueForKnownStates(t *testing.T) {
 	for _, state := range []string{operationSucceeded, operationCanceled, operationFailed} {
 		if !(pollingState{state: state}).hasTerminated() {
-			t.Errorf("azure: pollingState#hasTerminated failed to return true for the '%s' state", state)
+			t.Fatalf("azure: pollingState#hasTerminated failed to return true for the '%s' state", state)
 		}
 	}
 }
 
 func TestPollingState_HasTerminatedReturnsFalseForUnknownStates(t *testing.T) {
 	if (pollingState{state: "not a known state"}).hasTerminated() {
-		t.Errorf("azure: pollingState#hasTerminated returned true for a non-terminal operation")
+		t.Fatalf("azure: pollingState#hasTerminated returned true for a non-terminal operation")
 	}
 }
 
@@ -158,7 +158,7 @@ func TestUpdatePollingState_ReturnsAnErrorIfOneOccurs(t *testing.T) {
 	resp := mocks.NewResponseWithContent(operationResourceIllegal)
 	err := updatePollingState(resp, &pollingState{})
 	if err == nil {
-		t.Errorf("azure: updatePollingState failed to return an error after a JSON parsing error")
+		t.Fatalf("azure: updatePollingState failed to return an error after a JSON parsing error")
 	}
 }
 
@@ -169,7 +169,7 @@ func TestUpdatePollingState_ReturnsTerminatedForKnownProvisioningStates(t *testi
 		ps := &pollingState{responseFormat: usesProvisioningStatus}
 		updatePollingState(resp, ps)
 		if !ps.hasTerminated() {
-			t.Errorf("azure: updatePollingState failed to return a terminating pollingState for the '%s' state", state)
+			t.Fatalf("azure: updatePollingState failed to return a terminating pollingState for the '%s' state", state)
 		}
 	}
 }
@@ -180,7 +180,7 @@ func TestUpdatePollingState_ReturnsSuccessForSuccessfulProvisioningState(t *test
 	ps := &pollingState{responseFormat: usesProvisioningStatus}
 	updatePollingState(resp, ps)
 	if !ps.hasSucceeded() {
-		t.Errorf("azure: updatePollingState failed to return a successful pollingState for the '%s' state", operationSucceeded)
+		t.Fatalf("azure: updatePollingState failed to return a successful pollingState for the '%s' state", operationSucceeded)
 	}
 }
 
@@ -191,7 +191,7 @@ func TestUpdatePollingState_ReturnsInProgressForAllOtherProvisioningStates(t *te
 	ps := &pollingState{responseFormat: usesProvisioningStatus}
 	updatePollingState(resp, ps)
 	if ps.hasTerminated() {
-		t.Errorf("azure: updatePollingState returned terminated for unknown state '%s'", s)
+		t.Fatalf("azure: updatePollingState returned terminated for unknown state '%s'", s)
 	}
 }
 
@@ -202,7 +202,7 @@ func TestUpdatePollingState_ReturnsSuccessWhenProvisioningStateFieldIsAbsentForS
 		ps := &pollingState{responseFormat: usesProvisioningStatus}
 		updatePollingState(resp, ps)
 		if !ps.hasSucceeded() {
-			t.Errorf("azure: updatePollingState failed to return success when the provisionState field is absent for Status Code %d", sc)
+			t.Fatalf("azure: updatePollingState failed to return success when the provisionState field is absent for Status Code %d", sc)
 		}
 	}
 }
@@ -213,7 +213,7 @@ func TestUpdatePollingState_ReturnsInProgressWhenProvisioningStateFieldIsAbsentF
 	ps := &pollingState{responseFormat: usesProvisioningStatus}
 	updatePollingState(resp, ps)
 	if ps.hasTerminated() {
-		t.Errorf("azure: updatePollingState returned terminated when the provisionState field is absent for Status Code Accepted")
+		t.Fatalf("azure: updatePollingState returned terminated when the provisionState field is absent for Status Code Accepted")
 	}
 }
 
@@ -223,7 +223,7 @@ func TestUpdatePollingState_ReturnsFailedWhenProvisioningStateFieldIsAbsentForUn
 	ps := &pollingState{responseFormat: usesProvisioningStatus}
 	updatePollingState(resp, ps)
 	if !ps.hasTerminated() || ps.hasSucceeded() {
-		t.Errorf("azure: updatePollingState did not return failed when the provisionState field is absent for an unknown Status Code")
+		t.Fatalf("azure: updatePollingState did not return failed when the provisionState field is absent for an unknown Status Code")
 	}
 }
 
@@ -234,7 +234,7 @@ func TestUpdatePollingState_ReturnsTerminatedForKnownOperationResourceStates(t *
 		ps := &pollingState{responseFormat: usesOperationResponse}
 		updatePollingState(resp, ps)
 		if !ps.hasTerminated() {
-			t.Errorf("azure: updatePollingState failed to return a terminating pollingState for the '%s' state", state)
+			t.Fatalf("azure: updatePollingState failed to return a terminating pollingState for the '%s' state", state)
 		}
 	}
 }
@@ -245,7 +245,7 @@ func TestUpdatePollingState_ReturnsSuccessForSuccessfulOperationResourceState(t 
 	ps := &pollingState{responseFormat: usesOperationResponse}
 	updatePollingState(resp, ps)
 	if !ps.hasSucceeded() {
-		t.Errorf("azure: updatePollingState failed to return a successful pollingState for the '%s' state", operationSucceeded)
+		t.Fatalf("azure: updatePollingState failed to return a successful pollingState for the '%s' state", operationSucceeded)
 	}
 }
 
@@ -256,7 +256,7 @@ func TestUpdatePollingState_ReturnsInProgressForAllOtherOperationResourceStates(
 	ps := &pollingState{responseFormat: usesOperationResponse}
 	updatePollingState(resp, ps)
 	if ps.hasTerminated() {
-		t.Errorf("azure: updatePollingState returned terminated for unknown state '%s'", s)
+		t.Fatalf("azure: updatePollingState returned terminated for unknown state '%s'", s)
 	}
 }
 
@@ -268,10 +268,10 @@ func TestUpdatePollingState_CopiesTheResponseBody(t *testing.T) {
 	updatePollingState(resp, ps)
 	b, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		t.Errorf("azure: updatePollingState failed to replace the http.Response Body -- Error='%v'", err)
+		t.Fatalf("azure: updatePollingState failed to replace the http.Response Body -- Error='%v'", err)
 	}
 	if string(b) != s {
-		t.Errorf("azure: updatePollingState failed to copy the http.Response Body -- Expected='%s' Received='%s'", s, string(b))
+		t.Fatalf("azure: updatePollingState failed to copy the http.Response Body -- Expected='%s' Received='%s'", s, string(b))
 	}
 }
 
@@ -281,7 +281,7 @@ func TestUpdatePollingState_ClosesTheOriginalResponseBody(t *testing.T) {
 	ps := &pollingState{responseFormat: usesProvisioningStatus}
 	updatePollingState(resp, ps)
 	if b.IsOpen() {
-		t.Error("azure: updatePollingState failed to close the original http.Response Body")
+		t.Fatal("azure: updatePollingState failed to close the original http.Response Body")
 	}
 }
 
@@ -292,7 +292,7 @@ func TestUpdatePollingState_FailsWhenResponseLacksRequest(t *testing.T) {
 	ps := pollingState{}
 	err := updatePollingState(resp, &ps)
 	if err == nil {
-		t.Error("azure: updatePollingState failed to return an error when the http.Response lacked the original http.Request")
+		t.Fatal("azure: updatePollingState failed to return an error when the http.Response lacked the original http.Request")
 	}
 }
 
@@ -301,7 +301,7 @@ func TestUpdatePollingState_SetsTheResponseFormatWhenUsingTheAzureAsyncOperation
 	updatePollingState(newAsynchronousResponse(), &ps)
 
 	if ps.responseFormat != usesOperationResponse {
-		t.Error("azure: updatePollingState failed to set the correct response format when using the Azure-AsyncOperation header")
+		t.Fatal("azure: updatePollingState failed to set the correct response format when using the Azure-AsyncOperation header")
 	}
 }
 
@@ -313,7 +313,7 @@ func TestUpdatePollingState_SetsTheResponseFormatWhenUsingTheAzureAsyncOperation
 	updatePollingState(resp, &ps)
 
 	if ps.responseFormat != usesProvisioningStatus {
-		t.Error("azure: updatePollingState failed to set the correct response format when the Azure-AsyncOperation header is absent")
+		t.Fatal("azure: updatePollingState failed to set the correct response format when the Azure-AsyncOperation header is absent")
 	}
 }
 
@@ -325,7 +325,7 @@ func TestUpdatePollingState_DoesNotChangeAnExistingReponseFormat(t *testing.T) {
 	updatePollingState(resp, &ps)
 
 	if ps.responseFormat != usesOperationResponse {
-		t.Error("azure: updatePollingState failed to leave an existing response format setting")
+		t.Fatal("azure: updatePollingState failed to leave an existing response format setting")
 	}
 }
 
@@ -336,7 +336,7 @@ func TestUpdatePollingState_PrefersTheAzureAsyncOperationHeader(t *testing.T) {
 	updatePollingState(resp, &ps)
 
 	if ps.uri != mocks.TestAzureAsyncURL {
-		t.Error("azure: updatePollingState failed to prefer the Azure-AsyncOperation header")
+		t.Fatal("azure: updatePollingState failed to prefer the Azure-AsyncOperation header")
 	}
 }
 
@@ -348,7 +348,7 @@ func TestUpdatePollingState_PrefersLocationWhenTheAzureAsyncOperationHeaderMissi
 	updatePollingState(resp, &ps)
 
 	if ps.uri != mocks.TestLocationURL {
-		t.Error("azure: updatePollingState failed to prefer the Location header when the Azure-AsyncOperation header is missing")
+		t.Fatal("azure: updatePollingState failed to prefer the Location header when the Azure-AsyncOperation header is missing")
 	}
 }
 
@@ -362,7 +362,7 @@ func TestUpdatePollingState_UsesTheObjectLocationIfAsyncHeadersAreMissing(t *tes
 	updatePollingState(resp, &ps)
 
 	if ps.uri != mocks.TestURL {
-		t.Error("azure: updatePollingState failed to use the Object URL when the asynchronous headers are missing")
+		t.Fatal("azure: updatePollingState failed to use the Object URL when the asynchronous headers are missing")
 	}
 }
 
@@ -377,7 +377,7 @@ func TestUpdatePollingState_RecognizesLowerCaseHTTPVerbs(t *testing.T) {
 		updatePollingState(resp, &ps)
 
 		if ps.uri != mocks.TestURL {
-			t.Errorf("azure: updatePollingState failed to recognize the lower-case HTTP verb '%s'", m)
+			t.Fatalf("azure: updatePollingState failed to recognize the lower-case HTTP verb '%s'", m)
 		}
 	}
 }
@@ -391,7 +391,7 @@ func TestUpdatePollingState_ReturnsAnErrorIfAsyncHeadersAreMissingForANewOrDelet
 		resp.Request.Method = m
 		err := updatePollingState(resp, &pollingState{})
 		if err == nil {
-			t.Errorf("azure: updatePollingState failed to return an error even though it could not determine the polling URL for Method '%s'", m)
+			t.Fatalf("azure: updatePollingState failed to return an error even though it could not determine the polling URL for Method '%s'", m)
 		}
 	}
 }
@@ -402,28 +402,28 @@ func TestNewPollingRequest_FailsWhenResponseLacksRequest(t *testing.T) {
 
 	_, err := newPollingRequest(resp, pollingState{})
 	if err == nil {
-		t.Error("azure: newPollingRequest failed to return an error when the http.Response lacked the original http.Request")
+		t.Fatal("azure: newPollingRequest failed to return an error when the http.Response lacked the original http.Request")
 	}
 }
 
 func TestNewPollingRequest_ReturnsAnErrorWhenPrepareFails(t *testing.T) {
 	_, err := newPollingRequest(newAsynchronousResponse(), pollingState{responseFormat: usesOperationResponse, uri: mocks.TestBadURL})
 	if err == nil {
-		t.Error("azure: newPollingRequest failed to return an error when Prepare fails")
+		t.Fatal("azure: newPollingRequest failed to return an error when Prepare fails")
 	}
 }
 
 func TestNewPollingRequest_DoesNotReturnARequestWhenPrepareFails(t *testing.T) {
 	req, _ := newPollingRequest(newAsynchronousResponse(), pollingState{responseFormat: usesOperationResponse, uri: mocks.TestBadURL})
 	if req != nil {
-		t.Error("azure: newPollingRequest returned an http.Request when Prepare failed")
+		t.Fatal("azure: newPollingRequest returned an http.Request when Prepare failed")
 	}
 }
 
 func TestNewPollingRequest_ReturnsAGetRequest(t *testing.T) {
 	req, _ := newPollingRequest(newAsynchronousResponse(), pollingState{responseFormat: usesOperationResponse, uri: mocks.TestAzureAsyncURL})
 	if req.Method != "GET" {
-		t.Errorf("azure: newPollingRequest did not create an HTTP GET request -- actual method %v", req.Method)
+		t.Fatalf("azure: newPollingRequest did not create an HTTP GET request -- actual method %v", req.Method)
 	}
 }
 
@@ -434,7 +434,7 @@ func TestDoPollForAsynchronous_IgnoresUnspecifiedStatusCodes(t *testing.T) {
 		DoPollForAsynchronous(time.Duration(0)))
 
 	if client.Attempts() != 1 {
-		t.Errorf("azure: DoPollForAsynchronous polled for unspecified status code")
+		t.Fatalf("azure: DoPollForAsynchronous polled for unspecified status code")
 	}
 
 	autorest.Respond(r,
@@ -449,7 +449,7 @@ func TestDoPollForAsynchronous_PollsForSpecifiedStatusCodes(t *testing.T) {
 		DoPollForAsynchronous(time.Millisecond))
 
 	if client.Attempts() != 2 {
-		t.Errorf("azure: DoPollForAsynchronous failed to poll for specified status code")
+		t.Fatalf("azure: DoPollForAsynchronous failed to poll for specified status code")
 	}
 
 	autorest.Respond(r,
@@ -484,7 +484,7 @@ func TestDoPollForAsynchronous_CanBeCanceled(t *testing.T) {
 	close(cancel)
 	time.Sleep(5 * time.Millisecond)
 	if time.Since(start) >= delay {
-		t.Errorf("azure: DoPollForAsynchronous failed to cancel")
+		t.Fatalf("azure: DoPollForAsynchronous failed to cancel")
 	}
 }
 
@@ -505,7 +505,7 @@ func TestDoPollForAsynchronous_ClosesAllNonreturnedResponseBodiesWhenPolling(t *
 		DoPollForAsynchronous(time.Millisecond))
 
 	if b1.IsOpen() || b2.IsOpen() || b3.IsOpen() {
-		t.Errorf("azure: DoPollForAsynchronous did not close unreturned response bodies")
+		t.Fatalf("azure: DoPollForAsynchronous did not close unreturned response bodies")
 	}
 
 	autorest.Respond(r,
@@ -527,7 +527,7 @@ func TestDoPollForAsynchronous_LeavesLastResponseBodyOpen(t *testing.T) {
 
 	b, err := ioutil.ReadAll(r.Body)
 	if len(b) <= 0 || err != nil {
-		t.Errorf("azure: DoPollForAsynchronous did not leave open the body of the last response - Error='%v'", err)
+		t.Fatalf("azure: DoPollForAsynchronous did not leave open the body of the last response - Error='%v'", err)
 	}
 
 	autorest.Respond(r,
@@ -547,7 +547,7 @@ func TestDoPollForAsynchronous_DoesNotPollIfOriginalRequestReturnedAnError(t *te
 		DoPollForAsynchronous(time.Millisecond))
 
 	if client.Attempts() != 1 {
-		t.Errorf("azure: DoPollForAsynchronous tried to poll after receiving an error")
+		t.Fatalf("azure: DoPollForAsynchronous tried to poll after receiving an error")
 	}
 
 	autorest.Respond(r,
@@ -567,7 +567,7 @@ func TestDoPollForAsynchronous_DoesNotPollIfCreatingOperationRequestFails(t *tes
 		DoPollForAsynchronous(time.Millisecond))
 
 	if client.Attempts() > 1 {
-		t.Errorf("azure: DoPollForAsynchronous polled with an invalidly formed operation request")
+		t.Fatalf("azure: DoPollForAsynchronous polled with an invalidly formed operation request")
 	}
 
 	autorest.Respond(r,
@@ -588,7 +588,7 @@ func TestDoPollForAsynchronous_StopsPollingAfterAnError(t *testing.T) {
 		DoPollForAsynchronous(time.Millisecond))
 
 	if client.Attempts() > 3 {
-		t.Errorf("azure: DoPollForAsynchronous failed to stop polling after receiving an error")
+		t.Fatalf("azure: DoPollForAsynchronous failed to stop polling after receiving an error")
 	}
 
 	autorest.Respond(r,
@@ -605,7 +605,7 @@ func TestDoPollForAsynchronous_ReturnsPollingError(t *testing.T) {
 		DoPollForAsynchronous(time.Millisecond))
 
 	if err == nil {
-		t.Errorf("azure: DoPollForAsynchronous failed to return error from polling")
+		t.Fatalf("azure: DoPollForAsynchronous failed to return error from polling")
 	}
 
 	autorest.Respond(r,
@@ -628,7 +628,7 @@ func TestDoPollForAsynchronous_PollsForStatusAccepted(t *testing.T) {
 		DoPollForAsynchronous(time.Millisecond))
 
 	if client.Attempts() < 4 {
-		t.Errorf("azure: DoPollForAsynchronous stopped polling before receiving a terminated OperationResource")
+		t.Fatalf("azure: DoPollForAsynchronous stopped polling before receiving a terminated OperationResource")
 	}
 
 	autorest.Respond(r,
@@ -651,7 +651,7 @@ func TestDoPollForAsynchronous_PollsForStatusCreated(t *testing.T) {
 		DoPollForAsynchronous(time.Millisecond))
 
 	if client.Attempts() < 4 {
-		t.Errorf("azure: DoPollForAsynchronous stopped polling before receiving a terminated OperationResource")
+		t.Fatalf("azure: DoPollForAsynchronous stopped polling before receiving a terminated OperationResource")
 	}
 
 	autorest.Respond(r,
@@ -675,7 +675,7 @@ func TestDoPollForAsynchronous_PollsUntilProvisioningStatusTerminates(t *testing
 		DoPollForAsynchronous(time.Millisecond))
 
 	if client.Attempts() < 4 {
-		t.Errorf("azure: DoPollForAsynchronous stopped polling before receiving a terminated OperationResource")
+		t.Fatalf("azure: DoPollForAsynchronous stopped polling before receiving a terminated OperationResource")
 	}
 
 	autorest.Respond(r,
@@ -699,7 +699,7 @@ func TestDoPollForAsynchronous_PollsUntilProvisioningStatusSucceeds(t *testing.T
 		DoPollForAsynchronous(time.Millisecond))
 
 	if client.Attempts() < 4 {
-		t.Errorf("azure: DoPollForAsynchronous stopped polling before receiving a terminated OperationResource")
+		t.Fatalf("azure: DoPollForAsynchronous stopped polling before receiving a terminated OperationResource")
 	}
 
 	autorest.Respond(r,
@@ -720,7 +720,7 @@ func TestDoPollForAsynchronous_PollsUntilOperationResourceHasTerminated(t *testi
 		DoPollForAsynchronous(time.Millisecond))
 
 	if client.Attempts() < 4 {
-		t.Errorf("azure: DoPollForAsynchronous stopped polling before receiving a terminated OperationResource")
+		t.Fatalf("azure: DoPollForAsynchronous stopped polling before receiving a terminated OperationResource")
 	}
 
 	autorest.Respond(r,
@@ -741,7 +741,7 @@ func TestDoPollForAsynchronous_PollsUntilOperationResourceHasSucceeded(t *testin
 		DoPollForAsynchronous(time.Millisecond))
 
 	if client.Attempts() < 4 {
-		t.Errorf("azure: DoPollForAsynchronous stopped polling before receiving a terminated OperationResource")
+		t.Fatalf("azure: DoPollForAsynchronous stopped polling before receiving a terminated OperationResource")
 	}
 
 	autorest.Respond(r,
@@ -762,7 +762,7 @@ func TestDoPollForAsynchronous_StopsPollingWhenOperationResourceHasTerminated(t 
 		DoPollForAsynchronous(time.Millisecond))
 
 	if client.Attempts() > 4 {
-		t.Errorf("azure: DoPollForAsynchronous failed to stop after receiving a terminated OperationResource")
+		t.Fatalf("azure: DoPollForAsynchronous failed to stop after receiving a terminated OperationResource")
 	}
 
 	autorest.Respond(r,
@@ -783,7 +783,7 @@ func TestDoPollForAsynchronous_ReturnsAnErrorForCanceledOperations(t *testing.T)
 		DoPollForAsynchronous(time.Millisecond))
 
 	if err == nil || !strings.Contains(fmt.Sprintf("%v", err), "Canceled") {
-		t.Errorf("azure: DoPollForAsynchronous failed to return an appropriate error for a canceled OperationResource")
+		t.Fatalf("azure: DoPollForAsynchronous failed to return an appropriate error for a canceled OperationResource")
 	}
 
 	autorest.Respond(r,
@@ -804,7 +804,7 @@ func TestDoPollForAsynchronous_ReturnsAnErrorForFailedOperations(t *testing.T) {
 		DoPollForAsynchronous(time.Millisecond))
 
 	if err == nil || !strings.Contains(fmt.Sprintf("%v", err), "Failed") {
-		t.Errorf("azure: DoPollForAsynchronous failed to return an appropriate error for a canceled OperationResource")
+		t.Fatalf("azure: DoPollForAsynchronous failed to return an appropriate error for a canceled OperationResource")
 	}
 
 	autorest.Respond(r,
@@ -830,7 +830,7 @@ func TestDoPollForAsynchronous_ReturnsAnUnknownErrorForFailedOperations(t *testi
 
 	expected := makeLongRunningOperationErrorString("Unknown", "None")
 	if err.Error() != expected {
-		t.Errorf("azure: DoPollForAsynchronous failed to return an appropriate error message for an unknown error. \n expected=%q \n got=%q",
+		t.Fatalf("azure: DoPollForAsynchronous failed to return an appropriate error message for an unknown error. \n expected=%q \n got=%q",
 			expected, err.Error())
 	}
 
@@ -857,7 +857,7 @@ func TestDoPollForAsynchronous_ReturnsErrorForLastErrorResponse(t *testing.T) {
 
 	expected := makeLongRunningOperationErrorString("NetcfgInvalidSubnet", "Subnet is not valid in virtual network.")
 	if err.Error() != expected {
-		t.Errorf("azure: DoPollForAsynchronous failed to return an appropriate error message for an unknown error. \n expected=%q \n got=%q",
+		t.Fatalf("azure: DoPollForAsynchronous failed to return an appropriate error message for an unknown error. \n expected=%q \n got=%q",
 			expected, err.Error())
 	}
 
@@ -881,7 +881,7 @@ func TestDoPollForAsynchronous_ReturnsOperationResourceErrorForFailedOperations(
 
 	expected := makeLongRunningOperationErrorString("BadArgument", "The provided database 'foo' has an invalid username.")
 	if err.Error() != expected {
-		t.Errorf("azure: DoPollForAsynchronous failed to return an appropriate error message for a failed Operations. \n expected=%q \n got=%q",
+		t.Fatalf("azure: DoPollForAsynchronous failed to return an appropriate error message for a failed Operations. \n expected=%q \n got=%q",
 			expected, err.Error())
 	}
 
@@ -900,7 +900,7 @@ func TestDoPollForAsynchronous_ReturnsErrorForFirstPutWithUnknownError(t *testin
 
 	expected := makeLongRunningOperationErrorString("Unknown", "None")
 	if err.Error() != expected {
-		t.Errorf("azure: DoPollForAsynchronous failed to return an appropriate error message for a failed Operations. \n expected=%q \n got=%q",
+		t.Fatalf("azure: DoPollForAsynchronous failed to return an appropriate error message for a failed Operations. \n expected=%q \n got=%q",
 			expected, err.Error())
 	}
 
@@ -919,7 +919,7 @@ func TestDoPollForAsynchronous_ReturnsErrorForFirstPutRequest(t *testing.T) {
 
 	expected := makeLongRunningOperationErrorString("NetcfgInvalidSubnet", "Subnet is not valid in virtual network.")
 	if err.Error() != expected {
-		t.Errorf("azure: DoPollForAsynchronous failed to return an appropriate error message for a failed Operations. \n expected=%q \n got=%q", expected, err.Error())
+		t.Fatalf("azure: DoPollForAsynchronous failed to return an appropriate error message for a failed Operations. \n expected=%q \n got=%q", expected, err.Error())
 	}
 
 	autorest.Respond(r,
@@ -940,7 +940,7 @@ func TestDoPollForAsynchronous_ReturnsNoErrorForSuccessfulOperations(t *testing.
 		DoPollForAsynchronous(time.Millisecond))
 
 	if err != nil {
-		t.Errorf("azure: DoPollForAsynchronous returned an error for a successful OperationResource")
+		t.Fatalf("azure: DoPollForAsynchronous returned an error for a successful OperationResource")
 	}
 
 	autorest.Respond(r,
@@ -964,10 +964,10 @@ func TestDoPollForAsynchronous_StopsPollingIfItReceivesAnInvalidOperationResourc
 		DoPollForAsynchronous(time.Millisecond))
 
 	if client.Attempts() > 4 {
-		t.Errorf("azure: DoPollForAsynchronous failed to stop polling after receiving an invalid OperationResource")
+		t.Fatalf("azure: DoPollForAsynchronous failed to stop polling after receiving an invalid OperationResource")
 	}
 	if err == nil {
-		t.Errorf("azure: DoPollForAsynchronous failed to return an error after receving an invalid OperationResource")
+		t.Fatalf("azure: DoPollForAsynchronous failed to return an error after receving an invalid OperationResource")
 	}
 
 	autorest.Respond(r,

--- a/autorest/azure/azure_test.go
+++ b/autorest/azure/azure_test.go
@@ -48,7 +48,7 @@ func TestWithReturningClientIDReturnsError(t *testing.T) {
 		WithReturningClientID(uuid))
 
 	if errOut == nil || errIn != errOut {
-		t.Errorf("azure: WithReturningClientID failed to exit early when receiving an error -- expected (%v), received (%v)",
+		t.Fatalf("azure: WithReturningClientID failed to exit early when receiving an error -- expected (%v), received (%v)",
 			errIn, errOut)
 	}
 }
@@ -59,7 +59,7 @@ func TestWithClientID(t *testing.T) {
 		WithClientID(uuid))
 
 	if req.Header.Get(HeaderClientID) != uuid {
-		t.Errorf("azure: WithClientID failed to set %s -- expected %s, received %s",
+		t.Fatalf("azure: WithClientID failed to set %s -- expected %s, received %s",
 			HeaderClientID, uuid, req.Header.Get(HeaderClientID))
 	}
 }
@@ -70,7 +70,7 @@ func TestWithReturnClientID(t *testing.T) {
 		WithReturnClientID(b))
 
 	if req.Header.Get(HeaderReturnClientID) != strconv.FormatBool(b) {
-		t.Errorf("azure: WithReturnClientID failed to set %s -- expected %s, received %s",
+		t.Fatalf("azure: WithReturnClientID failed to set %s -- expected %s, received %s",
 			HeaderClientID, strconv.FormatBool(b), req.Header.Get(HeaderClientID))
 	}
 }
@@ -81,7 +81,7 @@ func TestExtractClientID(t *testing.T) {
 	mocks.SetResponseHeader(resp, HeaderClientID, uuid)
 
 	if ExtractClientID(resp) != uuid {
-		t.Errorf("azure: ExtractClientID failed to extract the %s -- expected %s, received %s",
+		t.Fatalf("azure: ExtractClientID failed to extract the %s -- expected %s, received %s",
 			HeaderClientID, uuid, ExtractClientID(resp))
 	}
 }
@@ -92,27 +92,27 @@ func TestExtractRequestID(t *testing.T) {
 	mocks.SetResponseHeader(resp, HeaderRequestID, uuid)
 
 	if ExtractRequestID(resp) != uuid {
-		t.Errorf("azure: ExtractRequestID failed to extract the %s -- expected %s, received %s",
+		t.Fatalf("azure: ExtractRequestID failed to extract the %s -- expected %s, received %s",
 			HeaderRequestID, uuid, ExtractRequestID(resp))
 	}
 }
 
 func TestIsAzureError_ReturnsTrueForAzureError(t *testing.T) {
 	if !IsAzureError(&RequestError{}) {
-		t.Errorf("azure: IsAzureError failed to return true for an Azure Service error")
+		t.Fatalf("azure: IsAzureError failed to return true for an Azure Service error")
 	}
 }
 
 func TestIsAzureError_ReturnsFalseForNonAzureError(t *testing.T) {
 	if IsAzureError(fmt.Errorf("An Error")) {
-		t.Errorf("azure: IsAzureError return true for an non-Azure Service error")
+		t.Fatalf("azure: IsAzureError return true for an non-Azure Service error")
 	}
 }
 
 func TestNewErrorWithError_UsesReponseStatusCode(t *testing.T) {
 	e := NewErrorWithError(fmt.Errorf("Error"), "packageType", "method", mocks.NewResponseWithStatus("Forbidden", http.StatusForbidden), "message")
 	if e.StatusCode != http.StatusForbidden {
-		t.Errorf("azure: NewErrorWithError failed to use the Status Code of the passed Response -- expected %v, received %v", http.StatusForbidden, e.StatusCode)
+		t.Fatalf("azure: NewErrorWithError failed to use the Status Code of the passed Response -- expected %v, received %v", http.StatusForbidden, e.StatusCode)
 	}
 }
 
@@ -124,7 +124,7 @@ func TestNewErrorWithError_ReturnsUnwrappedError(t *testing.T) {
 	e2 := NewErrorWithError(&e1, "packageType", "method", nil, "message")
 
 	if !reflect.DeepEqual(e1, e2) {
-		t.Errorf("azure: NewErrorWithError wrapped an RequestError -- expected %T, received %T", e1, e2)
+		t.Fatalf("azure: NewErrorWithError wrapped an RequestError -- expected %T, received %T", e1, e2)
 	}
 }
 
@@ -133,7 +133,7 @@ func TestNewErrorWithError_WrapsAnError(t *testing.T) {
 	var e2 interface{} = NewErrorWithError(e1, "packageType", "method", nil, "message")
 
 	if _, ok := e2.(RequestError); !ok {
-		t.Errorf("azure: NewErrorWithError failed to wrap a standard error -- received %T", e2)
+		t.Fatalf("azure: NewErrorWithError failed to wrap a standard error -- received %T", e2)
 	}
 }
 
@@ -212,7 +212,7 @@ func TestWithErrorUnlessStatusCode_FoundAzureError(t *testing.T) {
 	defer r.Body.Close()
 	b, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	if string(b) != j {
 		t.Fatalf("response body is wrong. got=%q expected=%q", string(b), j)

--- a/autorest/azure/devicetoken_test.go
+++ b/autorest/azure/devicetoken_test.go
@@ -50,11 +50,11 @@ func TestDeviceCodeIncludesResource(t *testing.T) {
 
 	code, err := InitiateDeviceAuth(client, TestOAuthConfig, TestClientID, TestResource)
 	if err != nil {
-		t.Errorf("azure: unexpected error initiating device auth")
+		t.Fatalf("azure: unexpected error initiating device auth")
 	}
 
 	if code.Resource != TestResource {
-		t.Errorf("azure: InitiateDeviceAuth failed to stash the resource in the DeviceCode struct")
+		t.Fatalf("azure: InitiateDeviceAuth failed to stash the resource in the DeviceCode struct")
 	}
 }
 
@@ -65,7 +65,7 @@ func TestDeviceCodeReturnsErrorIfSendingFails(t *testing.T) {
 
 	_, err := InitiateDeviceAuth(client, TestOAuthConfig, TestClientID, TestResource)
 	if err == nil || !strings.Contains(err.Error(), errCodeSendingFails) {
-		t.Errorf("azure: failed to get correct error expected(%s) actual(%s)", errCodeSendingFails, err.Error())
+		t.Fatalf("azure: failed to get correct error expected(%s) actual(%s)", errCodeSendingFails, err.Error())
 	}
 }
 
@@ -77,11 +77,11 @@ func TestDeviceCodeReturnsErrorIfBadRequest(t *testing.T) {
 
 	_, err := InitiateDeviceAuth(client, TestOAuthConfig, TestClientID, TestResource)
 	if err == nil || !strings.Contains(err.Error(), errCodeHandlingFails) {
-		t.Errorf("azure: failed to get correct error expected(%s) actual(%s)", errCodeHandlingFails, err.Error())
+		t.Fatalf("azure: failed to get correct error expected(%s) actual(%s)", errCodeHandlingFails, err.Error())
 	}
 
 	if body.IsOpen() {
-		t.Errorf("response body was left open!")
+		t.Fatalf("response body was left open!")
 	}
 }
 
@@ -94,11 +94,11 @@ func TestDeviceCodeReturnsErrorIfCannotDeserializeDeviceCode(t *testing.T) {
 
 	_, err := InitiateDeviceAuth(client, TestOAuthConfig, TestClientID, TestResource)
 	if err == nil || !strings.Contains(err.Error(), errCodeHandlingFails) {
-		t.Errorf("azure: failed to get correct error expected(%s) actual(%s)", errCodeHandlingFails, err.Error())
+		t.Fatalf("azure: failed to get correct error expected(%s) actual(%s)", errCodeHandlingFails, err.Error())
 	}
 
 	if body.IsOpen() {
-		t.Errorf("response body was left open!")
+		t.Fatalf("response body was left open!")
 	}
 }
 
@@ -118,11 +118,11 @@ func TestDeviceTokenReturns(t *testing.T) {
 
 	_, err := WaitForUserCompletion(client, deviceCode())
 	if err != nil {
-		t.Errorf("azure: got error unexpectedly")
+		t.Fatalf("azure: got error unexpectedly")
 	}
 
 	if body.IsOpen() {
-		t.Errorf("response body was left open!")
+		t.Fatalf("response body was left open!")
 	}
 }
 
@@ -133,7 +133,7 @@ func TestDeviceTokenReturnsErrorIfSendingFails(t *testing.T) {
 
 	_, err := WaitForUserCompletion(client, deviceCode())
 	if err == nil || !strings.Contains(err.Error(), errTokenSendingFails) {
-		t.Errorf("azure: failed to get correct error expected(%s) actual(%s)", errTokenSendingFails, err.Error())
+		t.Fatalf("azure: failed to get correct error expected(%s) actual(%s)", errTokenSendingFails, err.Error())
 	}
 }
 
@@ -145,11 +145,11 @@ func TestDeviceTokenReturnsErrorIfServerError(t *testing.T) {
 
 	_, err := WaitForUserCompletion(client, deviceCode())
 	if err == nil || !strings.Contains(err.Error(), errTokenHandlingFails) {
-		t.Errorf("azure: failed to get correct error expected(%s) actual(%s)", errTokenHandlingFails, err.Error())
+		t.Fatalf("azure: failed to get correct error expected(%s) actual(%s)", errTokenHandlingFails, err.Error())
 	}
 
 	if body.IsOpen() {
-		t.Errorf("response body was left open!")
+		t.Fatalf("response body was left open!")
 	}
 }
 
@@ -162,11 +162,11 @@ func TestDeviceTokenReturnsErrorIfCannotDeserializeDeviceToken(t *testing.T) {
 
 	_, err := WaitForUserCompletion(client, deviceCode())
 	if err == nil || !strings.Contains(err.Error(), errTokenHandlingFails) {
-		t.Errorf("azure: failed to get correct error expected(%s) actual(%s)", errTokenHandlingFails, err.Error())
+		t.Fatalf("azure: failed to get correct error expected(%s) actual(%s)", errTokenHandlingFails, err.Error())
 	}
 
 	if body.IsOpen() {
-		t.Errorf("response body was left open!")
+		t.Fatalf("response body was left open!")
 	}
 }
 
@@ -182,11 +182,11 @@ func TestDeviceTokenReturnsErrorIfAuthorizationPending(t *testing.T) {
 
 	_, err := CheckForUserCompletion(client, deviceCode())
 	if err != ErrDeviceAuthorizationPending {
-		t.Errorf("!!!")
+		t.Fatalf("!!!")
 	}
 
 	if body.IsOpen() {
-		t.Errorf("response body was left open!")
+		t.Fatalf("response body was left open!")
 	}
 }
 
@@ -198,11 +198,11 @@ func TestDeviceTokenReturnsErrorIfSlowDown(t *testing.T) {
 
 	_, err := CheckForUserCompletion(client, deviceCode())
 	if err != ErrDeviceSlowDown {
-		t.Errorf("!!!")
+		t.Fatalf("!!!")
 	}
 
 	if body.IsOpen() {
-		t.Errorf("response body was left open!")
+		t.Fatalf("response body was left open!")
 	}
 }
 
@@ -234,7 +234,7 @@ func TestDeviceTokenSucceedsWithIntermediateAuthPending(t *testing.T) {
 
 	_, err := WaitForUserCompletion(client, deviceCode())
 	if err != nil {
-		t.Errorf("unexpected error occurred")
+		t.Fatalf("unexpected error occurred")
 	}
 }
 
@@ -245,7 +245,7 @@ func TestDeviceTokenSucceedsWithIntermediateSlowDown(t *testing.T) {
 
 	_, err := WaitForUserCompletion(client, deviceCode())
 	if err != nil {
-		t.Errorf("unexpected error occurred")
+		t.Fatalf("unexpected error occurred")
 	}
 }
 
@@ -257,11 +257,11 @@ func TestDeviceTokenReturnsErrorIfAccessDenied(t *testing.T) {
 
 	_, err := WaitForUserCompletion(client, deviceCode())
 	if err != ErrDeviceAccessDenied {
-		t.Errorf("azure: got wrong error expected(%s) actual(%s)", ErrDeviceAccessDenied.Error(), err.Error())
+		t.Fatalf("azure: got wrong error expected(%s) actual(%s)", ErrDeviceAccessDenied.Error(), err.Error())
 	}
 
 	if body.IsOpen() {
-		t.Errorf("response body was left open!")
+		t.Fatalf("response body was left open!")
 	}
 }
 
@@ -273,11 +273,11 @@ func TestDeviceTokenReturnsErrorIfCodeExpired(t *testing.T) {
 
 	_, err := WaitForUserCompletion(client, deviceCode())
 	if err != ErrDeviceCodeExpired {
-		t.Errorf("azure: got wrong error expected(%s) actual(%s)", ErrDeviceCodeExpired.Error(), err.Error())
+		t.Fatalf("azure: got wrong error expected(%s) actual(%s)", ErrDeviceCodeExpired.Error(), err.Error())
 	}
 
 	if body.IsOpen() {
-		t.Errorf("response body was left open!")
+		t.Fatalf("response body was left open!")
 	}
 }
 
@@ -289,13 +289,13 @@ func TestDeviceTokenReturnsErrorForUnknownError(t *testing.T) {
 
 	_, err := WaitForUserCompletion(client, deviceCode())
 	if err == nil {
-		t.Errorf("failed to get error")
+		t.Fatalf("failed to get error")
 	}
 	if err != ErrDeviceGeneric {
-		t.Errorf("azure: got wrong error expected(%s) actual(%s)", ErrDeviceGeneric.Error(), err.Error())
+		t.Fatalf("azure: got wrong error expected(%s) actual(%s)", ErrDeviceGeneric.Error(), err.Error())
 	}
 
 	if body.IsOpen() {
-		t.Errorf("response body was left open!")
+		t.Fatalf("response body was left open!")
 	}
 }

--- a/autorest/azure/environments_test.go
+++ b/autorest/azure/environments_test.go
@@ -9,22 +9,22 @@ func TestOAuthConfigForTenant(t *testing.T) {
 
 	config, err := az.OAuthConfigForTenant("tenant-id-test")
 	if err != nil {
-		t.Errorf("autorest/azure: Unexpected error while retrieving oauth configuration for tenant: %v.", err)
+		t.Fatalf("autorest/azure: Unexpected error while retrieving oauth configuration for tenant: %v.", err)
 	}
 
 	expected := "https://login.microsoftonline.com/tenant-id-test/oauth2/authorize?api-version=1.0"
 	if config.AuthorizeEndpoint.String() != expected {
-		t.Errorf("autorest/azure: Incorrect authorize url for Tenant from Environment. expected(%s). actual(%s).", expected, config.AuthorizeEndpoint)
+		t.Fatalf("autorest/azure: Incorrect authorize url for Tenant from Environment. expected(%s). actual(%s).", expected, config.AuthorizeEndpoint)
 	}
 
 	expected = "https://login.microsoftonline.com/tenant-id-test/oauth2/token?api-version=1.0"
 	if config.TokenEndpoint.String() != expected {
-		t.Errorf("autorest/azure: Incorrect authorize url for Tenant from Environment. expected(%s). actual(%s).", expected, config.TokenEndpoint)
+		t.Fatalf("autorest/azure: Incorrect authorize url for Tenant from Environment. expected(%s). actual(%s).", expected, config.TokenEndpoint)
 	}
 
 	expected = "https://login.microsoftonline.com/tenant-id-test/oauth2/devicecode?api-version=1.0"
 	if config.DeviceCodeEndpoint.String() != expected {
-		t.Errorf("autorest/azure: Incorrect devicecode url for Tenant from Environment. expected(%s). actual(%s).", expected, config.DeviceCodeEndpoint)
+		t.Fatalf("autorest/azure: Incorrect devicecode url for Tenant from Environment. expected(%s). actual(%s).", expected, config.DeviceCodeEndpoint)
 	}
 
 }

--- a/autorest/azure/persist_test.go
+++ b/autorest/azure/persist_test.go
@@ -32,12 +32,12 @@ var TestToken = Token{
 func writeTestTokenFile(t *testing.T, suffix string, contents string) *os.File {
 	f, err := ioutil.TempFile(os.TempDir(), suffix)
 	if err != nil {
-		t.Errorf("azure: unexpected error when creating temp file: %v", err)
+		t.Fatalf("azure: unexpected error when creating temp file: %v", err)
 	}
 
 	_, err = f.Write([]byte(contents))
 	if err != nil {
-		t.Errorf("azure: unexpected error when writing temp test file: %v", err)
+		t.Fatalf("azure: unexpected error when writing temp test file: %v", err)
 	}
 
 	return f
@@ -50,11 +50,11 @@ func TestLoadToken(t *testing.T) {
 	expectedToken := TestToken
 	actualToken, err := LoadToken(f.Name())
 	if err != nil {
-		t.Errorf("azure: unexpected error loading token from file: %v", err)
+		t.Fatalf("azure: unexpected error loading token from file: %v", err)
 	}
 
 	if *actualToken != expectedToken {
-		t.Errorf("azure: failed to decode properly expected(%v) actual(%v)", expectedToken, *actualToken)
+		t.Fatalf("azure: failed to decode properly expected(%v) actual(%v)", expectedToken, *actualToken)
 	}
 }
 
@@ -62,7 +62,7 @@ func TestLoadTokenFailsBadPath(t *testing.T) {
 	_, err := LoadToken("/tmp/this_file_should_never_exist_really")
 	expectedSubstring := "failed to open file"
 	if err == nil || !strings.Contains(err.Error(), expectedSubstring) {
-		t.Errorf("azure: failed to get correct error expected(%s) actual(%s)", expectedSubstring, err.Error())
+		t.Fatalf("azure: failed to get correct error expected(%s) actual(%s)", expectedSubstring, err.Error())
 	}
 }
 
@@ -74,7 +74,7 @@ func TestLoadTokenFailsBadJson(t *testing.T) {
 	_, err := LoadToken(f.Name())
 	expectedSubstring := "failed to decode contents of file"
 	if err == nil || !strings.Contains(err.Error(), expectedSubstring) {
-		t.Errorf("azure: failed to get correct error expected(%s) actual(%s)", expectedSubstring, err.Error())
+		t.Fatalf("azure: failed to get correct error expected(%s) actual(%s)", expectedSubstring, err.Error())
 	}
 }
 
@@ -87,21 +87,21 @@ func token() *Token {
 func TestSaveToken(t *testing.T) {
 	f, err := ioutil.TempFile("", "testloadtoken")
 	if err != nil {
-		t.Errorf("azure: unexpected error when creating temp file: %v", err)
+		t.Fatalf("azure: unexpected error when creating temp file: %v", err)
 	}
 	defer os.Remove(f.Name())
 
 	mode := os.ModePerm & 0642
 	err = SaveToken(f.Name(), mode, *token())
 	if err != nil {
-		t.Errorf("azure: unexpected error saving token to file: %v", err)
+		t.Fatalf("azure: unexpected error saving token to file: %v", err)
 	}
 	fi, err := os.Stat(f.Name()) // open a new stat as held ones are not fresh
 	if err != nil {
-		t.Errorf("azure: stat failed: %v", err)
+		t.Fatalf("azure: stat failed: %v", err)
 	}
 	if perm := fi.Mode().Perm(); perm != mode {
-		t.Errorf("azure: wrong file perm. got:%s; expected:%s file :%s", perm, mode, f.Name())
+		t.Fatalf("azure: wrong file perm. got:%s; expected:%s file :%s", perm, mode, f.Name())
 	}
 
 	var actualToken Token
@@ -111,12 +111,12 @@ func TestSaveToken(t *testing.T) {
 
 	contents, err := ioutil.ReadFile(f.Name())
 	if err != nil {
-		t.Error("!!")
+		t.Fatal("!!")
 	}
 	json.Unmarshal(contents, actualToken)
 
 	if !reflect.DeepEqual(actualToken, expectedToken) {
-		t.Error("azure: token was not serialized correctly")
+		t.Fatal("azure: token was not serialized correctly")
 	}
 }
 
@@ -124,7 +124,7 @@ func TestSaveTokenFailsNoPermission(t *testing.T) {
 	err := SaveToken("/usr/thiswontwork/atall", 0644, *token())
 	expectedSubstring := "failed to create directory"
 	if err == nil || !strings.Contains(err.Error(), expectedSubstring) {
-		t.Errorf("azure: failed to get correct error expected(%s) actual(%s)", expectedSubstring, err.Error())
+		t.Fatalf("azure: failed to get correct error expected(%s) actual(%s)", expectedSubstring, err.Error())
 	}
 }
 
@@ -132,6 +132,6 @@ func TestSaveTokenFailsCantCreate(t *testing.T) {
 	err := SaveToken("/thiswontwork", 0644, *token())
 	expectedSubstring := "failed to move temporary token to desired output location."
 	if err == nil || !strings.Contains(err.Error(), expectedSubstring) {
-		t.Errorf("azure: failed to get correct error expected(%s) actual(%s)", expectedSubstring, err.Error())
+		t.Fatalf("azure: failed to get correct error expected(%s) actual(%s)", expectedSubstring, err.Error())
 	}
 }

--- a/autorest/client_test.go
+++ b/autorest/client_test.go
@@ -24,7 +24,7 @@ func TestLoggingInspectorWithInspection(t *testing.T) {
 		c.WithInspection())
 
 	if len(b.String()) <= 0 {
-		t.Error("autorest: LoggingInspector#WithInspection did not record Request to the log")
+		t.Fatal("autorest: LoggingInspector#WithInspection did not record Request to the log")
 	}
 }
 
@@ -40,7 +40,7 @@ func TestLoggingInspectorWithInspectionEmitsErrors(t *testing.T) {
 		c.WithInspection())
 
 	if len(b.String()) <= 0 {
-		t.Error("autorest: LoggingInspector#WithInspection did not record Request to the log")
+		t.Fatal("autorest: LoggingInspector#WithInspection did not record Request to the log")
 	}
 }
 
@@ -56,7 +56,7 @@ func TestLoggingInspectorWithInspectionRestoresBody(t *testing.T) {
 
 	s, _ := ioutil.ReadAll(r.Body)
 	if len(s) <= 0 {
-		t.Error("autorest: LoggingInspector#WithInspection did not restore the Request body")
+		t.Fatal("autorest: LoggingInspector#WithInspection did not restore the Request body")
 	}
 }
 
@@ -70,7 +70,7 @@ func TestLoggingInspectorByInspecting(t *testing.T) {
 		c.ByInspecting())
 
 	if len(b.String()) <= 0 {
-		t.Error("autorest: LoggingInspector#ByInspection did not record Response to the log")
+		t.Fatal("autorest: LoggingInspector#ByInspection did not record Response to the log")
 	}
 }
 
@@ -86,7 +86,7 @@ func TestLoggingInspectorByInspectingEmitsErrors(t *testing.T) {
 		c.ByInspecting())
 
 	if len(b.String()) <= 0 {
-		t.Error("autorest: LoggingInspector#ByInspection did not record Response to the log")
+		t.Fatal("autorest: LoggingInspector#ByInspection did not record Response to the log")
 	}
 }
 
@@ -102,7 +102,7 @@ func TestLoggingInspectorByInspectingRestoresBody(t *testing.T) {
 
 	s, _ := ioutil.ReadAll(r.Body)
 	if len(s) <= 0 {
-		t.Error("autorest: LoggingInspector#ByInspecting did not restore the Response body")
+		t.Fatal("autorest: LoggingInspector#ByInspecting did not restore the Response body")
 	}
 }
 
@@ -111,7 +111,7 @@ func TestNewClientWithUserAgent(t *testing.T) {
 	c := NewClientWithUserAgent(ua)
 
 	if c.UserAgent != ua {
-		t.Errorf("autorest: NewClientWithUserAgent failed to set the UserAgent -- expected %s, received %s",
+		t.Fatalf("autorest: NewClientWithUserAgent failed to set the UserAgent -- expected %s, received %s",
 			ua, c.UserAgent)
 	}
 }
@@ -120,7 +120,7 @@ func TestClientSenderReturnsHttpClientByDefault(t *testing.T) {
 	c := Client{}
 
 	if fmt.Sprintf("%T", c.sender()) != "*http.Client" {
-		t.Error("autorest: Client#sender failed to return http.Client by default")
+		t.Fatal("autorest: Client#sender failed to return http.Client by default")
 	}
 }
 
@@ -131,7 +131,7 @@ func TestClientSenderReturnsSetSender(t *testing.T) {
 	c.Sender = s
 
 	if c.sender() != s {
-		t.Error("autorest: Client#sender failed to return set Sender")
+		t.Fatal("autorest: Client#sender failed to return set Sender")
 	}
 }
 
@@ -143,7 +143,7 @@ func TestClientDoInvokesSender(t *testing.T) {
 
 	c.Do(&http.Request{})
 	if s.Attempts() != 1 {
-		t.Error("autorest: Client#Do failed to invoke the Sender")
+		t.Fatal("autorest: Client#Do failed to invoke the Sender")
 	}
 }
 
@@ -155,7 +155,7 @@ func TestClientDoSetsUserAgent(t *testing.T) {
 	c.Do(r)
 
 	if r.UserAgent() != ua {
-		t.Errorf("autorest: Client#Do failed to correctly set User-Agent header: %s=%s",
+		t.Fatalf("autorest: Client#Do failed to correctly set User-Agent header: %s=%s",
 			http.CanonicalHeaderKey(headerUserAgent), r.UserAgent())
 	}
 }
@@ -167,7 +167,7 @@ func TestClientDoSetsAuthorization(t *testing.T) {
 
 	c.Do(r)
 	if len(r.Header.Get(http.CanonicalHeaderKey(headerAuthorization))) <= 0 {
-		t.Errorf("autorest: Client#Send failed to set Authorization header -- %s=%s",
+		t.Fatalf("autorest: Client#Send failed to set Authorization header -- %s=%s",
 			http.CanonicalHeaderKey(headerAuthorization),
 			r.Header.Get(http.CanonicalHeaderKey(headerAuthorization)))
 	}
@@ -181,7 +181,7 @@ func TestClientDoInvokesRequestInspector(t *testing.T) {
 
 	c.Do(r)
 	if !i.wasInvoked {
-		t.Error("autorest: Client#Send failed to invoke the RequestInspector")
+		t.Fatal("autorest: Client#Send failed to invoke the RequestInspector")
 	}
 }
 
@@ -193,7 +193,7 @@ func TestClientDoInvokesResponseInspector(t *testing.T) {
 
 	c.Do(r)
 	if !i.wasInvoked {
-		t.Error("autorest: Client#Send failed to invoke the ResponseInspector")
+		t.Fatal("autorest: Client#Send failed to invoke the ResponseInspector")
 	}
 }
 
@@ -205,7 +205,7 @@ func TestClientDoReturnsErrorIfPrepareFails(t *testing.T) {
 
 	_, err := c.Do(&http.Request{})
 	if err == nil {
-		t.Errorf("autorest: Client#Do failed to return an error when Prepare failed")
+		t.Fatalf("autorest: Client#Do failed to return an error when Prepare failed")
 	}
 }
 
@@ -217,7 +217,7 @@ func TestClientDoDoesNotSendIfPrepareFails(t *testing.T) {
 
 	c.Do(&http.Request{})
 	if s.Attempts() > 0 {
-		t.Error("autorest: Client#Do failed to invoke the Sender")
+		t.Fatal("autorest: Client#Do failed to invoke the Sender")
 	}
 }
 
@@ -225,7 +225,7 @@ func TestClientAuthorizerReturnsNullAuthorizerByDefault(t *testing.T) {
 	c := Client{}
 
 	if fmt.Sprintf("%T", c.authorizer()) != "autorest.NullAuthorizer" {
-		t.Error("autorest: Client#authorizer failed to return the NullAuthorizer by default")
+		t.Fatal("autorest: Client#authorizer failed to return the NullAuthorizer by default")
 	}
 }
 
@@ -234,7 +234,7 @@ func TestClientAuthorizerReturnsSetAuthorizer(t *testing.T) {
 	c.Authorizer = mockAuthorizer{}
 
 	if fmt.Sprintf("%T", c.authorizer()) != "autorest.mockAuthorizer" {
-		t.Error("autorest: Client#authorizer failed to return the set Authorizer")
+		t.Fatal("autorest: Client#authorizer failed to return the set Authorizer")
 	}
 }
 
@@ -246,7 +246,7 @@ func TestClientWithAuthorizer(t *testing.T) {
 		c.WithAuthorization())
 
 	if req.Header.Get(headerAuthorization) == "" {
-		t.Error("autorest: Client#WithAuthorizer failed to return the WithAuthorizer from the active Authorizer")
+		t.Fatal("autorest: Client#WithAuthorizer failed to return the WithAuthorizer from the active Authorizer")
 	}
 }
 
@@ -259,7 +259,7 @@ func TestClientWithInspection(t *testing.T) {
 		c.WithInspection())
 
 	if !r.wasInvoked {
-		t.Error("autorest: Client#WithInspection failed to invoke RequestInspector")
+		t.Fatal("autorest: Client#WithInspection failed to invoke RequestInspector")
 	}
 }
 
@@ -271,7 +271,7 @@ func TestClientWithInspectionSetsDefault(t *testing.T) {
 		c.WithInspection())
 
 	if !reflect.DeepEqual(r1, r2) {
-		t.Error("autorest: Client#WithInspection failed to provide a default RequestInspector")
+		t.Fatal("autorest: Client#WithInspection failed to provide a default RequestInspector")
 	}
 }
 
@@ -284,7 +284,7 @@ func TestClientByInspecting(t *testing.T) {
 		c.ByInspecting())
 
 	if !r.wasInvoked {
-		t.Error("autorest: Client#ByInspecting failed to invoke ResponseInspector")
+		t.Fatal("autorest: Client#ByInspecting failed to invoke ResponseInspector")
 	}
 }
 
@@ -296,7 +296,7 @@ func TestClientByInspectingSetsDefault(t *testing.T) {
 		c.ByInspecting())
 
 	if !reflect.DeepEqual(r, &http.Response{}) {
-		t.Error("autorest: Client#ByInspecting failed to provide a default ResponseInspector")
+		t.Fatal("autorest: Client#ByInspecting failed to provide a default ResponseInspector")
 	}
 }
 

--- a/autorest/date/date_test.go
+++ b/autorest/date/date_test.go
@@ -121,30 +121,30 @@ func ExampleDate_UnmarshalText() {
 func TestDateString(t *testing.T) {
 	d, err := ParseDate("2001-02-03")
 	if err != nil {
-		t.Errorf("date: String failed (%v)", err)
+		t.Fatalf("date: String failed (%v)", err)
 	}
 	if d.String() != "2001-02-03" {
-		t.Errorf("date: String failed (%v)", d.String())
+		t.Fatalf("date: String failed (%v)", d.String())
 	}
 }
 
 func TestDateBinaryRoundTrip(t *testing.T) {
 	d1, err := ParseDate("2001-02-03")
 	if err != nil {
-		t.Errorf("date: ParseDate failed (%v)", err)
+		t.Fatalf("date: ParseDate failed (%v)", err)
 	}
 	t1, err := d1.MarshalBinary()
 	if err != nil {
-		t.Errorf("date: MarshalBinary failed (%v)", err)
+		t.Fatalf("date: MarshalBinary failed (%v)", err)
 	}
 
 	d2 := Date{}
 	if err = d2.UnmarshalBinary(t1); err != nil {
-		t.Errorf("date: UnmarshalBinary failed (%v)", err)
+		t.Fatalf("date: UnmarshalBinary failed (%v)", err)
 	}
 
 	if !reflect.DeepEqual(d1, d2) {
-		t.Errorf("date: Round-trip Binary failed (%v, %v)", d1, d2)
+		t.Fatalf("date: Round-trip Binary failed (%v, %v)", d1, d2)
 	}
 }
 
@@ -156,40 +156,40 @@ func TestDateJSONRoundTrip(t *testing.T) {
 	d1 := s{}
 	d1.Date, err = ParseDate("2001-02-03")
 	if err != nil {
-		t.Errorf("date: ParseDate failed (%v)", err)
+		t.Fatalf("date: ParseDate failed (%v)", err)
 	}
 
 	j, err := json.Marshal(d1)
 	if err != nil {
-		t.Errorf("date: MarshalJSON failed (%v)", err)
+		t.Fatalf("date: MarshalJSON failed (%v)", err)
 	}
 
 	d2 := s{}
 	if err = json.Unmarshal(j, &d2); err != nil {
-		t.Errorf("date: UnmarshalJSON failed (%v)", err)
+		t.Fatalf("date: UnmarshalJSON failed (%v)", err)
 	}
 
 	if !reflect.DeepEqual(d1, d2) {
-		t.Errorf("date: Round-trip JSON failed (%v, %v)", d1, d2)
+		t.Fatalf("date: Round-trip JSON failed (%v, %v)", d1, d2)
 	}
 }
 
 func TestDateTextRoundTrip(t *testing.T) {
 	d1, err := ParseDate("2001-02-03")
 	if err != nil {
-		t.Errorf("date: ParseDate failed (%v)", err)
+		t.Fatalf("date: ParseDate failed (%v)", err)
 	}
 	t1, err := d1.MarshalText()
 	if err != nil {
-		t.Errorf("date: MarshalText failed (%v)", err)
+		t.Fatalf("date: MarshalText failed (%v)", err)
 	}
 	d2 := Date{}
 	if err = d2.UnmarshalText(t1); err != nil {
-		t.Errorf("date: UnmarshalText failed (%v)", err)
+		t.Fatalf("date: UnmarshalText failed (%v)", err)
 	}
 
 	if !reflect.DeepEqual(d1, d2) {
-		t.Errorf("date: Round-trip Text failed (%v, %v)", d1, d2)
+		t.Fatalf("date: Round-trip Text failed (%v, %v)", d1, d2)
 	}
 }
 
@@ -197,7 +197,7 @@ func TestDateToTime(t *testing.T) {
 	var d Date
 	d, err := ParseDate("2001-02-03")
 	if err != nil {
-		t.Errorf("date: ParseDate failed (%v)", err)
+		t.Fatalf("date: ParseDate failed (%v)", err)
 	}
 	var _ time.Time = d.ToTime()
 }
@@ -209,7 +209,7 @@ func TestDateUnmarshalJSONReturnsError(t *testing.T) {
 	j := `{"date" : "February 3, 2001"}`
 
 	if err := json.Unmarshal([]byte(j), &d); err == nil {
-		t.Error("date: Date failed to return error for malformed JSON date")
+		t.Fatal("date: Date failed to return error for malformed JSON date")
 	}
 }
 
@@ -218,6 +218,6 @@ func TestDateUnmarshalTextReturnsError(t *testing.T) {
 	txt := "February 3, 2001"
 
 	if err := d.UnmarshalText([]byte(txt)); err == nil {
-		t.Error("date: Date failed to return error for malformed Text date")
+		t.Fatal("date: Date failed to return error for malformed Text date")
 	}
 }

--- a/autorest/date/time_test.go
+++ b/autorest/date/time_test.go
@@ -94,7 +94,7 @@ func TestUnmarshalTextforInvalidDate(t *testing.T) {
 	dt := "2001-02-03T04:05:06AAA"
 
 	if err := d.UnmarshalText([]byte(dt)); err == nil {
-		t.Errorf("date: Time#Unmarshal was expecting error for invalid date")
+		t.Fatalf("date: Time#Unmarshal was expecting error for invalid date")
 	}
 }
 
@@ -103,7 +103,7 @@ func TestUnmarshalJSONforInvalidDate(t *testing.T) {
 	dt := `"2001-02-03T04:05:06AAA"`
 
 	if err := d.UnmarshalJSON([]byte(dt)); err == nil {
-		t.Errorf("date: Time#Unmarshal was expecting error for invalid date")
+		t.Fatalf("date: Time#Unmarshal was expecting error for invalid date")
 	}
 }
 
@@ -114,35 +114,35 @@ func TestTimeString(t *testing.T) {
 	}
 	d := Time{ti}
 	if d.String() != "2001-02-03T04:05:06Z" {
-		t.Errorf("date: Time#String failed (%v)", d.String())
+		t.Fatalf("date: Time#String failed (%v)", d.String())
 	}
 }
 
 func TestTimeStringReturnsEmptyStringForError(t *testing.T) {
 	d := Time{Time: time.Date(20000, 01, 01, 01, 01, 01, 01, time.UTC)}
 	if d.String() != "" {
-		t.Errorf("date: Time#String failed empty string for an error")
+		t.Fatalf("date: Time#String failed empty string for an error")
 	}
 }
 
 func TestTimeBinaryRoundTrip(t *testing.T) {
 	ti, err := ParseTime(rfc3339, "2001-02-03T04:05:06Z")
 	if err != nil {
-		t.Errorf("date: Time#ParseTime failed (%v)", err)
+		t.Fatalf("date: Time#ParseTime failed (%v)", err)
 	}
 	d1 := Time{ti}
 	t1, err := d1.MarshalBinary()
 	if err != nil {
-		t.Errorf("date: Time#MarshalBinary failed (%v)", err)
+		t.Fatalf("date: Time#MarshalBinary failed (%v)", err)
 	}
 
 	d2 := Time{}
 	if err = d2.UnmarshalBinary(t1); err != nil {
-		t.Errorf("date: Time#UnmarshalBinary failed (%v)", err)
+		t.Fatalf("date: Time#UnmarshalBinary failed (%v)", err)
 	}
 
 	if !reflect.DeepEqual(d1, d2) {
-		t.Errorf("date:Round-trip Binary failed (%v, %v)", d1, d2)
+		t.Fatalf("date:Round-trip Binary failed (%v, %v)", d1, d2)
 	}
 }
 
@@ -153,43 +153,43 @@ func TestTimeJSONRoundTrip(t *testing.T) {
 
 	ti, err := ParseTime(rfc3339, "2001-02-03T04:05:06Z")
 	if err != nil {
-		t.Errorf("date: Time#ParseTime failed (%v)", err)
+		t.Fatalf("date: Time#ParseTime failed (%v)", err)
 	}
 
 	d1 := s{Time: Time{ti}}
 	j, err := json.Marshal(d1)
 	if err != nil {
-		t.Errorf("date: Time#MarshalJSON failed (%v)", err)
+		t.Fatalf("date: Time#MarshalJSON failed (%v)", err)
 	}
 
 	d2 := s{}
 	if err = json.Unmarshal(j, &d2); err != nil {
-		t.Errorf("date: Time#UnmarshalJSON failed (%v)", err)
+		t.Fatalf("date: Time#UnmarshalJSON failed (%v)", err)
 	}
 
 	if !reflect.DeepEqual(d1, d2) {
-		t.Errorf("date: Round-trip JSON failed (%v, %v)", d1, d2)
+		t.Fatalf("date: Round-trip JSON failed (%v, %v)", d1, d2)
 	}
 }
 
 func TestTimeTextRoundTrip(t *testing.T) {
 	ti, err := ParseTime(rfc3339, "2001-02-03T04:05:06Z")
 	if err != nil {
-		t.Errorf("date: Time#ParseTime failed (%v)", err)
+		t.Fatalf("date: Time#ParseTime failed (%v)", err)
 	}
 	d1 := Time{Time: ti}
 	t1, err := d1.MarshalText()
 	if err != nil {
-		t.Errorf("date: Time#MarshalText failed (%v)", err)
+		t.Fatalf("date: Time#MarshalText failed (%v)", err)
 	}
 
 	d2 := Time{}
 	if err = d2.UnmarshalText(t1); err != nil {
-		t.Errorf("date: Time#UnmarshalText failed (%v)", err)
+		t.Fatalf("date: Time#UnmarshalText failed (%v)", err)
 	}
 
 	if !reflect.DeepEqual(d1, d2) {
-		t.Errorf("date: Round-trip Text failed (%v, %v)", d1, d2)
+		t.Fatalf("date: Round-trip Text failed (%v, %v)", d1, d2)
 	}
 }
 
@@ -197,7 +197,7 @@ func TestTimeToTime(t *testing.T) {
 	ti, err := ParseTime(rfc3339, "2001-02-03T04:05:06Z")
 	d := Time{ti}
 	if err != nil {
-		t.Errorf("date: Time#ParseTime failed (%v)", err)
+		t.Fatalf("date: Time#ParseTime failed (%v)", err)
 	}
 	var _ time.Time = d.ToTime()
 }

--- a/autorest/date/timerfc1123_test.go
+++ b/autorest/date/timerfc1123_test.go
@@ -59,7 +59,7 @@ func TestTimeRFC1123MarshalJSONInvalid(t *testing.T) {
 	ti := time.Date(20000, 01, 01, 00, 00, 00, 00, time.UTC)
 	d := TimeRFC1123{ti}
 	if _, err := json.Marshal(d); err == nil {
-		t.Errorf("date: TimeRFC1123#Marshal failed for invalid date")
+		t.Fatalf("date: TimeRFC1123#Marshal failed for invalid date")
 	}
 }
 
@@ -105,7 +105,7 @@ func TestUnmarshalJSONforInvalidDateRfc1123(t *testing.T) {
 	dt := `"Mon, 02 Jan 2000000 15:05 MST"`
 	d := TimeRFC1123{}
 	if err := d.UnmarshalJSON([]byte(dt)); err == nil {
-		t.Errorf("date: TimeRFC1123#Unmarshal failed for invalid date")
+		t.Fatalf("date: TimeRFC1123#Unmarshal failed for invalid date")
 	}
 }
 
@@ -113,7 +113,7 @@ func TestUnmarshalTextforInvalidDateRfc1123(t *testing.T) {
 	dt := "Mon, 02 Jan 2000000 15:05 MST"
 	d := TimeRFC1123{}
 	if err := d.UnmarshalText([]byte(dt)); err == nil {
-		t.Errorf("date: TimeRFC1123#Unmarshal failed for invalid date")
+		t.Fatalf("date: TimeRFC1123#Unmarshal failed for invalid date")
 	}
 }
 
@@ -124,35 +124,35 @@ func TestTimeStringRfc1123(t *testing.T) {
 	}
 	d := TimeRFC1123{ti}
 	if d.String() != "Mon, 02 Jan 2006 15:04:05 MST" {
-		t.Errorf("date: TimeRFC1123#String failed (%v)", d.String())
+		t.Fatalf("date: TimeRFC1123#String failed (%v)", d.String())
 	}
 }
 
 func TestTimeStringReturnsEmptyStringForErrorRfc1123(t *testing.T) {
 	d := TimeRFC1123{Time: time.Date(20000, 01, 01, 01, 01, 01, 01, time.UTC)}
 	if d.String() != "" {
-		t.Errorf("date: TimeRFC1123#String failed empty string for an error")
+		t.Fatalf("date: TimeRFC1123#String failed empty string for an error")
 	}
 }
 
 func TestTimeBinaryRoundTripRfc1123(t *testing.T) {
 	ti, err := ParseTime(rfc3339, "2001-02-03T04:05:06Z")
 	if err != nil {
-		t.Errorf("date: TimeRFC1123#ParseTime failed (%v)", err)
+		t.Fatalf("date: TimeRFC1123#ParseTime failed (%v)", err)
 	}
 	d1 := TimeRFC1123{ti}
 	t1, err := d1.MarshalBinary()
 	if err != nil {
-		t.Errorf("date: TimeRFC1123#MarshalBinary failed (%v)", err)
+		t.Fatalf("date: TimeRFC1123#MarshalBinary failed (%v)", err)
 	}
 
 	d2 := TimeRFC1123{}
 	if err = d2.UnmarshalBinary(t1); err != nil {
-		t.Errorf("date: TimeRFC1123#UnmarshalBinary failed (%v)", err)
+		t.Fatalf("date: TimeRFC1123#UnmarshalBinary failed (%v)", err)
 	}
 
 	if !reflect.DeepEqual(d1, d2) {
-		t.Errorf("date: Round-trip Binary failed (%v, %v)", d1, d2)
+		t.Fatalf("date: Round-trip Binary failed (%v, %v)", d1, d2)
 	}
 }
 
@@ -163,42 +163,42 @@ func TestTimeJSONRoundTripRfc1123(t *testing.T) {
 	var err error
 	ti, err := ParseTime(rfc1123, "Mon, 02 Jan 2006 15:04:05 MST")
 	if err != nil {
-		t.Errorf("date: TimeRFC1123#ParseTime failed (%v)", err)
+		t.Fatalf("date: TimeRFC1123#ParseTime failed (%v)", err)
 	}
 	d1 := s{Time: TimeRFC1123{ti}}
 	j, err := json.Marshal(d1)
 	if err != nil {
-		t.Errorf("date: TimeRFC1123#MarshalJSON failed (%v)", err)
+		t.Fatalf("date: TimeRFC1123#MarshalJSON failed (%v)", err)
 	}
 
 	d2 := s{}
 	if err = json.Unmarshal(j, &d2); err != nil {
-		t.Errorf("date: TimeRFC1123#UnmarshalJSON failed (%v)", err)
+		t.Fatalf("date: TimeRFC1123#UnmarshalJSON failed (%v)", err)
 	}
 
 	if !reflect.DeepEqual(d1, d2) {
-		t.Errorf("date: Round-trip JSON failed (%v, %v)", d1, d2)
+		t.Fatalf("date: Round-trip JSON failed (%v, %v)", d1, d2)
 	}
 }
 
 func TestTimeTextRoundTripRfc1123(t *testing.T) {
 	ti, err := ParseTime(rfc1123, "Mon, 02 Jan 2006 15:04:05 MST")
 	if err != nil {
-		t.Errorf("date: TimeRFC1123#ParseTime failed (%v)", err)
+		t.Fatalf("date: TimeRFC1123#ParseTime failed (%v)", err)
 	}
 	d1 := TimeRFC1123{Time: ti}
 	t1, err := d1.MarshalText()
 	if err != nil {
-		t.Errorf("date: TimeRFC1123#MarshalText failed (%v)", err)
+		t.Fatalf("date: TimeRFC1123#MarshalText failed (%v)", err)
 	}
 
 	d2 := TimeRFC1123{}
 	if err = d2.UnmarshalText(t1); err != nil {
-		t.Errorf("date: TimeRFC1123#UnmarshalText failed (%v)", err)
+		t.Fatalf("date: TimeRFC1123#UnmarshalText failed (%v)", err)
 	}
 
 	if !reflect.DeepEqual(d1, d2) {
-		t.Errorf("date: Round-trip Text failed (%v, %v)", d1, d2)
+		t.Fatalf("date: Round-trip Text failed (%v, %v)", d1, d2)
 	}
 }
 
@@ -206,7 +206,7 @@ func TestTimeToTimeRFC1123(t *testing.T) {
 	ti, err := ParseTime(rfc1123, "Mon, 02 Jan 2006 15:04:05 MST")
 	d := TimeRFC1123{ti}
 	if err != nil {
-		t.Errorf("date: TimeRFC1123#ParseTime failed (%v)", err)
+		t.Fatalf("date: TimeRFC1123#ParseTime failed (%v)", err)
 	}
 	var _ time.Time = d.ToTime()
 }

--- a/autorest/error_test.go
+++ b/autorest/error_test.go
@@ -12,7 +12,7 @@ func TestNewErrorWithError_AssignsPackageType(t *testing.T) {
 	e := NewErrorWithError(fmt.Errorf("original"), "packageType", "method", nil, "message")
 
 	if e.PackageType != "packageType" {
-		t.Errorf("autorest: Error failed to set package type -- expected %v, received %v", "packageType", e.PackageType)
+		t.Fatalf("autorest: Error failed to set package type -- expected %v, received %v", "packageType", e.PackageType)
 	}
 }
 
@@ -20,7 +20,7 @@ func TestNewErrorWithError_AssignsMethod(t *testing.T) {
 	e := NewErrorWithError(fmt.Errorf("original"), "packageType", "method", nil, "message")
 
 	if e.Method != "method" {
-		t.Errorf("autorest: Error failed to set method -- expected %v, received %v", "method", e.Method)
+		t.Fatalf("autorest: Error failed to set method -- expected %v, received %v", "method", e.Method)
 	}
 }
 
@@ -28,14 +28,14 @@ func TestNewErrorWithError_AssignsMessage(t *testing.T) {
 	e := NewErrorWithError(fmt.Errorf("original"), "packageType", "method", nil, "message")
 
 	if e.Message != "message" {
-		t.Errorf("autorest: Error failed to set message -- expected %v, received %v", "message", e.Message)
+		t.Fatalf("autorest: Error failed to set message -- expected %v, received %v", "message", e.Message)
 	}
 }
 
 func TestNewErrorWithError_AssignsUndefinedStatusCodeIfRespNil(t *testing.T) {
 	e := NewErrorWithError(nil, "packageType", "method", nil, "message")
 	if e.StatusCode != UndefinedStatusCode {
-		t.Errorf("autorest: Error failed to set status code -- expected %v, received %v", UndefinedStatusCode, e.StatusCode)
+		t.Fatalf("autorest: Error failed to set status code -- expected %v, received %v", UndefinedStatusCode, e.StatusCode)
 	}
 }
 
@@ -45,7 +45,7 @@ func TestNewErrorWithError_AssignsStatusCode(t *testing.T) {
 		Status:     http.StatusText(http.StatusBadRequest)}, "message")
 
 	if e.StatusCode != http.StatusBadRequest {
-		t.Errorf("autorest: Error failed to set status code -- expected %v, received %v", http.StatusBadRequest, e.StatusCode)
+		t.Fatalf("autorest: Error failed to set status code -- expected %v, received %v", http.StatusBadRequest, e.StatusCode)
 	}
 }
 
@@ -53,7 +53,7 @@ func TestNewErrorWithError_AcceptsArgs(t *testing.T) {
 	e := NewErrorWithError(fmt.Errorf("original"), "packageType", "method", nil, "message %s", "arg")
 
 	if matched, _ := regexp.MatchString(`.*arg.*`, e.Message); !matched {
-		t.Errorf("autorest: Error failed to apply message arguments -- expected %v, received %v",
+		t.Fatalf("autorest: Error failed to apply message arguments -- expected %v, received %v",
 			`.*arg.*`, e.Message)
 	}
 }
@@ -63,7 +63,7 @@ func TestNewErrorWithError_AssignsError(t *testing.T) {
 	e := NewErrorWithError(err, "packageType", "method", nil, "message")
 
 	if e.Original != err {
-		t.Errorf("autorest: Error failed to set error -- expected %v, received %v", err, e.Original)
+		t.Fatalf("autorest: Error failed to set error -- expected %v, received %v", err, e.Original)
 	}
 }
 
@@ -73,7 +73,7 @@ func TestNewErrorWithResponse_ContainsStatusCode(t *testing.T) {
 		Status:     http.StatusText(http.StatusBadRequest)}, "message")
 
 	if e.StatusCode != http.StatusBadRequest {
-		t.Errorf("autorest: Error failed to set status code -- expected %v, received %v", http.StatusBadRequest, e.StatusCode)
+		t.Fatalf("autorest: Error failed to set status code -- expected %v, received %v", http.StatusBadRequest, e.StatusCode)
 	}
 }
 
@@ -81,7 +81,7 @@ func TestNewErrorWithResponse_nilResponse_ReportsUndefinedStatusCode(t *testing.
 	e := NewErrorWithResponse("packageType", "method", nil, "message")
 
 	if e.StatusCode != UndefinedStatusCode {
-		t.Errorf("autorest: Error failed to set status code -- expected %v, received %v", UndefinedStatusCode, e.StatusCode)
+		t.Fatalf("autorest: Error failed to set status code -- expected %v, received %v", UndefinedStatusCode, e.StatusCode)
 	}
 }
 
@@ -90,7 +90,7 @@ func TestNewErrorWithResponse_Forwards(t *testing.T) {
 	e2 := NewErrorWithResponse("packageType", "method", nil, "message %s", "arg")
 
 	if !reflect.DeepEqual(e1, e2) {
-		t.Error("autorest: NewError did not return an error equivelent to NewErrorWithError")
+		t.Fatal("autorest: NewError did not return an error equivelent to NewErrorWithError")
 	}
 }
 
@@ -99,7 +99,7 @@ func TestNewErrorWithError_Forwards(t *testing.T) {
 	e2 := NewErrorWithError(nil, "packageType", "method", nil, "message %s", "arg")
 
 	if !reflect.DeepEqual(e1, e2) {
-		t.Error("autorest: NewError did not return an error equivelent to NewErrorWithError")
+		t.Fatal("autorest: NewError did not return an error equivelent to NewErrorWithError")
 	}
 }
 
@@ -108,7 +108,7 @@ func TestNewErrorWithError_DoesNotWrapADetailedError(t *testing.T) {
 	e2 := NewErrorWithError(e1, "packageType2", "method2", nil, "message2 %s", "arg2")
 
 	if !reflect.DeepEqual(e1, e2) {
-		t.Errorf("autorest: NewErrorWithError incorrectly wrapped a DetailedError -- expected %v, received %v", e1, e2)
+		t.Fatalf("autorest: NewErrorWithError incorrectly wrapped a DetailedError -- expected %v, received %v", e1, e2)
 	}
 }
 
@@ -117,7 +117,7 @@ func TestNewErrorWithError_WrapsAnError(t *testing.T) {
 	var e2 interface{} = NewErrorWithError(e1, "packageType", "method", nil, "message")
 
 	if _, ok := e2.(DetailedError); !ok {
-		t.Errorf("autorest: NewErrorWithError failed to wrap a standard error -- received %T", e2)
+		t.Fatalf("autorest: NewErrorWithError failed to wrap a standard error -- received %T", e2)
 	}
 }
 
@@ -126,7 +126,7 @@ func TestDetailedError(t *testing.T) {
 	e := NewErrorWithError(err, "packageType", "method", nil, "message")
 
 	if matched, _ := regexp.MatchString(`.*original.*`, e.Error()); !matched {
-		t.Errorf("autorest: Error#Error failed to return original error message -- expected %v, received %v",
+		t.Fatalf("autorest: Error#Error failed to return original error message -- expected %v, received %v",
 			`.*original.*`, e.Error())
 	}
 }
@@ -135,7 +135,7 @@ func TestDetailedErrorConstainsPackageType(t *testing.T) {
 	e := NewErrorWithError(fmt.Errorf("original"), "packageType", "method", nil, "message")
 
 	if matched, _ := regexp.MatchString(`.*packageType.*`, e.Error()); !matched {
-		t.Errorf("autorest: Error#String failed to include PackageType -- expected %v, received %v",
+		t.Fatalf("autorest: Error#String failed to include PackageType -- expected %v, received %v",
 			`.*packageType.*`, e.Error())
 	}
 }
@@ -144,7 +144,7 @@ func TestDetailedErrorConstainsMethod(t *testing.T) {
 	e := NewErrorWithError(fmt.Errorf("original"), "packageType", "method", nil, "message")
 
 	if matched, _ := regexp.MatchString(`.*method.*`, e.Error()); !matched {
-		t.Errorf("autorest: Error#String failed to include Method -- expected %v, received %v",
+		t.Fatalf("autorest: Error#String failed to include Method -- expected %v, received %v",
 			`.*method.*`, e.Error())
 	}
 }
@@ -153,7 +153,7 @@ func TestDetailedErrorConstainsMessage(t *testing.T) {
 	e := NewErrorWithError(fmt.Errorf("original"), "packageType", "method", nil, "message")
 
 	if matched, _ := regexp.MatchString(`.*message.*`, e.Error()); !matched {
-		t.Errorf("autorest: Error#String failed to include Message -- expected %v, received %v",
+		t.Fatalf("autorest: Error#String failed to include Message -- expected %v, received %v",
 			`.*message.*`, e.Error())
 	}
 }
@@ -164,7 +164,7 @@ func TestDetailedErrorConstainsStatusCode(t *testing.T) {
 		Status:     http.StatusText(http.StatusBadRequest)}, "message")
 
 	if matched, _ := regexp.MatchString(`.*400.*`, e.Error()); !matched {
-		t.Errorf("autorest: Error#String failed to include Status Code -- expected %v, received %v",
+		t.Fatalf("autorest: Error#String failed to include Status Code -- expected %v, received %v",
 			`.*400.*`, e.Error())
 	}
 }
@@ -173,7 +173,7 @@ func TestDetailedErrorConstainsOriginal(t *testing.T) {
 	e := NewErrorWithError(fmt.Errorf("original"), "packageType", "method", nil, "message")
 
 	if matched, _ := regexp.MatchString(`.*original.*`, e.Error()); !matched {
-		t.Errorf("autorest: Error#String failed to include Original error -- expected %v, received %v",
+		t.Fatalf("autorest: Error#String failed to include Original error -- expected %v, received %v",
 			`.*original.*`, e.Error())
 	}
 }
@@ -182,7 +182,7 @@ func TestDetailedErrorSkipsOriginal(t *testing.T) {
 	e := NewError("packageType", "method", "message")
 
 	if matched, _ := regexp.MatchString(`.*Original.*`, e.Error()); matched {
-		t.Errorf("autorest: Error#String included missing Original error -- unexpected %v, received %v",
+		t.Fatalf("autorest: Error#String included missing Original error -- unexpected %v, received %v",
 			`.*Original.*`, e.Error())
 	}
 }

--- a/autorest/preparer_test.go
+++ b/autorest/preparer_test.go
@@ -254,10 +254,10 @@ func TestCreatePreparerDoesNotModify(t *testing.T) {
 	p := CreatePreparer()
 	r2, err := p.Prepare(r1)
 	if err != nil {
-		t.Errorf("autorest: CreatePreparer failed (%v)", err)
+		t.Fatalf("autorest: CreatePreparer failed (%v)", err)
 	}
 	if !reflect.DeepEqual(r1, r2) {
-		t.Errorf("autorest: CreatePreparer without decorators modified the request")
+		t.Fatalf("autorest: CreatePreparer without decorators modified the request")
 	}
 }
 
@@ -265,10 +265,10 @@ func TestCreatePreparerRunsDecoratorsInOrder(t *testing.T) {
 	p := CreatePreparer(WithBaseURL("https://microsoft.com/"), WithPath("1"), WithPath("2"), WithPath("3"))
 	r, err := p.Prepare(&http.Request{})
 	if err != nil {
-		t.Errorf("autorest: CreatePreparer failed (%v)", err)
+		t.Fatalf("autorest: CreatePreparer failed (%v)", err)
 	}
 	if r.URL.String() != "https://microsoft.com/1/2/3" {
-		t.Errorf("autorest: CreatePreparer failed to run decorators in order")
+		t.Fatalf("autorest: CreatePreparer failed to run decorators in order")
 	}
 }
 
@@ -278,7 +278,7 @@ func TestAsContentType(t *testing.T) {
 		fmt.Printf("ERROR: %v", err)
 	}
 	if r.Header.Get(headerContentType) != "application/text" {
-		t.Errorf("autorest: AsContentType failed to add header (%s=%s)", headerContentType, r.Header.Get(headerContentType))
+		t.Fatalf("autorest: AsContentType failed to add header (%s=%s)", headerContentType, r.Header.Get(headerContentType))
 	}
 }
 
@@ -288,7 +288,7 @@ func TestAsFormURLEncoded(t *testing.T) {
 		fmt.Printf("ERROR: %v", err)
 	}
 	if r.Header.Get(headerContentType) != mimeTypeFormPost {
-		t.Errorf("autorest: AsFormURLEncoded failed to add header (%s=%s)", headerContentType, r.Header.Get(headerContentType))
+		t.Fatalf("autorest: AsFormURLEncoded failed to add header (%s=%s)", headerContentType, r.Header.Get(headerContentType))
 	}
 }
 
@@ -298,7 +298,7 @@ func TestAsJSON(t *testing.T) {
 		fmt.Printf("ERROR: %v", err)
 	}
 	if r.Header.Get(headerContentType) != mimeTypeJSON {
-		t.Errorf("autorest: AsJSON failed to add header (%s=%s)", headerContentType, r.Header.Get(headerContentType))
+		t.Fatalf("autorest: AsJSON failed to add header (%s=%s)", headerContentType, r.Header.Get(headerContentType))
 	}
 }
 
@@ -306,11 +306,11 @@ func TestWithNothing(t *testing.T) {
 	r1 := mocks.NewRequest()
 	r2, err := Prepare(r1, WithNothing())
 	if err != nil {
-		t.Errorf("autorest: WithNothing returned an unexpected error (%v)", err)
+		t.Fatalf("autorest: WithNothing returned an unexpected error (%v)", err)
 	}
 
 	if !reflect.DeepEqual(r1, r2) {
-		t.Error("azure: WithNothing modified the passed HTTP Request")
+		t.Fatal("azure: WithNothing modified the passed HTTP Request")
 	}
 }
 
@@ -320,7 +320,7 @@ func TestWithBearerAuthorization(t *testing.T) {
 		fmt.Printf("ERROR: %v", err)
 	}
 	if r.Header.Get(headerAuthorization) != "Bearer SOME-TOKEN" {
-		t.Errorf("autorest: WithBearerAuthorization failed to add header (%s=%s)", headerAuthorization, r.Header.Get(headerAuthorization))
+		t.Fatalf("autorest: WithBearerAuthorization failed to add header (%s=%s)", headerAuthorization, r.Header.Get(headerAuthorization))
 	}
 }
 
@@ -331,70 +331,70 @@ func TestWithUserAgent(t *testing.T) {
 		fmt.Printf("ERROR: %v", err)
 	}
 	if r.UserAgent() != ua || r.Header.Get(headerUserAgent) != ua {
-		t.Errorf("autorest: WithUserAgent failed to add header (%s=%s)", headerUserAgent, r.Header.Get(headerUserAgent))
+		t.Fatalf("autorest: WithUserAgent failed to add header (%s=%s)", headerUserAgent, r.Header.Get(headerUserAgent))
 	}
 }
 
 func TestWithMethod(t *testing.T) {
 	r, _ := Prepare(mocks.NewRequest(), WithMethod("HEAD"))
 	if r.Method != "HEAD" {
-		t.Error("autorest: WithMethod failed to set HTTP method header")
+		t.Fatal("autorest: WithMethod failed to set HTTP method header")
 	}
 }
 
 func TestAsDelete(t *testing.T) {
 	r, _ := Prepare(mocks.NewRequest(), AsDelete())
 	if r.Method != "DELETE" {
-		t.Error("autorest: AsDelete failed to set HTTP method header to DELETE")
+		t.Fatal("autorest: AsDelete failed to set HTTP method header to DELETE")
 	}
 }
 
 func TestAsGet(t *testing.T) {
 	r, _ := Prepare(mocks.NewRequest(), AsGet())
 	if r.Method != "GET" {
-		t.Error("autorest: AsGet failed to set HTTP method header to GET")
+		t.Fatal("autorest: AsGet failed to set HTTP method header to GET")
 	}
 }
 
 func TestAsHead(t *testing.T) {
 	r, _ := Prepare(mocks.NewRequest(), AsHead())
 	if r.Method != "HEAD" {
-		t.Error("autorest: AsHead failed to set HTTP method header to HEAD")
+		t.Fatal("autorest: AsHead failed to set HTTP method header to HEAD")
 	}
 }
 
 func TestAsOptions(t *testing.T) {
 	r, _ := Prepare(mocks.NewRequest(), AsOptions())
 	if r.Method != "OPTIONS" {
-		t.Error("autorest: AsOptions failed to set HTTP method header to OPTIONS")
+		t.Fatal("autorest: AsOptions failed to set HTTP method header to OPTIONS")
 	}
 }
 
 func TestAsPatch(t *testing.T) {
 	r, _ := Prepare(mocks.NewRequest(), AsPatch())
 	if r.Method != "PATCH" {
-		t.Error("autorest: AsPatch failed to set HTTP method header to PATCH")
+		t.Fatal("autorest: AsPatch failed to set HTTP method header to PATCH")
 	}
 }
 
 func TestAsPost(t *testing.T) {
 	r, _ := Prepare(mocks.NewRequest(), AsPost())
 	if r.Method != "POST" {
-		t.Error("autorest: AsPost failed to set HTTP method header to POST")
+		t.Fatal("autorest: AsPost failed to set HTTP method header to POST")
 	}
 }
 
 func TestAsPut(t *testing.T) {
 	r, _ := Prepare(mocks.NewRequest(), AsPut())
 	if r.Method != "PUT" {
-		t.Error("autorest: AsPut failed to set HTTP method header to PUT")
+		t.Fatal("autorest: AsPut failed to set HTTP method header to PUT")
 	}
 }
 
 func TestPrepareWithNullRequest(t *testing.T) {
 	_, err := Prepare(nil)
 	if err == nil {
-		t.Error("autorest: Prepare failed to return an error when given a null http.Request")
+		t.Fatal("autorest: Prepare failed to return an error when given a null http.Request")
 	}
 }
 
@@ -406,16 +406,16 @@ func TestWithFormDataSetsContentLength(t *testing.T) {
 	r, err := Prepare(&http.Request{},
 		WithFormData(v))
 	if err != nil {
-		t.Errorf("autorest: WithFormData failed with error (%v)", err)
+		t.Fatalf("autorest: WithFormData failed with error (%v)", err)
 	}
 
 	b, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		t.Errorf("autorest: WithFormData failed with error (%v)", err)
+		t.Fatalf("autorest: WithFormData failed with error (%v)", err)
 	}
 
 	if r.ContentLength != int64(len(b)) {
-		t.Errorf("autorest:WithFormData set Content-Length to %v, expected %v", r.ContentLength, len(b))
+		t.Fatalf("autorest:WithFormData set Content-Length to %v, expected %v", r.ContentLength, len(b))
 	}
 }
 
@@ -423,21 +423,21 @@ func TestWithBool_SetsTheBody(t *testing.T) {
 	r, err := Prepare(&http.Request{},
 		WithBool(false))
 	if err != nil {
-		t.Errorf("autorest: WithBool failed with error (%v)", err)
+		t.Fatalf("autorest: WithBool failed with error (%v)", err)
 	}
 
 	s, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		t.Errorf("autorest: WithBool failed with error (%v)", err)
+		t.Fatalf("autorest: WithBool failed with error (%v)", err)
 	}
 
 	if r.ContentLength != int64(len(fmt.Sprintf("%v", false))) {
-		t.Errorf("autorest: WithBool set Content-Length to %v, expected %v", r.ContentLength, int64(len(fmt.Sprintf("%v", false))))
+		t.Fatalf("autorest: WithBool set Content-Length to %v, expected %v", r.ContentLength, int64(len(fmt.Sprintf("%v", false))))
 	}
 
 	v, err := strconv.ParseBool(string(s))
 	if err != nil || v {
-		t.Errorf("autorest: WithBool incorrectly encoded the boolean as %v", s)
+		t.Fatalf("autorest: WithBool incorrectly encoded the boolean as %v", s)
 	}
 }
 
@@ -445,21 +445,21 @@ func TestWithFloat32_SetsTheBody(t *testing.T) {
 	r, err := Prepare(&http.Request{},
 		WithFloat32(42.0))
 	if err != nil {
-		t.Errorf("autorest: WithFloat32 failed with error (%v)", err)
+		t.Fatalf("autorest: WithFloat32 failed with error (%v)", err)
 	}
 
 	s, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		t.Errorf("autorest: WithFloat32 failed with error (%v)", err)
+		t.Fatalf("autorest: WithFloat32 failed with error (%v)", err)
 	}
 
 	if r.ContentLength != int64(len(fmt.Sprintf("%v", 42.0))) {
-		t.Errorf("autorest: WithFloat32 set Content-Length to %v, expected %v", r.ContentLength, int64(len(fmt.Sprintf("%v", 42.0))))
+		t.Fatalf("autorest: WithFloat32 set Content-Length to %v, expected %v", r.ContentLength, int64(len(fmt.Sprintf("%v", 42.0))))
 	}
 
 	v, err := strconv.ParseFloat(string(s), 32)
 	if err != nil || float32(v) != float32(42.0) {
-		t.Errorf("autorest: WithFloat32 incorrectly encoded the boolean as %v", s)
+		t.Fatalf("autorest: WithFloat32 incorrectly encoded the boolean as %v", s)
 	}
 }
 
@@ -467,21 +467,21 @@ func TestWithFloat64_SetsTheBody(t *testing.T) {
 	r, err := Prepare(&http.Request{},
 		WithFloat64(42.0))
 	if err != nil {
-		t.Errorf("autorest: WithFloat64 failed with error (%v)", err)
+		t.Fatalf("autorest: WithFloat64 failed with error (%v)", err)
 	}
 
 	s, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		t.Errorf("autorest: WithFloat64 failed with error (%v)", err)
+		t.Fatalf("autorest: WithFloat64 failed with error (%v)", err)
 	}
 
 	if r.ContentLength != int64(len(fmt.Sprintf("%v", 42.0))) {
-		t.Errorf("autorest: WithFloat64 set Content-Length to %v, expected %v", r.ContentLength, int64(len(fmt.Sprintf("%v", 42.0))))
+		t.Fatalf("autorest: WithFloat64 set Content-Length to %v, expected %v", r.ContentLength, int64(len(fmt.Sprintf("%v", 42.0))))
 	}
 
 	v, err := strconv.ParseFloat(string(s), 64)
 	if err != nil || v != float64(42.0) {
-		t.Errorf("autorest: WithFloat64 incorrectly encoded the boolean as %v", s)
+		t.Fatalf("autorest: WithFloat64 incorrectly encoded the boolean as %v", s)
 	}
 }
 
@@ -489,21 +489,21 @@ func TestWithInt32_SetsTheBody(t *testing.T) {
 	r, err := Prepare(&http.Request{},
 		WithInt32(42))
 	if err != nil {
-		t.Errorf("autorest: WithInt32 failed with error (%v)", err)
+		t.Fatalf("autorest: WithInt32 failed with error (%v)", err)
 	}
 
 	s, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		t.Errorf("autorest: WithInt32 failed with error (%v)", err)
+		t.Fatalf("autorest: WithInt32 failed with error (%v)", err)
 	}
 
 	if r.ContentLength != int64(len(fmt.Sprintf("%v", 42))) {
-		t.Errorf("autorest: WithInt32 set Content-Length to %v, expected %v", r.ContentLength, int64(len(fmt.Sprintf("%v", 42))))
+		t.Fatalf("autorest: WithInt32 set Content-Length to %v, expected %v", r.ContentLength, int64(len(fmt.Sprintf("%v", 42))))
 	}
 
 	v, err := strconv.ParseInt(string(s), 10, 32)
 	if err != nil || int32(v) != int32(42) {
-		t.Errorf("autorest: WithInt32 incorrectly encoded the boolean as %v", s)
+		t.Fatalf("autorest: WithInt32 incorrectly encoded the boolean as %v", s)
 	}
 }
 
@@ -511,21 +511,21 @@ func TestWithInt64_SetsTheBody(t *testing.T) {
 	r, err := Prepare(&http.Request{},
 		WithInt64(42))
 	if err != nil {
-		t.Errorf("autorest: WithInt64 failed with error (%v)", err)
+		t.Fatalf("autorest: WithInt64 failed with error (%v)", err)
 	}
 
 	s, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		t.Errorf("autorest: WithInt64 failed with error (%v)", err)
+		t.Fatalf("autorest: WithInt64 failed with error (%v)", err)
 	}
 
 	if r.ContentLength != int64(len(fmt.Sprintf("%v", 42))) {
-		t.Errorf("autorest: WithInt64 set Content-Length to %v, expected %v", r.ContentLength, int64(len(fmt.Sprintf("%v", 42))))
+		t.Fatalf("autorest: WithInt64 set Content-Length to %v, expected %v", r.ContentLength, int64(len(fmt.Sprintf("%v", 42))))
 	}
 
 	v, err := strconv.ParseInt(string(s), 10, 64)
 	if err != nil || v != int64(42) {
-		t.Errorf("autorest: WithInt64 incorrectly encoded the boolean as %v", s)
+		t.Fatalf("autorest: WithInt64 incorrectly encoded the boolean as %v", s)
 	}
 }
 
@@ -533,20 +533,20 @@ func TestWithString_SetsTheBody(t *testing.T) {
 	r, err := Prepare(&http.Request{},
 		WithString("value"))
 	if err != nil {
-		t.Errorf("autorest: WithString failed with error (%v)", err)
+		t.Fatalf("autorest: WithString failed with error (%v)", err)
 	}
 
 	s, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		t.Errorf("autorest: WithString failed with error (%v)", err)
+		t.Fatalf("autorest: WithString failed with error (%v)", err)
 	}
 
 	if r.ContentLength != int64(len("value")) {
-		t.Errorf("autorest: WithString set Content-Length to %v, expected %v", r.ContentLength, int64(len("value")))
+		t.Fatalf("autorest: WithString set Content-Length to %v, expected %v", r.ContentLength, int64(len("value")))
 	}
 
 	if string(s) != "value" {
-		t.Errorf("autorest: WithString incorrectly encoded the string as %v", s)
+		t.Fatalf("autorest: WithString incorrectly encoded the string as %v", s)
 	}
 }
 
@@ -554,64 +554,64 @@ func TestWithJSONSetsContentLength(t *testing.T) {
 	r, err := Prepare(&http.Request{},
 		WithJSON(&mocks.T{Name: "Rob Pike", Age: 42}))
 	if err != nil {
-		t.Errorf("autorest: WithJSON failed with error (%v)", err)
+		t.Fatalf("autorest: WithJSON failed with error (%v)", err)
 	}
 
 	b, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		t.Errorf("autorest: WithJSON failed with error (%v)", err)
+		t.Fatalf("autorest: WithJSON failed with error (%v)", err)
 	}
 
 	if r.ContentLength != int64(len(b)) {
-		t.Errorf("autorest:WithJSON set Content-Length to %v, expected %v", r.ContentLength, len(b))
+		t.Fatalf("autorest:WithJSON set Content-Length to %v, expected %v", r.ContentLength, len(b))
 	}
 }
 
 func TestWithHeaderAllocatesHeaders(t *testing.T) {
 	r, err := Prepare(mocks.NewRequest(), WithHeader("x-foo", "bar"))
 	if err != nil {
-		t.Errorf("autorest: WithHeader failed (%v)", err)
+		t.Fatalf("autorest: WithHeader failed (%v)", err)
 	}
 	if r.Header.Get("x-foo") != "bar" {
-		t.Errorf("autorest: WithHeader failed to add header (%s=%s)", "x-foo", r.Header.Get("x-foo"))
+		t.Fatalf("autorest: WithHeader failed to add header (%s=%s)", "x-foo", r.Header.Get("x-foo"))
 	}
 }
 
 func TestWithPathCatchesNilURL(t *testing.T) {
 	_, err := Prepare(&http.Request{}, WithPath("a"))
 	if err == nil {
-		t.Errorf("autorest: WithPath failed to catch a nil URL")
+		t.Fatalf("autorest: WithPath failed to catch a nil URL")
 	}
 }
 
 func TestWithEscapedPathParametersCatchesNilURL(t *testing.T) {
 	_, err := Prepare(&http.Request{}, WithEscapedPathParameters(map[string]interface{}{"foo": "bar"}))
 	if err == nil {
-		t.Errorf("autorest: WithEscapedPathParameters failed to catch a nil URL")
+		t.Fatalf("autorest: WithEscapedPathParameters failed to catch a nil URL")
 	}
 }
 
 func TestWithPathParametersCatchesNilURL(t *testing.T) {
 	_, err := Prepare(&http.Request{}, WithPathParameters(map[string]interface{}{"foo": "bar"}))
 	if err == nil {
-		t.Errorf("autorest: WithPathParameters failed to catch a nil URL")
+		t.Fatalf("autorest: WithPathParameters failed to catch a nil URL")
 	}
 }
 
 func TestWithQueryParametersCatchesNilURL(t *testing.T) {
 	_, err := Prepare(&http.Request{}, WithQueryParameters(map[string]interface{}{"foo": "bar"}))
 	if err == nil {
-		t.Errorf("autorest: WithQueryParameters failed to catch a nil URL")
+		t.Fatalf("autorest: WithQueryParameters failed to catch a nil URL")
 	}
 }
 
 func TestModifyingExistingRequest(t *testing.T) {
 	r, err := Prepare(mocks.NewRequestForURL("https://bing.com"), WithPath("search"), WithQueryParameters(map[string]interface{}{"q": "golang"}))
 	if err != nil {
-		t.Errorf("autorest: Preparing an existing request returned an error (%v)", err)
+		t.Fatalf("autorest: Preparing an existing request returned an error (%v)", err)
 	}
 	if r.URL.String() != "https://bing.com/search?q=golang" {
-		t.Errorf("autorest: Preparing an existing request failed (%s)", r.URL)
+		t.Fatalf("autorest: Preparing an existing request failed (%s)", r.URL)
 	}
 }
 
@@ -622,8 +622,8 @@ func TestWithAuthorizer(t *testing.T) {
 	r2, err := Prepare(r1,
 		na.WithAuthorization())
 	if err != nil {
-		t.Errorf("autorest: NullAuthorizer#WithAuthorization returned an unexpected error (%v)", err)
+		t.Fatalf("autorest: NullAuthorizer#WithAuthorization returned an unexpected error (%v)", err)
 	} else if !reflect.DeepEqual(r1, r2) {
-		t.Errorf("autorest: NullAuthorizer#WithAuthorization modified the request -- received %v, expected %v", r2, r1)
+		t.Fatalf("autorest: NullAuthorizer#WithAuthorization modified the request -- received %v, expected %v", r2, r1)
 	}
 }

--- a/autorest/responder_test.go
+++ b/autorest/responder_test.go
@@ -81,10 +81,10 @@ func TestCreateResponderDoesNotModify(t *testing.T) {
 	p := CreateResponder()
 	err := p.Respond(r1)
 	if err != nil {
-		t.Errorf("autorest: CreateResponder failed (%v)", err)
+		t.Fatalf("autorest: CreateResponder failed (%v)", err)
 	}
 	if !reflect.DeepEqual(r1, r2) {
-		t.Errorf("autorest: CreateResponder without decorators modified the response")
+		t.Fatalf("autorest: CreateResponder without decorators modified the response")
 	}
 }
 
@@ -106,11 +106,11 @@ func TestCreateResponderRunsDecoratorsInOrder(t *testing.T) {
 	p := CreateResponder(d(1), d(2), d(3))
 	err := p.Respond(&http.Response{})
 	if err != nil {
-		t.Errorf("autorest: Respond failed (%v)", err)
+		t.Fatalf("autorest: Respond failed (%v)", err)
 	}
 
 	if s != "123" {
-		t.Errorf("autorest: CreateResponder invoked decorators in an incorrect order; expected '123', received '%s'", s)
+		t.Fatalf("autorest: CreateResponder invoked decorators in an incorrect order; expected '123', received '%s'", s)
 	}
 }
 
@@ -123,7 +123,7 @@ func TestByIgnoring(t *testing.T) {
 				return ResponderFunc(func(r2 *http.Response) error {
 					r1 := mocks.NewResponse()
 					if !reflect.DeepEqual(r1, r2) {
-						t.Errorf("autorest: ByIgnoring modified the HTTP Response -- received %v, expected %v", r2, r1)
+						t.Fatalf("autorest: ByIgnoring modified the HTTP Response -- received %v, expected %v", r2, r1)
 					}
 					return nil
 				})
@@ -142,10 +142,10 @@ func TestByCopying_Copies(t *testing.T) {
 		ByUnmarshallingJSON(&mocks.T{}),
 		ByClosing())
 	if err != nil {
-		t.Errorf("autorest: ByCopying returned an unexpected error -- %v", err)
+		t.Fatalf("autorest: ByCopying returned an unexpected error -- %v", err)
 	}
 	if b.String() != jsonT {
-		t.Errorf("autorest: ByCopying failed to copy the bytes read")
+		t.Fatalf("autorest: ByCopying failed to copy the bytes read")
 	}
 }
 
@@ -158,7 +158,7 @@ func TestByCopying_ReturnsNestedErrors(t *testing.T) {
 		ByUnmarshallingJSON(&mocks.T{}),
 		ByClosing())
 	if err == nil {
-		t.Errorf("autorest: ByCopying failed to return the expected error")
+		t.Fatalf("autorest: ByCopying failed to return the expected error")
 	}
 }
 
@@ -199,10 +199,10 @@ func TestByClosing(t *testing.T) {
 	r := mocks.NewResponse()
 	err := Respond(r, ByClosing())
 	if err != nil {
-		t.Errorf("autorest: ByClosing failed (%v)", err)
+		t.Fatalf("autorest: ByClosing failed (%v)", err)
 	}
 	if r.Body.(*mocks.Body).IsOpen() {
-		t.Errorf("autorest: ByClosing did not close the response body")
+		t.Fatalf("autorest: ByClosing did not close the response body")
 	}
 }
 
@@ -248,7 +248,7 @@ func TestByClosingClosesEvenAfterErrors(t *testing.T) {
 		ByClosing())
 
 	if r.Body.(*mocks.Body).IsOpen() {
-		t.Errorf("autorest: ByClosing did not close the response body after an error occurred")
+		t.Fatalf("autorest: ByClosing did not close the response body after an error occurred")
 	}
 }
 
@@ -261,7 +261,7 @@ func TestByClosingClosesReturnsNestedErrors(t *testing.T) {
 		ByClosing())
 
 	if err == nil || !reflect.DeepEqual(e, err) {
-		t.Errorf("autorest: ByClosing failed to return a nested error")
+		t.Fatalf("autorest: ByClosing failed to return a nested error")
 	}
 }
 
@@ -313,7 +313,7 @@ func TestByClosingIfErrorClosesIfAnErrorOccurs(t *testing.T) {
 		ByClosingIfError())
 
 	if r.Body.(*mocks.Body).IsOpen() {
-		t.Errorf("autorest: ByClosingIfError did not close the response body after an error occurred")
+		t.Fatalf("autorest: ByClosingIfError did not close the response body after an error occurred")
 	}
 }
 
@@ -323,7 +323,7 @@ func TestByClosingIfErrorDoesNotClosesIfNoErrorOccurs(t *testing.T) {
 		ByClosingIfError())
 
 	if !r.Body.(*mocks.Body).IsOpen() {
-		t.Errorf("autorest: ByClosingIfError closed the response body even though no error occurred")
+		t.Fatalf("autorest: ByClosingIfError closed the response body even though no error occurred")
 	}
 }
 
@@ -334,10 +334,10 @@ func TestByUnmarshallingJSON(t *testing.T) {
 		ByUnmarshallingJSON(v),
 		ByClosing())
 	if err != nil {
-		t.Errorf("autorest: ByUnmarshallingJSON failed (%v)", err)
+		t.Fatalf("autorest: ByUnmarshallingJSON failed (%v)", err)
 	}
 	if v.Name != "Rob Pike" || v.Age != 42 {
-		t.Errorf("autorest: ByUnmarshallingJSON failed to properly unmarshal")
+		t.Fatalf("autorest: ByUnmarshallingJSON failed to properly unmarshal")
 	}
 }
 
@@ -350,7 +350,7 @@ func TestByUnmarshallingJSON_HandlesReadErrors(t *testing.T) {
 		ByUnmarshallingJSON(v),
 		ByClosing())
 	if err == nil {
-		t.Errorf("autorest: ByUnmarshallingJSON failed to receive / respond to read error")
+		t.Fatalf("autorest: ByUnmarshallingJSON failed to receive / respond to read error")
 	}
 }
 
@@ -362,7 +362,7 @@ func TestByUnmarshallingJSONIncludesJSONInErrors(t *testing.T) {
 		ByUnmarshallingJSON(v),
 		ByClosing())
 	if err == nil || !strings.Contains(err.Error(), j) {
-		t.Errorf("autorest: ByUnmarshallingJSON failed to return JSON in error (%v)", err)
+		t.Fatalf("autorest: ByUnmarshallingJSON failed to return JSON in error (%v)", err)
 	}
 }
 
@@ -373,7 +373,7 @@ func TestByUnmarshallingJSONEmptyInput(t *testing.T) {
 		ByUnmarshallingJSON(v),
 		ByClosing())
 	if err != nil {
-		t.Errorf("autorest: ByUnmarshallingJSON failed to return nil in case of empty JSON (%v)", err)
+		t.Fatalf("autorest: ByUnmarshallingJSON failed to return nil in case of empty JSON (%v)", err)
 	}
 }
 
@@ -384,10 +384,10 @@ func TestByUnmarshallingXML(t *testing.T) {
 		ByUnmarshallingXML(v),
 		ByClosing())
 	if err != nil {
-		t.Errorf("autorest: ByUnmarshallingXML failed (%v)", err)
+		t.Fatalf("autorest: ByUnmarshallingXML failed (%v)", err)
 	}
 	if v.Name != "Rob Pike" || v.Age != 42 {
-		t.Errorf("autorest: ByUnmarshallingXML failed to properly unmarshal")
+		t.Fatalf("autorest: ByUnmarshallingXML failed to properly unmarshal")
 	}
 }
 
@@ -400,7 +400,7 @@ func TestByUnmarshallingXML_HandlesReadErrors(t *testing.T) {
 		ByUnmarshallingXML(v),
 		ByClosing())
 	if err == nil {
-		t.Errorf("autorest: ByUnmarshallingXML failed to receive / respond to read error")
+		t.Fatalf("autorest: ByUnmarshallingXML failed to receive / respond to read error")
 	}
 }
 
@@ -412,14 +412,14 @@ func TestByUnmarshallingXMLIncludesXMLInErrors(t *testing.T) {
 		ByUnmarshallingXML(v),
 		ByClosing())
 	if err == nil || !strings.Contains(err.Error(), x) {
-		t.Errorf("autorest: ByUnmarshallingXML failed to return XML in error (%v)", err)
+		t.Fatalf("autorest: ByUnmarshallingXML failed to return XML in error (%v)", err)
 	}
 }
 
 func TestRespondAcceptsNullResponse(t *testing.T) {
 	err := Respond(nil)
 	if err != nil {
-		t.Errorf("autorest: Respond returned an unexpected error when given a null Response (%v)", err)
+		t.Fatalf("autorest: Respond returned an unexpected error when given a null Response (%v)", err)
 	}
 }
 
@@ -434,7 +434,7 @@ func TestWithErrorUnlessStatusCode(t *testing.T) {
 		ByClosingIfError())
 
 	if err != nil {
-		t.Errorf("autorest: WithErrorUnlessStatusCode returned an error (%v) for an acceptable status code (%s)", err, r.Status)
+		t.Fatalf("autorest: WithErrorUnlessStatusCode returned an error (%v) for an acceptable status code (%s)", err, r.Status)
 	}
 }
 
@@ -449,7 +449,7 @@ func TestWithErrorUnlessStatusCodeEmitsErrorForUnacceptableStatusCode(t *testing
 		ByClosingIfError())
 
 	if err == nil {
-		t.Errorf("autorest: WithErrorUnlessStatusCode failed to return an error for an unacceptable status code (%s)", r.Status)
+		t.Fatalf("autorest: WithErrorUnlessStatusCode failed to return an error for an unacceptable status code (%s)", r.Status)
 	}
 }
 
@@ -462,7 +462,7 @@ func TestWithErrorUnlessOK(t *testing.T) {
 		ByClosingIfError())
 
 	if err != nil {
-		t.Errorf("autorest: WithErrorUnlessOK returned an error for OK status code (%v)", err)
+		t.Fatalf("autorest: WithErrorUnlessOK returned an error for OK status code (%v)", err)
 	}
 }
 
@@ -477,7 +477,7 @@ func TestWithErrorUnlessOKEmitsErrorIfNotOK(t *testing.T) {
 		ByClosingIfError())
 
 	if err == nil {
-		t.Errorf("autorest: WithErrorUnlessOK failed to return an error for a non-OK status code (%v)", err)
+		t.Fatalf("autorest: WithErrorUnlessOK failed to return an error for a non-OK status code (%v)", err)
 	}
 }
 
@@ -487,7 +487,7 @@ func TestExtractHeader(t *testing.T) {
 	mocks.SetResponseHeaderValues(r, mocks.TestHeader, v)
 
 	if !reflect.DeepEqual(ExtractHeader(mocks.TestHeader, r), v) {
-		t.Errorf("autorest: ExtractHeader failed to retrieve the expected header -- expected [%s]%v, received [%s]%v",
+		t.Fatalf("autorest: ExtractHeader failed to retrieve the expected header -- expected [%s]%v, received [%s]%v",
 			mocks.TestHeader, v, mocks.TestHeader, ExtractHeader(mocks.TestHeader, r))
 	}
 }
@@ -497,7 +497,7 @@ func TestExtractHeaderHandlesMissingHeader(t *testing.T) {
 	r := mocks.NewResponse()
 
 	if !reflect.DeepEqual(ExtractHeader(mocks.TestHeader, r), v) {
-		t.Errorf("autorest: ExtractHeader failed to handle a missing header -- expected %v, received %v",
+		t.Fatalf("autorest: ExtractHeader failed to handle a missing header -- expected %v, received %v",
 			v, ExtractHeader(mocks.TestHeader, r))
 	}
 }
@@ -508,7 +508,7 @@ func TestExtractHeaderValue(t *testing.T) {
 	mocks.SetResponseHeader(r, mocks.TestHeader, v)
 
 	if ExtractHeaderValue(mocks.TestHeader, r) != v {
-		t.Errorf("autorest: ExtractHeader failed to retrieve the expected header -- expected [%s]%v, received [%s]%v",
+		t.Fatalf("autorest: ExtractHeader failed to retrieve the expected header -- expected [%s]%v, received [%s]%v",
 			mocks.TestHeader, v, mocks.TestHeader, ExtractHeaderValue(mocks.TestHeader, r))
 	}
 }
@@ -518,7 +518,7 @@ func TestExtractHeaderValueHandlesMissingHeader(t *testing.T) {
 	v := ""
 
 	if ExtractHeaderValue(mocks.TestHeader, r) != v {
-		t.Errorf("autorest: ExtractHeader failed to retrieve the expected header -- expected [%s]%v, received [%s]%v",
+		t.Fatalf("autorest: ExtractHeader failed to retrieve the expected header -- expected [%s]%v, received [%s]%v",
 			mocks.TestHeader, v, mocks.TestHeader, ExtractHeaderValue(mocks.TestHeader, r))
 	}
 }
@@ -529,7 +529,7 @@ func TestExtractHeaderValueRetrievesFirstValue(t *testing.T) {
 	mocks.SetResponseHeaderValues(r, mocks.TestHeader, v)
 
 	if ExtractHeaderValue(mocks.TestHeader, r) != v[0] {
-		t.Errorf("autorest: ExtractHeader failed to retrieve the expected header -- expected [%s]%v, received [%s]%v",
+		t.Fatalf("autorest: ExtractHeader failed to retrieve the expected header -- expected [%s]%v, received [%s]%v",
 			mocks.TestHeader, v[0], mocks.TestHeader, ExtractHeaderValue(mocks.TestHeader, r))
 	}
 }

--- a/autorest/sender_test.go
+++ b/autorest/sender_test.go
@@ -93,14 +93,14 @@ func TestSendWithSenderRunsDecoratorsInOrder(t *testing.T) {
 		withMessage(&s, "b"),
 		withMessage(&s, "c"))
 	if err != nil {
-		t.Errorf("autorest: SendWithSender returned an error (%v)", err)
+		t.Fatalf("autorest: SendWithSender returned an error (%v)", err)
 	}
 
 	Respond(r,
 		ByClosing())
 
 	if s != "abc" {
-		t.Errorf("autorest: SendWithSender invoke decorators out of order; expected 'abc', received '%s'", s)
+		t.Fatalf("autorest: SendWithSender invoke decorators out of order; expected 'abc', received '%s'", s)
 	}
 }
 
@@ -119,7 +119,7 @@ func TestCreateSender(t *testing.T) {
 	s.Do(&http.Request{})
 
 	if !f {
-		t.Error("autorest: CreateSender failed to apply supplied decorator")
+		t.Fatal("autorest: CreateSender failed to apply supplied decorator")
 	}
 }
 
@@ -137,7 +137,7 @@ func TestSend(t *testing.T) {
 		})())
 
 	if !f {
-		t.Error("autorest: Send failed to apply supplied decorator")
+		t.Fatal("autorest: Send failed to apply supplied decorator")
 	}
 }
 
@@ -151,7 +151,7 @@ func TestAfterDelayWaits(t *testing.T) {
 		AfterDelay(d))
 	s := time.Since(tt)
 	if s < d {
-		t.Error("autorest: AfterDelay failed to wait for at least the specified duration")
+		t.Fatal("autorest: AfterDelay failed to wait for at least the specified duration")
 	}
 
 	Respond(r,
@@ -177,7 +177,7 @@ func TestAfterDelay_Cancels(t *testing.T) {
 	close(cancel)
 	time.Sleep(5 * time.Millisecond)
 	if time.Since(tt) >= delay {
-		t.Error("autorest: AfterDelay failed to cancel")
+		t.Fatal("autorest: AfterDelay failed to cancel")
 	}
 }
 
@@ -190,7 +190,7 @@ func TestAfterDelayDoesNotWaitTooLong(t *testing.T) {
 		AfterDelay(d))
 
 	if time.Since(start) > (5 * d) {
-		t.Error("autorest: AfterDelay waited too long (exceeded 5 times specified duration)")
+		t.Fatal("autorest: AfterDelay waited too long (exceeded 5 times specified duration)")
 	}
 
 	Respond(r,
@@ -206,9 +206,9 @@ func TestAsIs(t *testing.T) {
 	r2, err := SendWithSender(client, mocks.NewRequest(),
 		AsIs())
 	if err != nil {
-		t.Errorf("autorest: AsIs returned an unexpected error (%v)", err)
+		t.Fatalf("autorest: AsIs returned an unexpected error (%v)", err)
 	} else if !reflect.DeepEqual(r1, r2) {
-		t.Errorf("autorest: AsIs modified the response -- received %v, expected %v", r2, r1)
+		t.Fatalf("autorest: AsIs modified the response -- received %v, expected %v", r2, r1)
 	}
 
 	Respond(r1,
@@ -226,7 +226,7 @@ func TestDoCloseIfError(t *testing.T) {
 		DoCloseIfError())
 
 	if r.Body.(*mocks.Body).IsOpen() {
-		t.Error("autorest: Expected DoCloseIfError to close response body -- it was left open")
+		t.Fatal("autorest: Expected DoCloseIfError to close response body -- it was left open")
 	}
 
 	Respond(r,
@@ -278,7 +278,7 @@ func TestDoErrorIfStatusCode(t *testing.T) {
 		DoErrorIfStatusCode(http.StatusBadRequest),
 		DoCloseIfError())
 	if err == nil {
-		t.Error("autorest: DoErrorIfStatusCode failed to emit an error for passed code")
+		t.Fatal("autorest: DoErrorIfStatusCode failed to emit an error for passed code")
 	}
 
 	Respond(r,
@@ -293,7 +293,7 @@ func TestDoErrorIfStatusCodeIgnoresStatusCodes(t *testing.T) {
 		DoErrorIfStatusCode(http.StatusBadRequest),
 		DoCloseIfError())
 	if err != nil {
-		t.Error("autorest: DoErrorIfStatusCode failed to ignore a status code")
+		t.Fatal("autorest: DoErrorIfStatusCode failed to ignore a status code")
 	}
 
 	Respond(r,
@@ -308,7 +308,7 @@ func TestDoErrorUnlessStatusCode(t *testing.T) {
 		DoErrorUnlessStatusCode(http.StatusAccepted),
 		DoCloseIfError())
 	if err == nil {
-		t.Error("autorest: DoErrorUnlessStatusCode failed to emit an error for an unknown status code")
+		t.Fatal("autorest: DoErrorUnlessStatusCode failed to emit an error for an unknown status code")
 	}
 
 	Respond(r,
@@ -323,7 +323,7 @@ func TestDoErrorUnlessStatusCodeIgnoresStatusCodes(t *testing.T) {
 		DoErrorUnlessStatusCode(http.StatusAccepted),
 		DoCloseIfError())
 	if err != nil {
-		t.Error("autorest: DoErrorUnlessStatusCode emitted an error for a knonwn status code")
+		t.Fatal("autorest: DoErrorUnlessStatusCode emitted an error for a knonwn status code")
 	}
 
 	Respond(r,
@@ -336,11 +336,11 @@ func TestDoRetryForAttemptsStopsAfterSuccess(t *testing.T) {
 	r, err := SendWithSender(client, mocks.NewRequest(),
 		DoRetryForAttempts(5, time.Duration(0)))
 	if client.Attempts() != 1 {
-		t.Errorf("autorest: DoRetryForAttempts failed to stop after success -- expected attempts %v, actual %v",
+		t.Fatalf("autorest: DoRetryForAttempts failed to stop after success -- expected attempts %v, actual %v",
 			1, client.Attempts())
 	}
 	if err != nil {
-		t.Errorf("autorest: DoRetryForAttempts returned an unexpected error (%v)", err)
+		t.Fatalf("autorest: DoRetryForAttempts returned an unexpected error (%v)", err)
 	}
 
 	Respond(r,
@@ -355,14 +355,14 @@ func TestDoRetryForAttemptsStopsAfterAttempts(t *testing.T) {
 		DoRetryForAttempts(5, time.Duration(0)),
 		DoCloseIfError())
 	if err == nil {
-		t.Error("autorest: Mock client failed to emit errors")
+		t.Fatal("autorest: Mock client failed to emit errors")
 	}
 
 	Respond(r,
 		ByClosing())
 
 	if client.Attempts() != 5 {
-		t.Error("autorest: DoRetryForAttempts failed to stop after specified number of attempts")
+		t.Fatal("autorest: DoRetryForAttempts failed to stop after specified number of attempts")
 	}
 }
 
@@ -373,11 +373,11 @@ func TestDoRetryForAttemptsReturnsResponse(t *testing.T) {
 	r, err := SendWithSender(client, mocks.NewRequest(),
 		DoRetryForAttempts(1, time.Duration(0)))
 	if err == nil {
-		t.Error("autorest: Mock client failed to emit errors")
+		t.Fatal("autorest: Mock client failed to emit errors")
 	}
 
 	if r == nil {
-		t.Error("autorest: DoRetryForAttempts failed to return the underlying response")
+		t.Fatal("autorest: DoRetryForAttempts failed to return the underlying response")
 	}
 
 	Respond(r,
@@ -390,11 +390,11 @@ func TestDoRetryForDurationStopsAfterSuccess(t *testing.T) {
 	r, err := SendWithSender(client, mocks.NewRequest(),
 		DoRetryForDuration(10*time.Millisecond, time.Duration(0)))
 	if client.Attempts() != 1 {
-		t.Errorf("autorest: DoRetryForDuration failed to stop after success -- expected attempts %v, actual %v",
+		t.Fatalf("autorest: DoRetryForDuration failed to stop after success -- expected attempts %v, actual %v",
 			1, client.Attempts())
 	}
 	if err != nil {
-		t.Errorf("autorest: DoRetryForDuration returned an unexpected error (%v)", err)
+		t.Fatalf("autorest: DoRetryForDuration returned an unexpected error (%v)", err)
 	}
 
 	Respond(r,
@@ -411,11 +411,11 @@ func TestDoRetryForDurationStopsAfterDuration(t *testing.T) {
 		DoRetryForDuration(d, time.Duration(0)),
 		DoCloseIfError())
 	if err == nil {
-		t.Error("autorest: Mock client failed to emit errors")
+		t.Fatal("autorest: Mock client failed to emit errors")
 	}
 
 	if time.Since(start) < d {
-		t.Error("autorest: DoRetryForDuration failed stopped too soon")
+		t.Fatal("autorest: DoRetryForDuration failed stopped too soon")
 	}
 
 	Respond(r,
@@ -432,11 +432,11 @@ func TestDoRetryForDurationStopsWithinReason(t *testing.T) {
 		DoRetryForDuration(d, time.Duration(0)),
 		DoCloseIfError())
 	if err == nil {
-		t.Error("autorest: Mock client failed to emit errors")
+		t.Fatal("autorest: Mock client failed to emit errors")
 	}
 
 	if time.Since(start) > (5 * d) {
-		t.Error("autorest: DoRetryForDuration failed stopped soon enough (exceeded 5 times specified duration)")
+		t.Fatal("autorest: DoRetryForDuration failed stopped soon enough (exceeded 5 times specified duration)")
 	}
 
 	Respond(r,
@@ -451,11 +451,11 @@ func TestDoRetryForDurationReturnsResponse(t *testing.T) {
 		DoRetryForDuration(10*time.Millisecond, time.Duration(0)),
 		DoCloseIfError())
 	if err == nil {
-		t.Error("autorest: Mock client failed to emit errors")
+		t.Fatal("autorest: Mock client failed to emit errors")
 	}
 
 	if r == nil {
-		t.Error("autorest: DoRetryForDuration failed to return the underlying response")
+		t.Fatal("autorest: DoRetryForDuration failed to return the underlying response")
 	}
 
 	Respond(r,
@@ -467,7 +467,7 @@ func TestDelayForBackoff(t *testing.T) {
 	start := time.Now()
 	DelayForBackoff(d, 1, nil)
 	if time.Since(start) < d {
-		t.Error("autorest: DelayForBackoff did not delay as long as expected")
+		t.Fatal("autorest: DelayForBackoff did not delay as long as expected")
 	}
 }
 
@@ -486,7 +486,7 @@ func TestDelayForBackoff_Cancels(t *testing.T) {
 	close(cancel)
 	time.Sleep(5 * time.Millisecond)
 	if time.Since(start) >= delay {
-		t.Error("autorest: DelayForBackoff failed to cancel")
+		t.Fatal("autorest: DelayForBackoff failed to cancel")
 	}
 }
 
@@ -495,7 +495,7 @@ func TestDelayForBackoffWithinReason(t *testing.T) {
 	start := time.Now()
 	DelayForBackoff(d, 1, nil)
 	if time.Since(start) > (5 * d) {
-		t.Error("autorest: DelayForBackoff delayed too long (exceeded 5 times the specified duration)")
+		t.Fatal("autorest: DelayForBackoff delayed too long (exceeded 5 times the specified duration)")
 	}
 }
 
@@ -506,7 +506,7 @@ func TestDoPollForStatusCodes_IgnoresUnspecifiedStatusCodes(t *testing.T) {
 		DoPollForStatusCodes(time.Duration(0), time.Duration(0)))
 
 	if client.Attempts() != 1 {
-		t.Errorf("autorest: Sender#DoPollForStatusCodes polled for unspecified status code")
+		t.Fatalf("autorest: Sender#DoPollForStatusCodes polled for unspecified status code")
 	}
 
 	Respond(r,
@@ -521,7 +521,7 @@ func TestDoPollForStatusCodes_PollsForSpecifiedStatusCodes(t *testing.T) {
 		DoPollForStatusCodes(time.Millisecond, time.Millisecond, http.StatusAccepted))
 
 	if client.Attempts() != 2 {
-		t.Errorf("autorest: Sender#DoPollForStatusCodes failed to poll for specified status code")
+		t.Fatalf("autorest: Sender#DoPollForStatusCodes failed to poll for specified status code")
 	}
 
 	Respond(r,
@@ -551,7 +551,7 @@ func TestDoPollForStatusCodes_CanBeCanceled(t *testing.T) {
 	close(cancel)
 	time.Sleep(5 * time.Millisecond)
 	if time.Since(start) >= delay {
-		t.Errorf("autorest: Sender#DoPollForStatusCodes failed to cancel")
+		t.Fatalf("autorest: Sender#DoPollForStatusCodes failed to cancel")
 	}
 }
 
@@ -565,7 +565,7 @@ func TestDoPollForStatusCodes_ClosesAllNonreturnedResponseBodiesWhenPolling(t *t
 		DoPollForStatusCodes(time.Millisecond, time.Millisecond, http.StatusAccepted))
 
 	if resp.Body.(*mocks.Body).IsOpen() || resp.Body.(*mocks.Body).CloseAttempts() < 2 {
-		t.Errorf("autorest: Sender#DoPollForStatusCodes did not close unreturned response bodies")
+		t.Fatalf("autorest: Sender#DoPollForStatusCodes did not close unreturned response bodies")
 	}
 
 	Respond(r,
@@ -580,7 +580,7 @@ func TestDoPollForStatusCodes_LeavesLastResponseBodyOpen(t *testing.T) {
 		DoPollForStatusCodes(time.Millisecond, time.Millisecond, http.StatusAccepted))
 
 	if !r.Body.(*mocks.Body).IsOpen() {
-		t.Errorf("autorest: Sender#DoPollForStatusCodes did not leave open the body of the last response")
+		t.Fatalf("autorest: Sender#DoPollForStatusCodes did not leave open the body of the last response")
 	}
 
 	Respond(r,
@@ -597,7 +597,7 @@ func TestDoPollForStatusCodes_StopsPollingAfterAnError(t *testing.T) {
 		DoPollForStatusCodes(time.Millisecond, time.Millisecond, http.StatusAccepted))
 
 	if client.Attempts() > 2 {
-		t.Errorf("autorest: Sender#DoPollForStatusCodes failed to stop polling after receiving an error")
+		t.Fatalf("autorest: Sender#DoPollForStatusCodes failed to stop polling after receiving an error")
 	}
 
 	Respond(r,
@@ -614,7 +614,7 @@ func TestDoPollForStatusCodes_ReturnsPollingError(t *testing.T) {
 		DoPollForStatusCodes(time.Millisecond, time.Millisecond, http.StatusAccepted))
 
 	if err == nil {
-		t.Errorf("autorest: Sender#DoPollForStatusCodes failed to return error from polling")
+		t.Fatalf("autorest: Sender#DoPollForStatusCodes failed to return error from polling")
 	}
 
 	Respond(r,
@@ -630,7 +630,7 @@ func TestWithLogging_Logs(t *testing.T) {
 		WithLogging(logger))
 
 	if buf.String() == "" {
-		t.Error("autorest: Sender#WithLogging failed to log the request")
+		t.Fatal("autorest: Sender#WithLogging failed to log the request")
 	}
 
 	Respond(r,
@@ -648,10 +648,10 @@ func TestWithLogging_HandlesMissingResponse(t *testing.T) {
 		WithLogging(logger))
 
 	if r != nil || err == nil {
-		t.Error("autorest: Sender#WithLogging returned a valid response -- expecting nil")
+		t.Fatal("autorest: Sender#WithLogging returned a valid response -- expecting nil")
 	}
 	if buf.String() == "" {
-		t.Error("autorest: Sender#WithLogging failed to log the request for a nil response")
+		t.Fatal("autorest: Sender#WithLogging failed to log the request for a nil response")
 	}
 
 	Respond(r,

--- a/autorest/to/convert_test.go
+++ b/autorest/to/convert_test.go
@@ -8,14 +8,14 @@ import (
 func TestString(t *testing.T) {
 	v := ""
 	if String(&v) != v {
-		t.Errorf("to: String failed to return the correct string -- expected %v, received %v",
+		t.Fatalf("to: String failed to return the correct string -- expected %v, received %v",
 			v, String(&v))
 	}
 }
 
 func TestStringHandlesNil(t *testing.T) {
 	if String(nil) != "" {
-		t.Errorf("to: String failed to correctly convert nil -- expected %v, received %v",
+		t.Fatalf("to: String failed to correctly convert nil -- expected %v, received %v",
 			"", String(nil))
 	}
 }
@@ -23,7 +23,7 @@ func TestStringHandlesNil(t *testing.T) {
 func TestStringPtr(t *testing.T) {
 	v := ""
 	if *StringPtr(v) != v {
-		t.Errorf("to: StringPtr failed to return the correct string -- expected %v, received %v",
+		t.Fatalf("to: StringPtr failed to return the correct string -- expected %v, received %v",
 			v, *StringPtr(v))
 	}
 }
@@ -31,14 +31,14 @@ func TestStringPtr(t *testing.T) {
 func TestStringSlice(t *testing.T) {
 	v := []string{}
 	if out := StringSlice(&v); !reflect.DeepEqual(out, v) {
-		t.Errorf("to: StringSlice failed to return the correct slice -- expected %v, received %v",
+		t.Fatalf("to: StringSlice failed to return the correct slice -- expected %v, received %v",
 			v, out)
 	}
 }
 
 func TestStringSliceHandlesNil(t *testing.T) {
 	if out := StringSlice(nil); out != nil {
-		t.Errorf("to: StringSlice failed to correctly convert nil -- expected %v, received %v",
+		t.Fatalf("to: StringSlice failed to correctly convert nil -- expected %v, received %v",
 			nil, out)
 	}
 }
@@ -46,7 +46,7 @@ func TestStringSliceHandlesNil(t *testing.T) {
 func TestStringSlicePtr(t *testing.T) {
 	v := []string{"a", "b"}
 	if out := StringSlicePtr(v); !reflect.DeepEqual(*out, v) {
-		t.Errorf("to: StringSlicePtr failed to return the correct slice -- expected %v, received %v",
+		t.Fatalf("to: StringSlicePtr failed to return the correct slice -- expected %v, received %v",
 			v, *out)
 	}
 }
@@ -55,7 +55,7 @@ func TestStringMap(t *testing.T) {
 	msp := map[string]*string{"foo": StringPtr("foo"), "bar": StringPtr("bar"), "baz": StringPtr("baz")}
 	for k, v := range StringMap(msp) {
 		if *msp[k] != v {
-			t.Errorf("to: StringMap incorrectly converted an entry -- expected [%s]%v, received[%s]%v",
+			t.Fatalf("to: StringMap incorrectly converted an entry -- expected [%s]%v, received[%s]%v",
 				k, v, k, *msp[k])
 		}
 	}
@@ -65,7 +65,7 @@ func TestStringMapHandlesNil(t *testing.T) {
 	msp := map[string]*string{"foo": StringPtr("foo"), "bar": nil, "baz": StringPtr("baz")}
 	for k, v := range StringMap(msp) {
 		if msp[k] == nil && v != "" {
-			t.Errorf("to: StringMap incorrectly converted a nil entry -- expected [%s]%v, received[%s]%v",
+			t.Fatalf("to: StringMap incorrectly converted a nil entry -- expected [%s]%v, received[%s]%v",
 				k, v, k, *msp[k])
 		}
 	}
@@ -75,7 +75,7 @@ func TestStringMapPtr(t *testing.T) {
 	ms := map[string]string{"foo": "foo", "bar": "bar", "baz": "baz"}
 	for k, msp := range *StringMapPtr(ms) {
 		if ms[k] != *msp {
-			t.Errorf("to: StringMapPtr incorrectly converted an entry -- expected [%s]%v, received[%s]%v",
+			t.Fatalf("to: StringMapPtr incorrectly converted an entry -- expected [%s]%v, received[%s]%v",
 				k, ms[k], k, *msp)
 		}
 	}
@@ -84,14 +84,14 @@ func TestStringMapPtr(t *testing.T) {
 func TestBool(t *testing.T) {
 	v := false
 	if Bool(&v) != v {
-		t.Errorf("to: Bool failed to return the correct string -- expected %v, received %v",
+		t.Fatalf("to: Bool failed to return the correct string -- expected %v, received %v",
 			v, Bool(&v))
 	}
 }
 
 func TestBoolHandlesNil(t *testing.T) {
 	if Bool(nil) != false {
-		t.Errorf("to: Bool failed to correctly convert nil -- expected %v, received %v",
+		t.Fatalf("to: Bool failed to correctly convert nil -- expected %v, received %v",
 			false, Bool(nil))
 	}
 }
@@ -99,7 +99,7 @@ func TestBoolHandlesNil(t *testing.T) {
 func TestBoolPtr(t *testing.T) {
 	v := false
 	if *BoolPtr(v) != v {
-		t.Errorf("to: BoolPtr failed to return the correct string -- expected %v, received %v",
+		t.Fatalf("to: BoolPtr failed to return the correct string -- expected %v, received %v",
 			v, *BoolPtr(v))
 	}
 }
@@ -107,14 +107,14 @@ func TestBoolPtr(t *testing.T) {
 func TestInt(t *testing.T) {
 	v := 0
 	if Int(&v) != v {
-		t.Errorf("to: Int failed to return the correct string -- expected %v, received %v",
+		t.Fatalf("to: Int failed to return the correct string -- expected %v, received %v",
 			v, Int(&v))
 	}
 }
 
 func TestIntHandlesNil(t *testing.T) {
 	if Int(nil) != 0 {
-		t.Errorf("to: Int failed to correctly convert nil -- expected %v, received %v",
+		t.Fatalf("to: Int failed to correctly convert nil -- expected %v, received %v",
 			0, Int(nil))
 	}
 }
@@ -122,7 +122,7 @@ func TestIntHandlesNil(t *testing.T) {
 func TestIntPtr(t *testing.T) {
 	v := 0
 	if *IntPtr(v) != v {
-		t.Errorf("to: IntPtr failed to return the correct string -- expected %v, received %v",
+		t.Fatalf("to: IntPtr failed to return the correct string -- expected %v, received %v",
 			v, *IntPtr(v))
 	}
 }
@@ -130,14 +130,14 @@ func TestIntPtr(t *testing.T) {
 func TestInt32(t *testing.T) {
 	v := int32(0)
 	if Int32(&v) != v {
-		t.Errorf("to: Int32 failed to return the correct string -- expected %v, received %v",
+		t.Fatalf("to: Int32 failed to return the correct string -- expected %v, received %v",
 			v, Int32(&v))
 	}
 }
 
 func TestInt32HandlesNil(t *testing.T) {
 	if Int32(nil) != int32(0) {
-		t.Errorf("to: Int32 failed to correctly convert nil -- expected %v, received %v",
+		t.Fatalf("to: Int32 failed to correctly convert nil -- expected %v, received %v",
 			0, Int32(nil))
 	}
 }
@@ -145,7 +145,7 @@ func TestInt32HandlesNil(t *testing.T) {
 func TestInt32Ptr(t *testing.T) {
 	v := int32(0)
 	if *Int32Ptr(v) != v {
-		t.Errorf("to: Int32Ptr failed to return the correct string -- expected %v, received %v",
+		t.Fatalf("to: Int32Ptr failed to return the correct string -- expected %v, received %v",
 			v, *Int32Ptr(v))
 	}
 }
@@ -153,14 +153,14 @@ func TestInt32Ptr(t *testing.T) {
 func TestInt64(t *testing.T) {
 	v := int64(0)
 	if Int64(&v) != v {
-		t.Errorf("to: Int64 failed to return the correct string -- expected %v, received %v",
+		t.Fatalf("to: Int64 failed to return the correct string -- expected %v, received %v",
 			v, Int64(&v))
 	}
 }
 
 func TestInt64HandlesNil(t *testing.T) {
 	if Int64(nil) != int64(0) {
-		t.Errorf("to: Int64 failed to correctly convert nil -- expected %v, received %v",
+		t.Fatalf("to: Int64 failed to correctly convert nil -- expected %v, received %v",
 			0, Int64(nil))
 	}
 }
@@ -168,7 +168,7 @@ func TestInt64HandlesNil(t *testing.T) {
 func TestInt64Ptr(t *testing.T) {
 	v := int64(0)
 	if *Int64Ptr(v) != v {
-		t.Errorf("to: Int64Ptr failed to return the correct string -- expected %v, received %v",
+		t.Fatalf("to: Int64Ptr failed to return the correct string -- expected %v, received %v",
 			v, *Int64Ptr(v))
 	}
 }
@@ -176,14 +176,14 @@ func TestInt64Ptr(t *testing.T) {
 func TestFloat32(t *testing.T) {
 	v := float32(0)
 	if Float32(&v) != v {
-		t.Errorf("to: Float32 failed to return the correct string -- expected %v, received %v",
+		t.Fatalf("to: Float32 failed to return the correct string -- expected %v, received %v",
 			v, Float32(&v))
 	}
 }
 
 func TestFloat32HandlesNil(t *testing.T) {
 	if Float32(nil) != float32(0) {
-		t.Errorf("to: Float32 failed to correctly convert nil -- expected %v, received %v",
+		t.Fatalf("to: Float32 failed to correctly convert nil -- expected %v, received %v",
 			0, Float32(nil))
 	}
 }
@@ -191,7 +191,7 @@ func TestFloat32HandlesNil(t *testing.T) {
 func TestFloat32Ptr(t *testing.T) {
 	v := float32(0)
 	if *Float32Ptr(v) != v {
-		t.Errorf("to: Float32Ptr failed to return the correct string -- expected %v, received %v",
+		t.Fatalf("to: Float32Ptr failed to return the correct string -- expected %v, received %v",
 			v, *Float32Ptr(v))
 	}
 }
@@ -199,14 +199,14 @@ func TestFloat32Ptr(t *testing.T) {
 func TestFloat64(t *testing.T) {
 	v := float64(0)
 	if Float64(&v) != v {
-		t.Errorf("to: Float64 failed to return the correct string -- expected %v, received %v",
+		t.Fatalf("to: Float64 failed to return the correct string -- expected %v, received %v",
 			v, Float64(&v))
 	}
 }
 
 func TestFloat64HandlesNil(t *testing.T) {
 	if Float64(nil) != float64(0) {
-		t.Errorf("to: Float64 failed to correctly convert nil -- expected %v, received %v",
+		t.Fatalf("to: Float64 failed to correctly convert nil -- expected %v, received %v",
 			0, Float64(nil))
 	}
 }
@@ -214,7 +214,7 @@ func TestFloat64HandlesNil(t *testing.T) {
 func TestFloat64Ptr(t *testing.T) {
 	v := float64(0)
 	if *Float64Ptr(v) != v {
-		t.Errorf("to: Float64Ptr failed to return the correct string -- expected %v, received %v",
+		t.Fatalf("to: Float64Ptr failed to return the correct string -- expected %v, received %v",
 			v, *Float64Ptr(v))
 	}
 }

--- a/autorest/utility_test.go
+++ b/autorest/utility_test.go
@@ -30,7 +30,7 @@ func TestNewDecoderCreatesJSONDecoder(t *testing.T) {
 	d := NewDecoder(EncodedAsJSON, strings.NewReader(jsonT))
 	_, ok := d.(*json.Decoder)
 	if d == nil || !ok {
-		t.Error("autorest: NewDecoder failed to create a JSON decoder when requested")
+		t.Fatal("autorest: NewDecoder failed to create a JSON decoder when requested")
 	}
 }
 
@@ -38,49 +38,49 @@ func TestNewDecoderCreatesXMLDecoder(t *testing.T) {
 	d := NewDecoder(EncodedAsXML, strings.NewReader(xmlT))
 	_, ok := d.(*xml.Decoder)
 	if d == nil || !ok {
-		t.Error("autorest: NewDecoder failed to create an XML decoder when requested")
+		t.Fatal("autorest: NewDecoder failed to create an XML decoder when requested")
 	}
 }
 
 func TestNewDecoderReturnsNilForUnknownEncoding(t *testing.T) {
 	d := NewDecoder("unknown", strings.NewReader(xmlT))
 	if d != nil {
-		t.Error("autorest: NewDecoder created a decoder for an unknown encoding")
+		t.Fatal("autorest: NewDecoder created a decoder for an unknown encoding")
 	}
 }
 
 func TestCopyAndDecodeDecodesJSON(t *testing.T) {
 	_, err := CopyAndDecode(EncodedAsJSON, strings.NewReader(jsonT), &mocks.T{})
 	if err != nil {
-		t.Errorf("autorest: CopyAndDecode returned an error with valid JSON - %v", err)
+		t.Fatalf("autorest: CopyAndDecode returned an error with valid JSON - %v", err)
 	}
 }
 
 func TestCopyAndDecodeDecodesXML(t *testing.T) {
 	_, err := CopyAndDecode(EncodedAsXML, strings.NewReader(xmlT), &mocks.T{})
 	if err != nil {
-		t.Errorf("autorest: CopyAndDecode returned an error with valid XML - %v", err)
+		t.Fatalf("autorest: CopyAndDecode returned an error with valid XML - %v", err)
 	}
 }
 
 func TestCopyAndDecodeReturnsJSONDecodingErrors(t *testing.T) {
 	_, err := CopyAndDecode(EncodedAsJSON, strings.NewReader(jsonT[0:len(jsonT)-2]), &mocks.T{})
 	if err == nil {
-		t.Errorf("autorest: CopyAndDecode failed to return an error with invalid JSON")
+		t.Fatalf("autorest: CopyAndDecode failed to return an error with invalid JSON")
 	}
 }
 
 func TestCopyAndDecodeReturnsXMLDecodingErrors(t *testing.T) {
 	_, err := CopyAndDecode(EncodedAsXML, strings.NewReader(xmlT[0:len(xmlT)-2]), &mocks.T{})
 	if err == nil {
-		t.Errorf("autorest: CopyAndDecode failed to return an error with invalid XML")
+		t.Fatalf("autorest: CopyAndDecode failed to return an error with invalid XML")
 	}
 }
 
 func TestCopyAndDecodeAlwaysReturnsACopy(t *testing.T) {
 	b, _ := CopyAndDecode(EncodedAsJSON, strings.NewReader(jsonT), &mocks.T{})
 	if b.String() != jsonT {
-		t.Errorf("autorest: CopyAndDecode failed to return a valid copy of the data - %v", b.String())
+		t.Fatalf("autorest: CopyAndDecode failed to return a valid copy of the data - %v", b.String())
 	}
 }
 
@@ -95,10 +95,10 @@ func TestTeeReadCloser_Copies(t *testing.T) {
 		ByUnmarshallingJSON(v),
 		ByClosing())
 	if err != nil {
-		t.Errorf("autorest: TeeReadCloser returned an unexpected error -- %v", err)
+		t.Fatalf("autorest: TeeReadCloser returned an unexpected error -- %v", err)
 	}
 	if b.String() != jsonT {
-		t.Errorf("autorest: TeeReadCloser failed to copy the bytes read")
+		t.Fatalf("autorest: TeeReadCloser failed to copy the bytes read")
 	}
 }
 
@@ -113,7 +113,7 @@ func TestTeeReadCloser_PassesReadErrors(t *testing.T) {
 		ByUnmarshallingJSON(v),
 		ByClosing())
 	if err == nil {
-		t.Errorf("autorest: TeeReadCloser failed to return the expected error")
+		t.Fatalf("autorest: TeeReadCloser failed to return the expected error")
 	}
 }
 
@@ -127,10 +127,10 @@ func TestTeeReadCloser_ClosesWrappedReader(t *testing.T) {
 		ByUnmarshallingJSON(v),
 		ByClosing())
 	if err != nil {
-		t.Errorf("autorest: TeeReadCloser returned an unexpected error -- %v", err)
+		t.Fatalf("autorest: TeeReadCloser returned an unexpected error -- %v", err)
 	}
 	if b.IsOpen() {
-		t.Errorf("autorest: TeeReadCloser failed to close the nested io.ReadCloser")
+		t.Fatalf("autorest: TeeReadCloser failed to close the nested io.ReadCloser")
 	}
 }
 
@@ -138,7 +138,7 @@ func TestContainsIntFindsValue(t *testing.T) {
 	ints := []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
 	v := 5
 	if !containsInt(ints, v) {
-		t.Errorf("autorest: containsInt failed to find %v in %v", v, ints)
+		t.Fatalf("autorest: containsInt failed to find %v in %v", v, ints)
 	}
 }
 
@@ -146,21 +146,21 @@ func TestContainsIntDoesNotFindValue(t *testing.T) {
 	ints := []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
 	v := 42
 	if containsInt(ints, v) {
-		t.Errorf("autorest: containsInt unexpectedly found %v in %v", v, ints)
+		t.Fatalf("autorest: containsInt unexpectedly found %v in %v", v, ints)
 	}
 }
 
 func TestContainsIntAcceptsEmptyList(t *testing.T) {
 	ints := make([]int, 10)
 	if containsInt(ints, 42) {
-		t.Errorf("autorest: containsInt failed to handle an empty list")
+		t.Fatalf("autorest: containsInt failed to handle an empty list")
 	}
 }
 
 func TestContainsIntAcceptsNilList(t *testing.T) {
 	var ints []int
 	if containsInt(ints, 42) {
-		t.Errorf("autorest: containsInt failed to handle an nil list")
+		t.Fatalf("autorest: containsInt failed to handle an nil list")
 	}
 }
 
@@ -177,7 +177,7 @@ func TestEscapeStrings(t *testing.T) {
 	}
 	v := escapeValueStrings(m)
 	if !reflect.DeepEqual(v, r) {
-		t.Errorf("autorest: ensureValueStrings returned %v\n", v)
+		t.Fatalf("autorest: ensureValueStrings returned %v\n", v)
 	}
 }
 
@@ -194,7 +194,7 @@ func TestEnsureStrings(t *testing.T) {
 	}
 	v := ensureValueStrings(m)
 	if !reflect.DeepEqual(v, r) {
-		t.Errorf("autorest: ensureValueStrings returned %v\n", v)
+		t.Fatalf("autorest: ensureValueStrings returned %v\n", v)
 	}
 }
 
@@ -203,7 +203,7 @@ func doEnsureBodyClosed(t *testing.T) SendDecorator {
 		return SenderFunc(func(r *http.Request) (*http.Response, error) {
 			resp, err := s.Do(r)
 			if resp != nil && resp.Body != nil && resp.Body.(*mocks.Body).IsOpen() {
-				t.Error("autorest: Expected Body to be closed -- it was left open")
+				t.Fatal("autorest: Expected Body to be closed -- it was left open")
 			}
 			return resp, err
 		})

--- a/autorest/version_test.go
+++ b/autorest/version_test.go
@@ -7,7 +7,7 @@ import (
 func TestVersion(t *testing.T) {
 	v := "7.0.0"
 	if Version() != v {
-		t.Errorf("autorest: Version failed to return the expected version -- expected %s, received %s",
+		t.Fatalf("autorest: Version failed to return the expected version -- expected %s, received %s",
 			v, Version())
 	}
 }


### PR DESCRIPTION
t.Error continues execution for the rest of the test and often
relies on miscomputed values etc, whereas t.Fatal returns from
the test case right away.

t.Fatal fits better in our use case as we compute-and-use
in our use case rather than exercising a set of test inputs.
