### PR TITLE
Fix UTC time parsing when an offset is specified.

### DIFF
--- a/autorest/date/time.go
+++ b/autorest/date/time.go
@@ -1,7 +1,7 @@
 package date
 
 import (
-	"strings"
+	"regexp"
 	"time"
 )
 
@@ -11,6 +11,7 @@ const (
 	azureUtcFormat     = "2006-01-02T15:04:05.999999999"
 	rfc3339JSON        = `"` + time.RFC3339Nano + `"`
 	rfc3339            = time.RFC3339Nano
+	tzOffsetRegex      = `(Z|z|\+|-)(\d+:\d+)*"*$`
 )
 
 // Time defines a type similar to time.Time but assumes a layout of RFC3339 date-time (i.e.,
@@ -40,12 +41,11 @@ func (t Time) MarshalJSON() (json []byte, err error) {
 // UnmarshalJSON reconstitutes the Time from a JSON string conforming to RFC3339 date-time
 // (i.e., 2006-01-02T15:04:05Z).
 func (t *Time) UnmarshalJSON(data []byte) (err error) {
-	stringData := string(data)
 	timeFormat := azureUtcFormatJSON
-	if strings.IndexAny(stringData, "Zz") > -1 {
+	if m, _ := regexp.Match(tzOffsetRegex, data); m {
 		timeFormat = rfc3339JSON
 	}
-	t.Time, err = ParseTime(timeFormat, stringData)
+	t.Time, err = ParseTime(timeFormat, string(data))
 	return err
 }
 
@@ -58,12 +58,11 @@ func (t Time) MarshalText() (text []byte, err error) {
 // UnmarshalText reconstitutes a Time saved as a byte array conforming to RFC3339 date-time
 // (i.e., 2006-01-02T15:04:05Z).
 func (t *Time) UnmarshalText(data []byte) (err error) {
-	stringData := string(data)
 	timeFormat := azureUtcFormat
-	if strings.IndexAny(stringData, "Zz") > -1 {
+	if m, _ := regexp.Match(tzOffsetRegex, data); m {
 		timeFormat = rfc3339
 	}
-	t.Time, err = ParseTime(timeFormat, stringData)
+	t.Time, err = ParseTime(timeFormat, string(data))
 	return err
 }
 

--- a/autorest/date/time.go
+++ b/autorest/date/time.go
@@ -42,7 +42,10 @@ func (t Time) MarshalJSON() (json []byte, err error) {
 // (i.e., 2006-01-02T15:04:05Z).
 func (t *Time) UnmarshalJSON(data []byte) (err error) {
 	timeFormat := azureUtcFormatJSON
-	if m, _ := regexp.Match(tzOffsetRegex, data); m {
+	match, err := regexp.Match(tzOffsetRegex, data)
+	if err != nil {
+		return err
+	} else if match {
 		timeFormat = rfc3339JSON
 	}
 	t.Time, err = ParseTime(timeFormat, string(data))
@@ -59,7 +62,10 @@ func (t Time) MarshalText() (text []byte, err error) {
 // (i.e., 2006-01-02T15:04:05Z).
 func (t *Time) UnmarshalText(data []byte) (err error) {
 	timeFormat := azureUtcFormat
-	if m, _ := regexp.Match(tzOffsetRegex, data); m {
+	match, err := regexp.Match(tzOffsetRegex, data)
+	if err != nil {
+		return err
+	} else if match {
 		timeFormat = rfc3339
 	}
 	t.Time, err = ParseTime(timeFormat, string(data))

--- a/autorest/date/time_test.go
+++ b/autorest/date/time_test.go
@@ -201,3 +201,63 @@ func TestTimeToTime(t *testing.T) {
 	}
 	var _ time.Time = d.ToTime()
 }
+
+func TestUnmarshalJSONNoOffset(t *testing.T) {
+	var d struct {
+		Time Time `json:"datetime"`
+	}
+	j := `{"datetime" : "2001-02-03T04:05:06.789"}`
+
+	if err := json.Unmarshal([]byte(j), &d); err != nil {
+		t.Fatalf("date: Time#Unmarshal failed (%v)", err)
+	}
+}
+
+func TestUnmarshalJSONPosOffset(t *testing.T) {
+	var d struct {
+		Time Time `json:"datetime"`
+	}
+	j := `{"datetime" : "1980-01-02T00:11:35.01+01:00"}`
+
+	if err := json.Unmarshal([]byte(j), &d); err != nil {
+		t.Fatalf("date: Time#Unmarshal failed (%v)", err)
+	}
+}
+
+func TestUnmarshalJSONNegOffset(t *testing.T) {
+	var d struct {
+		Time Time `json:"datetime"`
+	}
+	j := `{"datetime" : "1492-10-12T10:15:01.789-08:00"}`
+
+	if err := json.Unmarshal([]byte(j), &d); err != nil {
+		t.Fatalf("date: Time#Unmarshal failed (%v)", err)
+	}
+}
+
+func TestUnmarshalTextNoOffset(t *testing.T) {
+	d := Time{}
+	t1 := "2001-02-03T04:05:06"
+
+	if err := d.UnmarshalText([]byte(t1)); err != nil {
+		t.Fatalf("date: Time#UnmarshalText failed (%v)", err)
+	}
+}
+
+func TestUnmarshalTextPosOffset(t *testing.T) {
+	d := Time{}
+	t1 := "2001-02-03T04:05:06+00:30"
+
+	if err := d.UnmarshalText([]byte(t1)); err != nil {
+		t.Fatalf("date: Time#UnmarshalText failed (%v)", err)
+	}
+}
+
+func TestUnmarshalTextNegOffset(t *testing.T) {
+	d := Time{}
+	t1 := "2001-02-03T04:05:06-11:00"
+
+	if err := d.UnmarshalText([]byte(t1)); err != nil {
+		t.Fatalf("date: Time#UnmarshalText failed (%v)", err)
+	}
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,28 +1,40 @@
-hash: fe11759f8785c35a54b84dcce121eab8c8f220a2c05ebe3f36087ebe5bf38528
-updated: 2016-08-31T12:55:26.8368496-07:00
+hash: 51202aefdfe9c4a992f96ab58f6cacf21cdbd1b66efe955c9030bca736ac816d
+updated: 2016-09-29T13:30:42.5916675-07:00
 imports:
 - name: github.com/dgrijalva/jwt-go
   version: 24c63f56522a87ec5339cc3567883f1039378fdb
   subpackages:
   - .
 - name: golang.org/x/crypto
-  version: d3c1194e7ce73913451befd89c26ca6d222f641e
+  version: a20de3fa94e069ec699987416679230d72e030a3
   repo: https://github.com/golang/crypto.git
   vcs: git
   subpackages:
   - pkcs12
   - pkcs12/internal/rc2
+- name: golang.org/x/net
+  version: 8058fc7b18f8794d9fc57eee98d64fe2c750e3f1
+  repo: https://github.com/golang/net.git
+  vcs: git
+  subpackages:
+  - .
+- name: golang.org/x/text
+  version: a7c023693a94aedd6b6df43ae7526bfe9d2b7d22
+  repo: https://github.com/golang/text.git
+  vcs: git
+  subpackages:
+  - .
 testImports:
 - name: github.com/davecgh/go-spew
-  version: 6cf5744a041a0022271cefed95ba843f6d87fd51
+  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
   subpackages:
   - spew
 - name: github.com/pmezard/go-difflib
-  version: 792786c7400a136282c1664665ae0a8db921c6c2
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: d77da356e56a7428ad25149ca77381849a6a5232
+  version: 976c720a22c8eb4eb6a0b4348ad85ad12491a506
   subpackages:
-  - assert
   - require
+  - assert

--- a/glide.yaml
+++ b/glide.yaml
@@ -8,6 +8,16 @@ import:
   repo: https://github.com/golang/crypto.git
   subpackages:
   - /pkcs12
+- package: golang.org/x/net
+  vcs: git
+  repo: https://github.com/golang/net.git
+  subpackages:
+  - .
+- package: golang.org/x/text
+  vcs: git
+  repo: https://github.com/golang/text.git
+  subpackages:
+  - .
 testImports:
 - package: github.com/stretchr/testify
   vcs: git


### PR DESCRIPTION
The change made in commit 55719cb didn't account for positive or negative
offsets, this change fixes that.  Added test coverage for this scenario.