### PR TITLE
Fixing a personal nit in the Version() function.

### DIFF
--- a/autorest/version.go
+++ b/autorest/version.go
@@ -1,15 +1,16 @@
 package autorest
 
 import (
+	"bytes"
 	"fmt"
+	"strings"
 )
 
 const (
-	major        = "7"
-	minor        = "3"
-	patch        = "1"
-	tag          = ""
-	semVerFormat = "%s.%s.%s%s"
+	major = 7
+	minor = 3
+	patch = 1
+	tag   = ""
 )
 
 var version string
@@ -17,7 +18,13 @@ var version string
 // Version returns the semantic version (see http://semver.org).
 func Version() string {
 	if version == "" {
-		version = fmt.Sprintf(semVerFormat, major, minor, patch, tag)
+		verBuilder := bytes.NewBufferString(fmt.Sprintf("%d.%d.%d", major, minor, patch))
+		if tag != "" && tag != "-" {
+			updated := strings.TrimPrefix(tag, "-")
+			verBuilder.WriteRune('-')
+			verBuilder.WriteString(updated)
+		}
+		version = verBuilder.String()
 	}
 	return version
 }


### PR DESCRIPTION
This will match the auto-generated ARM `Version()` functions in [Azure/azure-sdk-for-go](https://github.com/Azure/azure-sdk-for-go). Also, it helps employ the type system to prevent people from shooting themselves in the foot when updating the reported version.

