### PR TITLE
New responder to unmarshal success or error response at one place.

### DIFF
--- a/autorest/azure/token.go
+++ b/autorest/azure/token.go
@@ -302,7 +302,7 @@ func (spt *ServicePrincipalToken) refreshInternal(resource string) error {
 
 	var newToken Token
 	err = autorest.Respond(resp,
-		autorest.WithErrorUnlessOK(),
+		autorest.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&newToken),
 		autorest.ByClosing())
 	if err != nil {

--- a/autorest/error.go
+++ b/autorest/error.go
@@ -28,6 +28,9 @@ type DetailedError struct {
 
 	// Message is the error message.
 	Message string
+
+	// Service Error is the response body of failed API in bytes
+	ServiceError []byte
 }
 
 // NewError creates a new Error conforming object from the passed packageType, method, and

--- a/autorest/responder.go
+++ b/autorest/responder.go
@@ -165,17 +165,24 @@ func ByUnmarshallingXML(v interface{}) RespondDecorator {
 }
 
 // WithErrorUnlessStatusCode returns a RespondDecorator that emits an error unless the response
-// StatusCode is among the set passed. Since these are artificial errors, the response body
-// may still require closing.
+// StatusCode is among the set passed. On error, response body is fully read into a buffer and
+// presented in the returned error, as well as in the response body.
 func WithErrorUnlessStatusCode(codes ...int) RespondDecorator {
 	return func(r Responder) Responder {
 		return ResponderFunc(func(resp *http.Response) error {
 			err := r.Respond(resp)
 			if err == nil && !ResponseHasStatusCode(resp, codes...) {
-				err = NewErrorWithResponse("autorest", "WithErrorUnlessStatusCode", resp, "%v %v failed with %s",
+				derr := NewErrorWithResponse("autorest", "WithErrorUnlessStatusCode", resp, "%v %v failed with %s",
 					resp.Request.Method,
 					resp.Request.URL,
 					resp.Status)
+				if resp.Body != nil {
+					defer resp.Body.Close()
+					b, _ := ioutil.ReadAll(resp.Body)
+					derr.ServiceError = b
+					resp.Body = ioutil.NopCloser(bytes.NewReader(b))
+				}
+				err = derr
 			}
 			return err
 		})


### PR DESCRIPTION
Adding responder which can deal with both success and error response. This will also help to consolidate usage of response.Body at one place. Depending on API result, response body is unmarshalled to either success type or error type.