### PR TITLE
New responder to unmarshal success or error response at one place.

### DIFF
--- a/autorest/azure/azure.go
+++ b/autorest/azure/azure.go
@@ -28,6 +28,17 @@ const (
 	HeaderRequestID = "x-ms-request-id"
 )
 
+// AAD Service Error encapsulates the error response from Azure Token Service.
+type AADServiceError struct {
+    ErrorTitle       string  `json:"error"`
+    ErrorDescription string  `json:"error_description"`
+    ErrorCodes       []int   `json:"error_codes"`
+    TraceId          string  `json:"trace_id"`
+    CorrelationId    string  `json:"correlation_id"`
+}
+func (aade *AADServiceError) Error() string {
+    return fmt.Sprintf("Error=%q Message=%q", aade.ErrorTitle, aade.ErrorDescription)
+}
 // ServiceError encapsulates the error response from an Azure service.
 type ServiceError struct {
 	Code    string         `json:"code"`

--- a/autorest/azure/azure.go
+++ b/autorest/azure/azure.go
@@ -28,13 +28,13 @@ const (
 	HeaderRequestID = "x-ms-request-id"
 )
 
-// AAD Service Error encapsulates the error response from Azure Token Service.
+// AADServiceError encapsulates the error response from Azure Token Service.
 type AADServiceError struct {
     ErrorTitle       string  `json:"error"`
     ErrorDescription string  `json:"error_description"`
     ErrorCodes       []int   `json:"error_codes"`
-    TraceId          string  `json:"trace_id"`
-    CorrelationId    string  `json:"correlation_id"`
+    TraceID          string  `json:"trace_id"`
+    CorrelationID    string  `json:"correlation_id"`
 }
 func (aade *AADServiceError) Error() string {
     return fmt.Sprintf("Error=%q Message=%q", aade.ErrorTitle, aade.ErrorDescription)

--- a/autorest/azure/token.go
+++ b/autorest/azure/token.go
@@ -301,14 +301,17 @@ func (spt *ServicePrincipalToken) refreshInternal(resource string) error {
 	}
 
 	var newToken Token
+	var aadError AADServiceError
 	err = autorest.Respond(resp,
 		autorest.WithErrorUnlessOK(),
-		autorest.ByUnmarshallingJSON(&newToken),
+		autorest.ByUnmarshallingSuccessandErrorJSON(&newToken, &aadError),
 		autorest.ByClosing())
 	if err != nil {
-		return autorest.NewErrorWithError(err,
+		newerr := autorest.NewErrorWithError(err,
 			"azure.ServicePrincipalToken", "Refresh", resp, "Failure handling response to Service Principal %s request",
 			spt.clientID)
+		newerr.ServiceError = aadError
+		return newerr
 	}
 
 	spt.Token = newToken

--- a/autorest/error.go
+++ b/autorest/error.go
@@ -28,6 +28,9 @@ type DetailedError struct {
 
 	// Message is the error message.
 	Message string
+
+	// Service Error is the response body of failed API.
+	ServiceError interface{}
 }
 
 // NewError creates a new Error conforming object from the passed packageType, method, and


### PR DESCRIPTION
Adding responder which can deal with both success and error response. This will also help to consolidate usage of response.Body at one place. Depending on API result, response body is unmarshalled to either success type or error type.