### PR TITLE
Fix for a few test bugs.

### DIFF
--- a/autorest/azure/persist_test.go
+++ b/autorest/azure/persist_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"os"
+	"path"
 	"reflect"
 	"runtime"
 	"strings"
@@ -134,7 +135,7 @@ func TestSaveToken(t *testing.T) {
 func TestSaveTokenFailsNoPermission(t *testing.T) {
 	pathWhereWeShouldntHavePermission := "/usr/thiswontwork/atall"
 	if runtime.GOOS == "windows" {
-		pathWhereWeShouldntHavePermission = "c:\\windows\\system32\\mytokendir\\mytoken"
+		pathWhereWeShouldntHavePermission = path.Join(os.Getenv("windir"), "system32\\mytokendir\\mytoken")
 	}
 	err := SaveToken(pathWhereWeShouldntHavePermission, 0644, *token())
 	expectedSubstring := "failed to create directory"
@@ -144,7 +145,11 @@ func TestSaveTokenFailsNoPermission(t *testing.T) {
 }
 
 func TestSaveTokenFailsCantCreate(t *testing.T) {
-	err := SaveToken("/thiswontwork", 0644, *token())
+	tokenPath := "/thiswontwork"
+	if runtime.GOOS == "windows" {
+		tokenPath = path.Join(os.Getenv("windir"), "system32")
+	}
+	err := SaveToken(tokenPath, 0644, *token())
 	expectedSubstring := "failed to create the temp file to write the token"
 	if err == nil || !strings.Contains(err.Error(), expectedSubstring) {
 		t.Fatalf("azure: failed to get correct error expected(%s) actual(%v)", expectedSubstring, err)

--- a/autorest/azure/token_test.go
+++ b/autorest/azure/token_test.go
@@ -377,8 +377,11 @@ func TestServicePrincipalTokenWithAuthorization(t *testing.T) {
 
 func TestServicePrincipalTokenWithAuthorizationReturnsErrorIfCannotRefresh(t *testing.T) {
 	spt := newServicePrincipalToken()
+	s := mocks.NewSender()
+	s.AppendResponse(mocks.NewResponseWithStatus("400 Bad Request", 400))
+	spt.SetSender(s)
 
-	_, err := autorest.Prepare(&http.Request{}, spt.WithAuthorization())
+	_, err := autorest.Prepare(mocks.NewRequest(), spt.WithAuthorization())
 	if err == nil {
 		t.Fatal("azure: ServicePrincipalToken#WithAuthorization failed to return an error when refresh fails")
 	}


### PR DESCRIPTION
Fixed hard-coded assumption on windir being "c:\windows".
The test "TestSaveTokenFailsCantCreate" now passes on Windows OS.
Fixed token test to use a mock so it doesn't hit the network.