### PR TITLE
Pass attempt 0 to DelayForBackoff in AfterDelay

### DIFF
--- a/autorest/sender.go
+++ b/autorest/sender.go
@@ -73,7 +73,7 @@ func SendWithSender(s Sender, r *http.Request, decorators ...SendDecorator) (*ht
 func AfterDelay(d time.Duration) SendDecorator {
 	return func(s Sender) Sender {
 		return SenderFunc(func(r *http.Request) (*http.Response, error) {
-			if !DelayForBackoff(d, 1, r.Cancel) {
+			if !DelayForBackoff(d, 0, r.Cancel) {
 				return nil, fmt.Errorf("autorest: AfterDelay canceled before full delay")
 			}
 			return s.Do(r)


### PR DESCRIPTION
Passing 1 to DelayForBackoff results in the delay being doubled. If a delay
of 1 minute is used, it is unexpected that the polling delays for 2
minutes.

Encountered while debugging https://github.com/kubernetes/kubernetes/issues/35180#issuecomment-273085063