### PR TITLE
Add package testify in glide.yaml

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,15 +1,28 @@
 hash: fe11759f8785c35a54b84dcce121eab8c8f220a2c05ebe3f36087ebe5bf38528
-updated: 2016-06-22T13:31:27.2502096-07:00
+updated: 2016-08-31T12:55:26.8368496-07:00
 imports:
 - name: github.com/dgrijalva/jwt-go
-  version: f0777076321ab64f6efc15a82d9d23b98539b943
+  version: 24c63f56522a87ec5339cc3567883f1039378fdb
   subpackages:
   - .
 - name: golang.org/x/crypto
-  version: f3241ce8505855877cc8a9717bd61a0f7c4ea83c
+  version: d3c1194e7ce73913451befd89c26ca6d222f641e
   repo: https://github.com/golang/crypto.git
   vcs: git
   subpackages:
   - pkcs12
   - pkcs12/internal/rc2
-devImports: []
+testImports:
+- name: github.com/davecgh/go-spew
+  version: 6cf5744a041a0022271cefed95ba843f6d87fd51
+  subpackages:
+  - spew
+- name: github.com/pmezard/go-difflib
+  version: 792786c7400a136282c1664665ae0a8db921c6c2
+  subpackages:
+  - difflib
+- name: github.com/stretchr/testify
+  version: d77da356e56a7428ad25149ca77381849a6a5232
+  subpackages:
+  - assert
+  - require

--- a/glide.yaml
+++ b/glide.yaml
@@ -8,3 +8,9 @@ import:
   repo: https://github.com/golang/crypto.git
   subpackages:
   - /pkcs12
+testImports:
+- package: github.com/stretchr/testify
+  vcs: git
+  repo: https://github.com/stretchr/testify.git
+  subpackages:
+  - /require


### PR DESCRIPTION
Added package testify in glide.yaml.

When I did ```glide up```, it added some test imports in lock file(assuming for testify). I removed these tests imports to keep lock file clean and they are not affecting go-autorest code anyway.

```Go
hash: e9be0ae2ba50b38578ec6b497b908924851ece4a9f796714bae46327e25b9ae9
updated: 2016-08-31T11:13:52.9423908-07:00
imports:
- name: github.com/dgrijalva/jwt-go
  version: f0777076321ab64f6efc15a82d9d23b98539b943
  subpackages:
  - .
- name: github.com/stretchr/testify
  version: d77da356e56a7428ad25149ca77381849a6a5232
  repo: https://github.com/stretchr/testify.git
  vcs: git
  subpackages:
  - assert
  - require
- name: golang.org/x/crypto
  version: f3241ce8505855877cc8a9717bd61a0f7c4ea83c
  repo: https://github.com/golang/crypto.git
  vcs: git
  subpackages:
  - pkcs12
  - pkcs12/internal/rc2
testImports:
- name: github.com/davecgh/go-spew
  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
  subpackages:
  - spew
- name: github.com/pmezard/go-difflib
  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
  subpackages:
  - difflib
```