### PR TITLE
Cleaning up redundant consts.

### DIFF
--- a/autorest/azure/async.go
+++ b/autorest/azure/async.go
@@ -17,12 +17,6 @@ const (
 )
 
 const (
-	methodDelete = "DELETE"
-	methodPatch  = "PATCH"
-	methodPost   = "POST"
-	methodPut    = "PUT"
-	methodGet    = "GET"
-
 	operationInProgress string = "InProgress"
 	operationCanceled   string = "Canceled"
 	operationFailed     string = "Failed"
@@ -226,7 +220,7 @@ func updatePollingState(resp *http.Response, ps *pollingState) error {
 		// Lastly, requests against an existing resource, use the last request URI
 		if ps.uri == "" {
 			m := strings.ToUpper(req.Method)
-			if m == methodPatch || m == methodPut || m == methodGet {
+			if m == http.MethodPatch || m == http.MethodPut || m == http.MethodGet {
 				ps.uri = req.URL.String()
 			}
 		}

--- a/autorest/azure/async_test.go
+++ b/autorest/azure/async_test.go
@@ -358,7 +358,7 @@ func TestUpdatePollingState_UsesTheObjectLocationIfAsyncHeadersAreMissing(t *tes
 	resp := newAsynchronousResponse()
 	resp.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
 	resp.Header.Del(http.CanonicalHeaderKey(autorest.HeaderLocation))
-	resp.Request.Method = methodPatch
+	resp.Request.Method = http.MethodPatch
 
 	ps := pollingState{}
 	updatePollingState(resp, &ps)
@@ -369,7 +369,7 @@ func TestUpdatePollingState_UsesTheObjectLocationIfAsyncHeadersAreMissing(t *tes
 }
 
 func TestUpdatePollingState_RecognizesLowerCaseHTTPVerbs(t *testing.T) {
-	for _, m := range []string{"patch", "put", "get"} {
+	for _, m := range []string{strings.ToLower(http.MethodPatch), strings.ToLower(http.MethodPut), strings.ToLower(http.MethodGet)} {
 		resp := newAsynchronousResponse()
 		resp.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
 		resp.Header.Del(http.CanonicalHeaderKey(autorest.HeaderLocation))
@@ -389,7 +389,7 @@ func TestUpdatePollingState_ReturnsAnErrorIfAsyncHeadersAreMissingForANewOrDelet
 	resp.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
 	resp.Header.Del(http.CanonicalHeaderKey(autorest.HeaderLocation))
 
-	for _, m := range []string{methodDelete, methodPost} {
+	for _, m := range []string{http.MethodDelete, http.MethodPost} {
 		resp.Request.Method = m
 		err := updatePollingState(resp, &pollingState{})
 		if err == nil {


### PR DESCRIPTION
When available, there is no reason not to re-use constant values from stdlib.