### PR TITLE
Add decorator DoRetryForStatusCodes for retry logic. Add CookieJar.

### DIFF
--- a/autorest/azure/example/main.go
+++ b/autorest/azure/example/main.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	resourceGroupURLTemplate = "https://management.azure.com/subscriptions/{subscription-id}/resourcegroups"
+	resourceGroupURLTemplate = "https://management.azure.com"
 	apiVersion               = "2015-01-01"
 	nativeAppClientID        = "a87032a7-203c-4bf7-913c-44c50d23409a"
 	resource                 = "https://management.core.windows.net/"
@@ -159,7 +159,7 @@ func printResourceGroups(client *autorest.Client) error {
 	req, _ := autorest.Prepare(&http.Request{},
 		autorest.AsGet(),
 		autorest.WithBaseURL(resourceGroupURLTemplate),
-		autorest.WithPathParameters(p),
+		autorest.WithPathParameters("/subscriptions/{subscription-id}/resourcegroups", p),
 		autorest.WithQueryParameters(q))
 
 	resp, err := autorest.SendWithSender(client, req)

--- a/autorest/client.go
+++ b/autorest/client.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"net/http/cookiejar"
 	"time"
 )
 
@@ -16,7 +17,21 @@ const (
 
 	// DefaultPollingDuration is a reasonable total polling duration.
 	DefaultPollingDuration = 15 * time.Minute
+
+	// DefaultRetryAttempts is number of attempts for retry status codes (5xx).
+	DefaultRetryAttempts = 3
+
+	// DefaultRetryDuration is a resonable delay for retry.
+	defaultRetryInterval = 30 * time.Second
 )
