### PR TITLE
Fix 'file in use' issue when renewing token in devicetoken flow

### DIFF
--- a/autorest/azure/persist.go
+++ b/autorest/azure/persist.go
@@ -14,6 +14,7 @@ func LoadToken(path string) (*Token, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file (%s) while loading token: %v", path, err)
 	}
+	defer file.Close()
 
 	var token Token
 


### PR DESCRIPTION
I had a couple of instances where token renewal failed to replace to persisted token. There error message was "file is in use". It checked with procexp to see what was holding the file open and it turns out to be the same process. I tracked it down to here.

Also made the tests work on Windows...