### PR TITLE
Prevent tests from accessing the network.

### DIFF
--- a/autorest/azure/token_test.go
+++ b/autorest/azure/token_test.go
@@ -363,8 +363,11 @@ func TestServicePrincipalTokenEnsureFreshSkipsIfFresh(t *testing.T) {
 func TestServicePrincipalTokenWithAuthorization(t *testing.T) {
 	spt := newServicePrincipalToken()
 	setTokenToExpireIn(&spt.Token, 1000*time.Second)
+	r := mocks.NewRequest()
+	s := mocks.NewSender()
+	spt.SetSender(s)
 
-	req, err := autorest.Prepare(&http.Request{}, spt.WithAuthorization())
+	req, err := autorest.Prepare(r, spt.WithAuthorization())
 	if err != nil {
 		t.Fatalf("azure: ServicePrincipalToken#WithAuthorization returned an error (%v)", err)
 	} else if req.Header.Get(http.CanonicalHeaderKey("Authorization")) != fmt.Sprintf("Bearer %s", spt.AccessToken) {

--- a/autorest/client_test.go
+++ b/autorest/client_test.go
@@ -153,6 +153,8 @@ func TestClientDoSetsUserAgent(t *testing.T) {
 	ua := "UserAgent"
 	c := Client{UserAgent: ua}
 	r := mocks.NewRequest()
+	s := mocks.NewSender()
+	c.Sender = s
 
 	c.Do(r)
 


### PR DESCRIPTION
As reported in #83, there are some tests that are accessing the network, which is a policy violation in Debian, and in general not a good idea. This PR fixes two of these tests.

Please note that there is another test in token_test.go (TestServicePrincipalTokenWithAuthorizationReturnsErrorIfCannotRefresh) that is also accessing the network but I was not able to fix, as I don't really know the autorest API, I am just the Debian maintainer :-)