+
+var statusCodesForRetry = []int{
+	http.StatusRequestTimeout,      // 408
+	http.StatusInternalServerError, // 500
+	http.StatusBadGateway,          // 502
+	http.StatusServiceUnavailable,  // 503
+	http.StatusGatewayTimeout,      // 504
+}
 
 const (
 	requestFormat = `HTTP Request Begin ===================================================
@@ -75,9 +90,7 @@ func (li LoggingInspector) ByInspecting() RespondDecorator {
 	return func(r Responder) Responder {
 		return ResponderFunc(func(resp *http.Response) error {
 			var body, b bytes.Buffer
-
 			defer resp.Body.Close()
-
 			resp.Body = ioutil.NopCloser(io.TeeReader(resp.Body, &body))
 			if err := resp.Write(&b); err != nil {
 				return fmt.Errorf("Failed to write response: %v", err)
@@ -114,17 +127,25 @@ type Client struct {
 	// PollingDuration sets the maximum polling time after which an error is returned.
 	PollingDuration time.Duration
 
+	// RetryAttempts sets the default number of retry attempts for client.
+	RetryAttempts int
+
 	// UserAgent, if not empty, will be set as the HTTP User-Agent header on all requests sent
 	// through the Do method.
 	UserAgent string
+
+	Jar http.CookieJar
 }
 
 // NewClientWithUserAgent returns an instance of a Client with the UserAgent set to the passed
 // string.
 func NewClientWithUserAgent(ua string) Client {
-	c := Client{PollingDelay: DefaultPollingDelay, PollingDuration: DefaultPollingDuration}
-	c.UserAgent = ua
-	return c
+	return Client{
+		PollingDelay:    DefaultPollingDelay,
+		PollingDuration: DefaultPollingDuration,
+		RetryAttempts:   DefaultRetryAttempts,
+		UserAgent:       ua,
+	}
 }
 
 // Do implements the Sender interface by invoking the active Sender after applying authorization.
@@ -141,18 +162,18 @@ func (c Client) Do(r *http.Request) (*http.Response, error) {
 	if err != nil {
 		return nil, NewErrorWithError(err, "autorest/Client", "Do", nil, "Preparing request failed")
 	}
-
-	resp, err := c.sender().Do(r)
+	resp, err := SendWithSender(c.sender(), r,
+		DoRetryForStatusCodes(c.RetryAttempts, defaultRetryInterval, statusCodesForRetry...))
 	Respond(resp,
 		c.ByInspecting())
-
 	return resp, err
 }
 
 // sender returns the Sender to which to send requests.
 func (c Client) sender() Sender {
 	if c.Sender == nil {
-		return http.DefaultClient
+		j, _ := cookiejar.New(nil)
+		return &http.Client{Jar: j}
 	}
 	return c.Sender
 }

--- a/autorest/mocks/helpers.go
+++ b/autorest/mocks/helpers.go
@@ -45,6 +45,17 @@ func NewRequestWithContent(c string) *http.Request {
 	return r
 }
 
+// NewRequestWithCloseBody instantiates a new request.
+func NewRequestWithCloseBody() *http.Request {
+	return NewRequestWithCloseBodyContent("request body")
+}
+
+// NewRequestWithCloseBodyContent instantiates a new request using the passed string for the body content.
+func NewRequestWithCloseBodyContent(c string) *http.Request {
+	r, _ := http.NewRequest("GET", "https://microsoft.com/a/b/c/", NewBodyClose(c))
+	return r
+}
+
 // NewRequestForURL instantiates a new request using the passed URL.
 func NewRequestForURL(u string) *http.Request {
 	r, err := http.NewRequest("GET", u, NewBody(""))

--- a/autorest/mocks/mocks.go
+++ b/autorest/mocks/mocks.go
@@ -22,6 +22,11 @@ func NewBody(s string) *Body {
 	return (&Body{s: s}).reset()
 }
 
+// NewBodyClose creates a new instance of Body.
+func NewBodyClose(s string) *Body {
+	return &Body{s: s}
+}
+
 // Read reads into the passed byte slice and returns the bytes read.
 func (body *Body) Read(b []byte) (n int, err error) {
 	if !body.IsOpen() {

--- a/autorest/sender.go
+++ b/autorest/sender.go
@@ -1,7 +1,9 @@
 package autorest
 
 import (
+	"bytes"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"math"
 	"net/http"
@@ -184,6 +186,36 @@ func DoRetryForAttempts(attempts int, backoff time.Duration) SendDecorator {
 	}
 }
 
+// DoRetryForStatusCodes returns a SendDecorator that retries for specified statusCodes for up to the specified
+// number of attempts, exponentially backing off between requests using the supplied backoff
+// time.Duration (which may be zero). Retrying may be canceled by closing the optional channel on
+// the http.Request.
+func DoRetryForStatusCodes(attempts int, backoff time.Duration, codes ...int) SendDecorator {
+	return func(s Sender) Sender {
+		return SenderFunc(func(r *http.Request) (resp *http.Response, err error) {
+			b := []byte{}
+			if r.Body != nil {
+				b, err = ioutil.ReadAll(r.Body)
+				if err != nil {
+					return resp, err
+				}
+			}
+
+			// Increment to add the first call (attempts denotes number of retries)
+			attempts++
+			for attempt := 0; attempt < attempts; attempt++ {
+				r.Body = ioutil.NopCloser(bytes.NewBuffer(b))
+				resp, err = s.Do(r)
+				if err != nil || !ResponseHasStatusCode(resp, codes...) {
+					return resp, err
+				}
+				DelayForBackoff(backoff, attempt, r.Cancel)
+			}
+			return resp, err
+		})
+	}
+}
+
 // DoRetryForDuration returns a SendDecorator that retries the request until the total time is equal
 // to or greater than the specified duration, exponentially backing off between requests using the
 // supplied backoff time.Duration (which may be zero). Retrying may be canceled by closing the
@@ -222,11 +254,12 @@ func WithLogging(logger *log.Logger) SendDecorator {
 }
 
 // DelayForBackoff invokes time.After for the supplied backoff duration raised to the power of
-// passed attempt (i.e., an exponential backoff delay). Backoff may be zero. The delay may be
-// canceled by closing the passed channel. If terminated early, returns false.
+// passed attempt (i.e., an exponential backoff delay). Backoff duration is in seconds and can set
+// to zero for no delay. The delay may be canceled by closing the passed channel. If terminated early,
+// returns false.
 func DelayForBackoff(backoff time.Duration, attempt int, cancel <-chan struct{}) bool {
 	select {
-	case <-time.After(time.Duration(math.Pow(float64(backoff), float64(attempt)))):
+	case <-time.After(time.Duration(backoff.Seconds()*math.Pow(2, float64(attempt))) * time.Second):
 		return true
 	case <-cancel:
 		return false

--- a/autorest/utility_test.go
+++ b/autorest/utility_test.go
@@ -186,15 +186,56 @@ func TestEnsureStrings(t *testing.T) {
 		"string": "string",
 		"int":    42,
 		"nil":    nil,
+		"bytes":  []byte{255, 254, 253},
 	}
 	r := map[string]string{
 		"string": "string",
 		"int":    "42",
 		"nil":    "",
+		"bytes":  string([]byte{255, 254, 253}),
 	}
 	v := ensureValueStrings(m)
 	if !reflect.DeepEqual(v, r) {
 		t.Fatalf("autorest: ensureValueStrings returned %v\n", v)
+	}
+}
+
+func ExampleStringWithSeparator() {
+	m := []string{
+		"string1",
+		"string2",
+		"string3",
+	}
+
+	fmt.Println(String(m, ","))
+	// Output: string1,string2,string3
+}
+
+func TestStringWithValidString(t *testing.T) {
+	i := 123
+	if String(i) != "123" {
+		t.Fatal("autorest: String method failed to convert integer 123 to string")
+	}
+}
+
+func TestEncodeWithValidPath(t *testing.T) {
+	s := Encode("Path", "Hello Gopher")
+	if s != "Hello%20Gopher" {
+		t.Fatalf("autorest: Encode method failed for valid path encoding. Got: %v; Want: %v", s, "Hello%20Gopher")
+	}
+}
+
+func TestEncodeWithValidQuery(t *testing.T) {
+	s := Encode("Query", "Hello Gopher")
+	if s != "Hello+Gopher" {
+		t.Fatalf("autorest: Encode method failed for valid query encoding. Got: '%v'; Want: 'Hello+Gopher'", s)
+	}
+}
+
+func TestEncodeWithValidNotPathQuery(t *testing.T) {
+	s := Encode("Host", "Hello Gopher")
+	if s != "Hello Gopher" {
+		t.Fatalf("autorest: Encode method failed for parameter not query or path. Got: '%v'; Want: 'Hello Gopher'", s)
 	}
 }
 


### PR DESCRIPTION
- Add retry logic for 408, 500, 502, 503 and 504 status codes.
- Add CookieJar in Client.
- Change url path and query encoding logic.
- Fix DelayForBackoff for proper exponential delay.