### PR TITLE
Fix for #58: Store RetryAfter for subsequent requests

### DIFF
--- a/autorest/azure/async.go
+++ b/autorest/azure/async.go
@@ -62,8 +62,9 @@ func DoPollForAsynchronous(delay time.Duration) autorest.SendDecorator {
 					return resp, err
 				}
 
+				delay = autorest.GetRetryAfter(resp, delay)
 				resp, err = autorest.SendWithSender(s, r,
-					autorest.AfterDelay(autorest.GetRetryAfter(resp, delay)))
+					autorest.AfterDelay(delay))
 			}
 
 			return resp, err


### PR DESCRIPTION
I think @garimakhulbe was making this change as part of a larger PR, but I'm sending this so that I can vendor it now for the PR I'm preparing for Kubernetes. This change saves me upwards of a minute or two whenever provisioning external load balancers for Kubernetes Services. I've been running this code for a while as-is; works as intended.