### PR TITLE
Reformat validation error for better error message.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ go: 1.6
 install:
   - go get -u github.com/golang/lint/golint
   - go get -u github.com/Masterminds/glide
+  - go get -u github.com/stretchr/testify
   - glide install
 
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## v7.2.0
+- autorest/validation: Reformat validation error for better error message.
+
 ## v7.1.0
 - preparer: Added support for multipart formdata - WithMultiPartFormdata()
 - preparer: Added support for sending file in request body - WithFile


### PR DESCRIPTION
Added field names in parameter in validation struct. ```parameters.Properties.AutoStorage.StorageAccountID```

It will now look like below...
```Go
{resourceGroupName,
			[]validation.Constraint{{"resourceGroupName", validation.Pattern, `^[-\w\._]+$`, nil}}},
		{accountName,
			[]validation.Constraint{{"accountName", validation.MaxLength, 24, nil},
				{"accountName", validation.MinLength, 3, nil},
				{"accountName", validation.Pattern, `^[-\w\._]+$`, nil}}},
		{parameters,
			[]validation.Constraint{{"parameters.Properties", validation.Null, false,
				[]validation.Constraint{{"parameters.Properties.AutoStorage", validation.Null, false,
					[]validation.Constraint{{"parameters.Properties.AutoStorage.StorageAccountID", validation.Null, true, nil}}},
				}}}}}); err != nil {
```

Errors will be...

```batch.AccountClient#Create: Invalid input: autorest/validation: validation failed: parameter=resourceGroupName constraint=Pattern value="dhfkj$sdf" details: value doesn't match pattern ^[-\w\._]+$```


```batch.AccountClient#Create: Invalid input: autorest/validation: validation failed: parameter=accountName constraint=MinLength value="xx" details: value length must be greater than 3```


```batch.AccountClient#Create: Invalid input: autorest/validation: validation failed: parameter=parameters.Properties.AutoStorage.StorageAccountID constraint=Null value=(*string)(nil) details: value can not be null; required parameter```

