### PR TITLE
Updating CI to use Go 1.8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 
 language: go
 
-go: 1.7
+go: 1.8
 
 install:
   - go get -u github.com/golang/lint/golint


### PR DESCRIPTION
Several of our partners have upgraded to use Go 1.8. In order to support
them, CI should do this.

https://beta.golang.org/doc/go1.8