### PR TITLE
Fix parsing of UTC times that are not RFC3339 conformant.

### DIFF
--- a/autorest/date/time.go
+++ b/autorest/date/time.go
@@ -1,12 +1,16 @@
 package date
 
 import (
+	"strings"
 	"time"
 )
 
+// Azure reports time in UTC but it doesn't include the 'Z' time zone suffix in some cases.
 const (
-	rfc3339JSON = `"` + time.RFC3339Nano + `"`
-	rfc3339     = time.RFC3339Nano
+	azureUtcFormatJSON = `"2006-01-02T15:04:05.999999999"`
+	azureUtcFormat     = "2006-01-02T15:04:05.999999999"
+	rfc3339JSON        = `"` + time.RFC3339Nano + `"`
+	rfc3339            = time.RFC3339Nano
 )
 
 // Time defines a type similar to time.Time but assumes a layout of RFC3339 date-time (i.e.,
@@ -36,7 +40,12 @@ func (t Time) MarshalJSON() (json []byte, err error) {
 // UnmarshalJSON reconstitutes the Time from a JSON string conforming to RFC3339 date-time
 // (i.e., 2006-01-02T15:04:05Z).
 func (t *Time) UnmarshalJSON(data []byte) (err error) {
-	t.Time, err = ParseTime(rfc3339JSON, string(data))
+	stringData := string(data)
+	timeFormat := azureUtcFormatJSON
+	if strings.IndexAny(stringData, "Zz") > -1 {
+		timeFormat = rfc3339JSON
+	}
+	t.Time, err = ParseTime(timeFormat, stringData)
 	return err
 }
 
@@ -49,7 +58,12 @@ func (t Time) MarshalText() (text []byte, err error) {
 // UnmarshalText reconstitutes a Time saved as a byte array conforming to RFC3339 date-time
 // (i.e., 2006-01-02T15:04:05Z).
 func (t *Time) UnmarshalText(data []byte) (err error) {
-	t.Time, err = ParseTime(rfc3339, string(data))
+	stringData := string(data)
+	timeFormat := azureUtcFormat
+	if strings.IndexAny(stringData, "Zz") > -1 {
+		timeFormat = rfc3339
+	}
+	t.Time, err = ParseTime(timeFormat, stringData)
 	return err
 }
 


### PR DESCRIPTION
Some APIs don't fully comply with RFC3339 and omit the time zone suffix
which breaks unmarshaling.  To work around this I have added another
formatting for time parsing that omits the suffix.
Ideally the APIs should return proper RFC3339 time information, will
follow up on this separately.