### PR TITLE
Adding telemetry

### DIFF
--- a/autorest/client.go
+++ b/autorest/client.go
@@ -152,6 +152,8 @@ func NewClientWithUserAgent(ua string) Client {
 	return c
 }
 
+// getDefaultUserAgent builds a string containing the Go version, system archityecture and OS,
+// and the go-autorest version.
 func getDefaultUserAgent() string {
 	return fmt.Sprintf("Go/%s (%s-%s) go-autorest/%s",
 		runtime.Version(),

--- a/autorest/client.go
+++ b/autorest/client.go
@@ -23,13 +23,24 @@ const (
 	DefaultRetryAttempts = 3
 )
 
-var statusCodesForRetry = []int{
-	http.StatusRequestTimeout,      // 408
-	http.StatusInternalServerError, // 500
-	http.StatusBadGateway,          // 502
-	http.StatusServiceUnavailable,  // 503
-	http.StatusGatewayTimeout,      // 504
-}
+var (
+	// defaultUserAgent builds a string containing the Go version, system archityecture and OS,
+	// and the go-autorest version.
+	defaultUserAgent = fmt.Sprintf("Go/%s (%s-%s) go-autorest/%s",
+		runtime.Version(),
+		runtime.GOARCH,
+		runtime.GOOS,
+		Version(),
+	)
+
+	statusCodesForRetry = []int{
+		http.StatusRequestTimeout,      // 408
+		http.StatusInternalServerError, // 500
+		http.StatusBadGateway,          // 502
+		http.StatusServiceUnavailable,  // 503
+		http.StatusGatewayTimeout,      // 504
+	}
+)
 
 const (
 	requestFormat = `HTTP Request Begin ===================================================
@@ -146,28 +157,19 @@ func NewClientWithUserAgent(ua string) Client {
 		PollingDuration: DefaultPollingDuration,
 		RetryAttempts:   DefaultRetryAttempts,
 		RetryDuration:   30 * time.Second,
-		UserAgent:       getDefaultUserAgent(),
+		UserAgent:       defaultUserAgent,
 	}
 	c.AddToUserAgent(ua)
 	return c
 }
 
-// getDefaultUserAgent builds a string containing the Go version, system archityecture and OS,
-// and the go-autorest version.
-func getDefaultUserAgent() string {
-	return fmt.Sprintf("Go/%s (%s-%s) go-autorest/%s",
-		runtime.Version(),
-		runtime.GOARCH,
-		runtime.GOOS,
-		Version(),
-	)
-}
-
 // AddToUserAgent adds an extension to the current user agent
-func (c *Client) AddToUserAgent(extension string) {
+func (c *Client) AddToUserAgent(extension string) error {
 	if extension != "" {
 		c.UserAgent = fmt.Sprintf("%s %s", c.UserAgent, extension)
+		return nil
 	}
+	return fmt.Errorf("Extension was empty, User Agent stayed as %s", c.UserAgent)
 }
 
 // Do implements the Sender interface by invoking the active Sender after applying authorization.

--- a/autorest/client.go
+++ b/autorest/client.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net/http"
 	"net/http/cookiejar"
+	"runtime"
 	"time"
 )
 
@@ -140,12 +141,30 @@ type Client struct {
 // NewClientWithUserAgent returns an instance of a Client with the UserAgent set to the passed
 // string.
 func NewClientWithUserAgent(ua string) Client {
-	return Client{
+	c := Client{
 		PollingDelay:    DefaultPollingDelay,
 		PollingDuration: DefaultPollingDuration,
 		RetryAttempts:   DefaultRetryAttempts,
 		RetryDuration:   30 * time.Second,
-		UserAgent:       ua,
+		UserAgent:       getDefaultUserAgent(),
+	}
+	c.AddToUserAgent(ua)
+	return c
+}
+
+func getDefaultUserAgent() string {
+	return fmt.Sprintf("Go/%s (%s-%s) go-autorest/%s",
+		runtime.Version(),
+		runtime.GOARCH,
+		runtime.GOOS,
+		Version(),
+	)
+}
+
+// AddToUserAgent adds an extension to the current user agent
+func (c *Client) AddToUserAgent(extension string) {
+	if extension != "" {
+		c.UserAgent = fmt.Sprintf("%s %s", c.UserAgent, extension)
 	}
 }
 

--- a/autorest/client_test.go
+++ b/autorest/client_test.go
@@ -111,7 +111,7 @@ func TestLoggingInspectorByInspectingRestoresBody(t *testing.T) {
 func TestNewClientWithUserAgent(t *testing.T) {
 	ua := "UserAgent"
 	c := NewClientWithUserAgent(ua)
-	completeUA := fmt.Sprintf("%s %s", getDefaultUserAgent(), ua)
+	completeUA := fmt.Sprintf("%s %s", defaultUserAgent, ua)
 
 	if c.UserAgent != completeUA {
 		t.Fatalf("autorest: NewClientWithUserAgent failed to set the UserAgent -- expected %s, received %s",
@@ -123,15 +123,22 @@ func TestAddToUserAgent(t *testing.T) {
 	ua := "UserAgent"
 	c := NewClientWithUserAgent(ua)
 	ext := "extension"
-	c.AddToUserAgent(ext)
-	completeUA := fmt.Sprintf("%s %s %s", getDefaultUserAgent(), ua, ext)
+	err := c.AddToUserAgent(ext)
+	if err != nil {
+		t.Fatalf("autorest: AddToUserAgent returned error -- expected nil, received %s", err)
+	}
+	completeUA := fmt.Sprintf("%s %s %s", defaultUserAgent, ua, ext)
 
 	if c.UserAgent != completeUA {
 		t.Fatalf("autorest: AddToUserAgent failed to add an extension to the UserAgent -- expected %s, received %s",
 			completeUA, c.UserAgent)
 	}
 
-	c.AddToUserAgent("")
+	err = c.AddToUserAgent("")
+	if err == nil {
+		t.Fatalf("autorest: AddToUserAgent didn't return error -- expected %s, received nil",
+			fmt.Errorf("Extension was empty, User Agent stayed as %s", c.UserAgent))
+	}
 	if c.UserAgent != completeUA {
 		t.Fatalf("autorest: AddToUserAgent failed to not add an empty extension to the UserAgent -- expected %s, received %s",
 			completeUA, c.UserAgent)

--- a/autorest/client_test.go
+++ b/autorest/client_test.go
@@ -111,10 +111,30 @@ func TestLoggingInspectorByInspectingRestoresBody(t *testing.T) {
 func TestNewClientWithUserAgent(t *testing.T) {
 	ua := "UserAgent"
 	c := NewClientWithUserAgent(ua)
+	completeUA := fmt.Sprintf("%s %s", getDefaultUserAgent(), ua)
 
-	if c.UserAgent != ua {
+	if c.UserAgent != completeUA {
 		t.Fatalf("autorest: NewClientWithUserAgent failed to set the UserAgent -- expected %s, received %s",
-			ua, c.UserAgent)
+			completeUA, c.UserAgent)
+	}
+}
+
+func TestAddToUserAgent(t *testing.T) {
+	ua := "UserAgent"
+	c := NewClientWithUserAgent(ua)
+	ext := "extension"
+	c.AddToUserAgent(ext)
+	completeUA := fmt.Sprintf("%s %s %s", getDefaultUserAgent(), ua, ext)
+
+	if c.UserAgent != completeUA {
+		t.Fatalf("autorest: AddToUserAgent failed to add an extension to the UserAgent -- expected %s, received %s",
+			completeUA, c.UserAgent)
+	}
+
+	c.AddToUserAgent("")
+	if c.UserAgent != completeUA {
+		t.Fatalf("autorest: AddToUserAgent failed to not add an empty extension to the UserAgent -- expected %s, received %s",
+			completeUA, c.UserAgent)
 	}
 }
 

--- a/autorest/version.go
+++ b/autorest/version.go
@@ -7,7 +7,7 @@ import (
 const (
 	major        = "7"
 	minor        = "2"
-	patch        = "2"
+	patch        = "3"
 	tag          = ""
 	semVerFormat = "%s.%s.%s%s"
 )

--- a/autorest/version.go
+++ b/autorest/version.go
@@ -6,8 +6,8 @@ import (
 
 const (
 	major        = "7"
-	minor        = "0"
-	patch        = "0"
+	minor        = "2"
+	patch        = "2"
 	tag          = ""
 	semVerFormat = "%s.%s.%s%s"
 )

--- a/autorest/version.go
+++ b/autorest/version.go
@@ -7,7 +7,7 @@ import (
 const (
 	major        = "7"
 	minor        = "2"
-	patch        = "3"
+	patch        = "4"
 	tag          = ""
 	semVerFormat = "%s.%s.%s%s"
 )

--- a/autorest/version_test.go
+++ b/autorest/version_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestVersion(t *testing.T) {
-	v := "7.2.2"
+	v := "7.2.3"
 	if Version() != v {
 		t.Fatalf("autorest: Version failed to return the expected version -- expected %s, received %s",
 			v, Version())

--- a/autorest/version_test.go
+++ b/autorest/version_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestVersion(t *testing.T) {
-	v := "7.0.0"
+	v := "7.2.2"
 	if Version() != v {
 		t.Fatalf("autorest: Version failed to return the expected version -- expected %s, received %s",
 			v, Version())

--- a/autorest/version_test.go
+++ b/autorest/version_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestVersion(t *testing.T) {
-	v := "7.2.3"
+	v := "7.2.4"
 	if Version() != v {
 		t.Fatalf("autorest: Version failed to return the expected version -- expected %s, received %s",
 			v, Version())


### PR DESCRIPTION
An example user agent looks like this...
```
Go/go1.7 (amd64-windows) go-autorest/7.2.2
```

Another example. When using ARM packages in the Azure SDK for Go, the user agent would look like this...
```
Go/go1.7 (amd64-windows) go-autorest/7.2.2 Azure-SDK-for-Go/7.0.1-beta arm-resources/2016-09-01
```

Just like in the [Ruby SDK](https://github.com/Azure/azure-sdk-for-ruby/pull/543), users can also add more info with `AddToUserAgent`.
PTAL
@kirthik @salameer @jhendrixMSFT @marstr @vishrutshah 