### PR TITLE
Updating Version() test to assert it is updated

### DIFF
--- a/autorest/version.go
+++ b/autorest/version.go
@@ -12,7 +12,12 @@ const (
 	semVerFormat = "%s.%s.%s%s"
 )
 
+var version string
+
 // Version returns the semantic version (see http://semver.org).
 func Version() string {
-	return fmt.Sprintf(semVerFormat, major, minor, patch, tag)
+	if "" == version {
+		version = fmt.Sprintf(semVerFormat, major, minor, patch, tag)
+	}
+	return version
 }

--- a/autorest/version.go
+++ b/autorest/version.go
@@ -16,7 +16,7 @@ var version string
 
 // Version returns the semantic version (see http://semver.org).
 func Version() string {
-	if "" == version {
+	if version == "" {
 		version = fmt.Sprintf(semVerFormat, major, minor, patch, tag)
 	}
 	return version

--- a/autorest/version_test.go
+++ b/autorest/version_test.go
@@ -1,13 +1,79 @@
 package autorest
 
 import (
+	"io"
+	"os/exec"
 	"testing"
+
+	"fmt"
+
+	"sync"
+
+	"github.com/Masterminds/semver"
 )
 
 func TestVersion(t *testing.T) {
-	v := "7.2.4"
-	if Version() != v {
-		t.Fatalf("autorest: Version failed to return the expected version -- expected %s, received %s",
-			v, Version())
+	var declaredVersion *semver.Version
+	if temp, err := semver.NewVersion(Version()); nil == err {
+		declaredVersion = temp
+		t.Logf("Declared Version: %s", declaredVersion.String())
+	} else {
+		t.Error(err)
 	}
+
+	var currentVersion *semver.Version
+	if temp, err := getMaxReleasedVersion(); nil == err {
+		currentVersion = temp
+		t.Logf("Current Release Version: %s", currentVersion.String())
+	} else {
+		t.Error(err)
+	}
+
+	if !declaredVersion.GreaterThan(currentVersion) {
+		t.Log("autorest: Assertion that the Declared version is greater than Current Release Version failed", currentVersion.String(), declaredVersion.String())
+		t.Fail()
+	}
+}
+
+// Variables required by getMaxReleasedVersion. None of these variables should be used outside of that
+// function.
+var (
+	maxReleasedVersion *semver.Version
+)
+
+func getMaxReleasedVersion() (*semver.Version, error) {
+	if nil == maxReleasedVersion {
+		var wg sync.WaitGroup
+		var currentTag string
+		var emptyVersion semver.Version
+		reader, writer := io.Pipe()
+		tagLister := exec.Command("git", "tag")
+		tagLister.Stdout = writer
+
+		if err := tagLister.Start(); nil != err {
+			return nil, err
+		}
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			maxReleasedVersion = &emptyVersion
+			for {
+				if parity, err := fmt.Fscanln(reader, &currentTag); err != nil || parity != 1 {
+					break
+				}
+
+				if currentVersion, err := semver.NewVersion(currentTag); err == nil && currentVersion.GreaterThan(maxReleasedVersion) {
+					maxReleasedVersion = currentVersion
+				}
+			}
+		}()
+
+		if err := tagLister.Wait(); nil != err {
+			return nil, err
+		}
+		writer.Close()
+		wg.Wait()
+	}
+	return maxReleasedVersion, nil
 }

--- a/autorest/version_test.go
+++ b/autorest/version_test.go
@@ -1,15 +1,12 @@
 package autorest
 
 import (
+	"errors"
+	"fmt"
 	"io"
 	"os/exec"
-	"testing"
-
-	"fmt"
-
 	"sync"
-
-	"errors"
+	"testing"
 
 	"github.com/Masterminds/semver"
 )
@@ -18,20 +15,20 @@ func TestVersion(t *testing.T) {
 	var declaredVersion *semver.Version
 	if temp, err := semver.NewVersion(Version()); nil == err {
 		declaredVersion = temp
-		t.Logf("Declared Version: %s", declaredVersion.String())
 	} else {
 		t.Error(err)
 		t.FailNow()
 	}
+	t.Logf("Declared Version: %s", declaredVersion.String())
 
 	var currentVersion *semver.Version
 	if temp, err := getMaxReleasedVersion(); nil == err {
 		currentVersion = temp
-		t.Logf("Current Release Version: %s", currentVersion.String())
 	} else {
 		t.Error(err)
 		t.FailNow()
 	}
+	t.Logf("Current Release Version: %s", currentVersion.String())
 
 	if !declaredVersion.GreaterThan(currentVersion) {
 		t.Log("autorest: Assertion that the Declared version is greater than Current Release Version failed", currentVersion.String(), declaredVersion.String())

--- a/glide.lock
+++ b/glide.lock
@@ -1,40 +1,42 @@
 hash: 51202aefdfe9c4a992f96ab58f6cacf21cdbd1b66efe955c9030bca736ac816d
-updated: 2016-10-25T10:45:46.536665-07:00
+updated: 2017-01-19T10:37:32.4976575-08:00
 imports:
 - name: github.com/dgrijalva/jwt-go
-  version: 24c63f56522a87ec5339cc3567883f1039378fdb
+  version: a601269ab70c205d26370c16f7c81e9017c14e04
   subpackages:
   - .
 - name: golang.org/x/crypto
-  version: d3c1194e7ce73913451befd89c26ca6d222f641e
+  version: b8a2a83acfe6e6770b75de42d5ff4c67596675c0
   repo: https://github.com/golang/crypto.git
   vcs: git
   subpackages:
   - pkcs12
   - pkcs12/internal/rc2
 - name: golang.org/x/net
-  version: 65dfc08770ce66f74becfdff5f8ab01caef4e946
+  version: f2499483f923065a842d38eb4c7f1927e6fc6e6d
   repo: https://github.com/golang/net.git
   vcs: git
   subpackages:
   - .
 - name: golang.org/x/text
-  version: 16e1d1f27f7aba51c74c0aeb7a7ee31a75c5c63c
+  version: 11dbc599981ccdf4fb18802a28392a8bcf7a9395
   repo: https://github.com/golang/text.git
   vcs: git
   subpackages:
   - .
 testImports:
 - name: github.com/davecgh/go-spew
-  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
+  version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
   subpackages:
   - spew
+- name: github.com/Masterminds/semver
+  version: 59c29afe1a994eacb71c833025ca7acf874bb1da
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: d77da356e56a7428ad25149ca77381849a6a5232
+  version: 2402e8e7a02fc811447d11f881aa9746cdc57983
   subpackages:
   - require
   - assert

--- a/glide.yaml
+++ b/glide.yaml
@@ -25,3 +25,4 @@ testImports:
   subpackages:
   - /require
 - package: github.com/Masterminds/semver
+  version: ~1.2.2

--- a/glide.yaml
+++ b/glide.yaml
@@ -24,3 +24,4 @@ testImports:
   repo: https://github.com/stretchr/testify.git
   subpackages:
   - /require
+- package: github.com/Masterminds/semver


### PR DESCRIPTION
For the v7.2.3 release, the autorest.Version() function didn't get
updated to reflect the new release. To ensure that doesn't happen again,
the TestVersion() function was updated to make sure that when commited,
the version is greater than the most recently relesed version.

This added a tight coupling with Git and using tags as release
mechanisms.