### PR TITLE
AUD Claim Fix to have string value

### DIFF
--- a/autorest/azure/token.go
+++ b/autorest/azure/token.go
@@ -138,7 +138,7 @@ func (secret *ServicePrincipalCertificateSecret) SignJwt(spt *ServicePrincipalTo
 	token := jwt.New(jwt.SigningMethodRS256)
 	token.Header["x5t"] = thumbprint
 	token.Claims = jwt.MapClaims{
-		"aud": spt.oauthConfig.TokenEndpoint,
+		"aud": spt.oauthConfig.TokenEndpoint.String(),
 		"iss": spt.clientID,
 		"sub": spt.clientID,
 		"jti": base64.URLEncoding.EncodeToString(jti),


### PR DESCRIPTION
Currently, the token API is failing for cert based secrets. The failure is because of invalid aud claim. Fixing audience (aud) claim to have string value, rather than URL object