### PR TITLE
azure: add EnvironmentFromName

### DIFF
--- a/autorest/azure/environments.go
+++ b/autorest/azure/environments.go
@@ -3,11 +3,19 @@ package azure
 import (
 	"fmt"
 	"net/url"
+	"strings"
 )
 
 const (
 	activeDirectoryAPIVersion = "1.0"
 )
+
+var environments = map[string]Environment{
+	"AZURECHINACLOUD":        ChinaCloud,
+	"AZUREGERMANCLOUD":       GermanCloud,
+	"AZUREPUBLICCLOUD":       PublicCloud,
+	"AZUREUSGOVERNMENTCLOUD": USGovernmentCloud,
+}
 
 // Environment represents a set of endpoints for each of Azure's Clouds.
 type Environment struct {
@@ -100,6 +108,16 @@ var (
 		ServiceBusEndpointSuffix:  "servicebus.cloudapi.de",
 	}
 )
+
+// EnvironmentFromName returns an Environment based on the common name specified
+func EnvironmentFromName(name string) (Environment, error) {
+	name = strings.ToUpper(name)
+	env, ok := environments[name]
+	if !ok {
+		return env, fmt.Errorf("autorest/azure: There is no cloud environment matching the name %q", name)
+	}
+	return env, nil
+}
 
 // OAuthConfigForTenant returns an OAuthConfig with tenant specific urls
 func (env Environment) OAuthConfigForTenant(tenantID string) (*OAuthConfig, error) {

--- a/autorest/azure/environments_test.go
+++ b/autorest/azure/environments_test.go
@@ -29,6 +29,53 @@ func TestOAuthConfigForTenant(t *testing.T) {
 	}
 }
 
+func TestEnvironmentFromName(t *testing.T) {
+	name := "azurechinacloud"
+	if env, _ := EnvironmentFromName(name); env != ChinaCloud {
+		t.Errorf("Expected to get ChinaCloud for %q", name)
+	}
+
+	name = "AzureChinaCloud"
+	if env, _ := EnvironmentFromName(name); env != ChinaCloud {
+		t.Errorf("Expected to get ChinaCloud for %q", name)
+	}
+
+	name = "azuregermancloud"
+	if env, _ := EnvironmentFromName(name); env != GermanCloud {
+		t.Errorf("Expected to get GermanCloud for %q", name)
+	}
+
+	name = "AzureGermanCloud"
+	if env, _ := EnvironmentFromName(name); env != GermanCloud {
+		t.Errorf("Expected to get GermanCloud for %q", name)
+	}
+
+	name = "azurepubliccloud"
+	if env, _ := EnvironmentFromName(name); env != PublicCloud {
+		t.Errorf("Expected to get PublicCloud for %q", name)
+	}
+
+	name = "AzurePublicCloud"
+	if env, _ := EnvironmentFromName(name); env != PublicCloud {
+		t.Errorf("Expected to get PublicCloud for %q", name)
+	}
+
+	name = "azureusgovernmentcloud"
+	if env, _ := EnvironmentFromName(name); env != USGovernmentCloud {
+		t.Errorf("Expected to get USGovernmentCloud for %q", name)
+	}
+
+	name = "AzureUSGovernmentCloud"
+	if env, _ := EnvironmentFromName(name); env != USGovernmentCloud {
+		t.Errorf("Expected to get USGovernmentCloud for %q", name)
+	}
+
+	name = "thisisnotarealcloudenv"
+	if _, err := EnvironmentFromName(name); err == nil {
+		t.Errorf("Expected to get an error for %q", name)
+	}
+}
+
 func TestDeserializeEnvironment(t *testing.T) {
 	env := `{
 		"name": "--name--",


### PR DESCRIPTION
I need this too, so I thought to make it a helper in autorest/azure.

Rather than being so lenient, it expects exact values.

Curious about:

1. If these are the exact values we want (again, I contend we need to get ARM/someone to publish an exact guideline for this).

2. If we want to fix noun/adjective agreement

3. If we want to treat empty string as public cloud? Or if that should just be handled by caller.

CC: @boumenot @ahmetalpbalkan @paulmey 