### PR TITLE
update azure error for detailed error

### DIFF
--- a/autorest/azure/azure.go
+++ b/autorest/azure/azure.go
@@ -6,6 +6,7 @@ See the included examples for more detail.
 package azure
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -29,12 +30,20 @@ const (
 
 // ServiceError encapsulates the error response from an Azure service.
 type ServiceError struct {
-	Code    string `json:"code"`
-	Message string `json:"message"`
+	Code    string         `json:"code"`
+	Message string         `json:"message"`
+	Details *[]interface{} `json:"details"`
 }
 
 func (se ServiceError) Error() string {
-	return fmt.Sprintf("Azure Error: Code=%q Message=%q", se.Code, se.Message)
+	if se.Details != nil {
+		d, err := json.Marshal(*(se.Details))
+		if err != nil {
+			return fmt.Sprintf("Code=%q Message=%q Details=%v", se.Code, se.Message, *se.Details)
+		}
+		return fmt.Sprintf("Code=%q Message=%q Details=%v", se.Code, se.Message, string(d))
+	}
+	return fmt.Sprintf("Code=%q Message=%q", se.Code, se.Message)
 }
 
 // RequestError describes an error response returned by Azure service.
@@ -50,8 +59,8 @@ type RequestError struct {
 
 // Error returns a human-friendly error message from service error.
 func (e RequestError) Error() string {
-	return fmt.Sprintf("azure: Service returned an error. Code=%q Message=%q Status=%d",
-		e.ServiceError.Code, e.ServiceError.Message, e.StatusCode)
+	return fmt.Sprintf("autorest/azure: Service returned an error. Status=%v %v",
+		e.StatusCode, e.ServiceError)
 }
 
 // IsAzureError returns true if the passed error is an Azure Service error; false otherwise.
@@ -149,14 +158,20 @@ func WithErrorUnlessStatusCode(codes ...int) autorest.RespondDecorator {
 				var e RequestError
 				defer resp.Body.Close()
 
+				// Copy and replace the Body in case it does not contain an error object.
+				// This will leave the Body available to the caller.
 				b, decodeErr := autorest.CopyAndDecode(autorest.EncodedAsJSON, resp.Body, &e)
-				resp.Body = ioutil.NopCloser(&b) // replace body with in-memory reader
-				if decodeErr != nil || e.ServiceError == nil {
-					return fmt.Errorf("autorest/azure: error response cannot be parsed: %q error: %v", b.String(), err)
+				resp.Body = ioutil.NopCloser(&b)
+				if decodeErr != nil {
+					return fmt.Errorf("autorest/azure: error response cannot be parsed: %q error: %v", b.String(), decodeErr)
+				} else if e.ServiceError == nil {
+					e.ServiceError = &ServiceError{Code: "Unknown", Message: "Unknown service error"}
 				}
 
 				e.RequestID = ExtractRequestID(resp)
-				e.StatusCode = resp.StatusCode
+				if e.StatusCode == nil {
+					e.StatusCode = resp.StatusCode
+				}
 				err = &e
 			}
 			return err

--- a/autorest/error.go
+++ b/autorest/error.go
@@ -24,7 +24,7 @@ type DetailedError struct {
 	Method string
 
 	// StatusCode is the HTTP Response StatusCode (if non-zero) that led to the error.
-	StatusCode int
+	StatusCode interface{}
 
 	// Message is the error message.
 	Message string


### PR DESCRIPTION
Fix sdk issue [#339](https://github.com/Azure/azure-sdk-for-go/issues/339). Code to decode "details:" in service error when present.
```
error:
      code:
      message:
      **details:[]**
```
