### PR TITLE
adal: add support for MSI VM Extension

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ go:
 
 install:
   - go get -u github.com/golang/lint/golint
+  - go get -u github.com/Azure/azure-sdk-for-go/arm/resources/resources
   - go get -u github.com/Masterminds/glide
   - go get -u github.com/stretchr/testify
   - go get -u github.com/GoASTScanner/gas

--- a/autorest/adal/config.go
+++ b/autorest/adal/config.go
@@ -12,6 +12,7 @@ const (
 // OAuthConfig represents the endpoints needed
 // in OAuth operations
 type OAuthConfig struct {
+	AuthorityEndpoint  url.URL
 	AuthorizeEndpoint  url.URL
 	TokenEndpoint      url.URL
 	DeviceCodeEndpoint url.URL
@@ -20,8 +21,11 @@ type OAuthConfig struct {
 // NewOAuthConfig returns an OAuthConfig with tenant specific urls
 func NewOAuthConfig(activeDirectoryEndpoint, tenantID string) (*OAuthConfig, error) {
 	const activeDirectoryEndpointTemplate = "%s/oauth2/%s?api-version=%s"
-
 	u, err := url.Parse(activeDirectoryEndpoint)
+	if err != nil {
+		return nil, err
+	}
+	authorityURL, err := u.Parse(tenantID)
 	if err != nil {
 		return nil, err
 	}
@@ -39,6 +43,7 @@ func NewOAuthConfig(activeDirectoryEndpoint, tenantID string) (*OAuthConfig, err
 	}
 
 	return &OAuthConfig{
+		AuthorityEndpoint:  *authorityURL,
 		AuthorizeEndpoint:  *authorizeURL,
 		TokenEndpoint:      *tokenURL,
 		DeviceCodeEndpoint: *deviceCodeURL,

--- a/autorest/adal/example-msi-app/.gitignore
+++ b/autorest/adal/example-msi-app/.gitignore
@@ -1,0 +1,1 @@
+example-msi-app

--- a/autorest/adal/example-msi-app/README.md
+++ b/autorest/adal/example-msi-app/README.md
@@ -1,5 +1,0 @@
-# Go ADAL MSI Example
-
-[fill in more details here with boilerplate info about what MSI is]
-
-[eventually this sample will be much cooler when it can auto-discover the subid/rg from IMDS]

--- a/autorest/adal/example-msi-app/README.md
+++ b/autorest/adal/example-msi-app/README.md
@@ -1,0 +1,5 @@
+# Go ADAL MSI Example
+
+[fill in more details here with boilerplate info about what MSI is]
+
+[eventually this sample will be much cooler when it can auto-discover the subid/rg from IMDS]

--- a/autorest/adal/example-msi-app/build-and-upload.sh
+++ b/autorest/adal/example-msi-app/build-and-upload.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+set -euo pipefail
+set -x
+
+(
+cd "${DIR}"
+CGO_ENABLED=0 go build -a -installsuffix cgo -ldflags '-s' .
+az storage blob upload \
+	--account-name=colemickmsitest0 \
+	--container=testapp \
+	--name=example-msi-app \
+	--file=./example-msi-app
+)

--- a/autorest/adal/example-msi-app/main.go
+++ b/autorest/adal/example-msi-app/main.go
@@ -13,9 +13,6 @@ import (
 var cloud = azure.PublicCloud
 
 func main() {
-	//var spt *azure.ServicePrincipalToken
-	//var err error
-
 	tenantID := os.Getenv("TENANT_ID")
 	subscriptionID := os.Getenv("SUBSCRIPTION_ID")
 	resourceGroupName := os.Getenv("RESOURCE_GROUP")

--- a/autorest/adal/example-msi-app/main.go
+++ b/autorest/adal/example-msi-app/main.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/Azure/azure-sdk-for-go/arm/resources/resources"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/adal"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+var cloud = azure.PublicCloud
+
+func main() {
+	//var spt *azure.ServicePrincipalToken
+	//var err error
+
+	tenantID := os.Getenv("TENANT_ID")
+	subscriptionID := os.Getenv("SUBSCRIPTION_ID")
+	resourceGroupName := os.Getenv("RESOURCE_GROUP")
+
+	oauthConfig, err := adal.NewOAuthConfig(cloud.ActiveDirectoryEndpoint, tenantID)
+	if err != nil {
+		panic(err)
+	}
+
+	spt, err := adal.NewServicePrincipalTokenFromMSI(
+		*oauthConfig,
+		cloud.ResourceManagerEndpoint)
+	if err != nil {
+		panic(err)
+	}
+
+	client := resources.NewGroupsClientWithBaseURI(cloud.ResourceManagerEndpoint, subscriptionID)
+	client.Authorizer = autorest.NewBearerAuthorizer(spt)
+
+	resources, err := client.ListResources(resourceGroupName, "", "", nil)
+	if err != nil {
+		panic(err)
+	}
+
+	result := "resources: "
+	for _, r := range *(resources.Value) {
+		result += *r.Name + ", "
+	}
+
+	log.Println(result)
+
+	// update RG, add a tag
+	rg, err := client.Get(resourceGroupName)
+	if err != nil {
+		panic(err)
+	}
+
+	value := "success"
+	var tags map[string]*string
+	if rg.Tags != nil {
+		tags = *rg.Tags
+	} else {
+		tags = make(map[string]*string)
+	}
+	tags["msie2e"] = &value
+
+	rg.Tags = &tags
+
+	// this is a silly necessity
+	rg.Properties.ProvisioningState = nil
+	rg.ID = nil
+
+	_, err = client.CreateOrUpdate(
+		resourceGroupName,
+		rg)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/autorest/adal/example-msi-app/test.sh
+++ b/autorest/adal/example-msi-app/test.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# RUN THIS ON THE REMOTE MACHINE WITH MSI EXTENSION ACTIVE
+
+wget 'https://colemickmsitest0.blob.core.windows.net/testapp/example-msi-app'
+chmod +x example-msi-app
+./example-msi-app

--- a/autorest/adal/token_test.go
+++ b/autorest/adal/token_test.go
@@ -503,7 +503,7 @@ func TestNewServicePrincipalTokenFromMSI(t *testing.T) {
 		tempSettingsFile.Name(),
 		cb)
 	if err != nil {
-		t.Fatal("Failed to get MSI SPT: %v", err)
+		t.Fatalf("Failed to get MSI SPT: %v", err)
 	}
 
 	// check some of the SPT fields

--- a/autorest/adal/token_test.go
+++ b/autorest/adal/token_test.go
@@ -10,6 +10,7 @@ import (
 	"math/big"
 	"net/http"
 	"net/url"
+	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -470,6 +471,52 @@ func TestServicePrincipalTokenManualRefreshFailsWithoutRefresh(t *testing.T) {
 	err := spt.Refresh()
 	if err == nil {
 		t.Fatalf("adal: ServicePrincipalToken#Refresh should have failed with a ManualTokenSecret without a refresh token")
+	}
+}
+
+func TestNewServicePrincipalTokenFromMSI(t *testing.T) {
+	resource := "https://resource"
+
+	cb := func(token Token) error { return nil }
+	tempSettingsFile, err := ioutil.TempFile("", "ManagedIdentity-Settings")
+	if err != nil {
+		t.Fatal("Couldn't write temp settings file")
+	}
+	defer os.Remove(tempSettingsFile.Name())
+
+	settingsContents := []byte(`{
+		"url": "http://msiendpoint/"
+	}`)
+
+	if _, err := tempSettingsFile.Write(settingsContents); err != nil {
+		t.Fatal("Couldn't fill temp settings file")
+	}
+
+	oauthConfig, err := NewOAuthConfig("http://adendpoint", "1-2-3-4")
+	if err != nil {
+		t.Fatal("Failed to construct oauthconfig")
+	}
+
+	spt, err := newServicePrincipalTokenFromMSI(
+		*oauthConfig,
+		resource,
+		tempSettingsFile.Name(),
+		cb)
+	if err != nil {
+		t.Fatal("Failed to get MSI SPT: %v", err)
+	}
+
+	// check some of the SPT fields
+	if _, ok := spt.secret.(*ServicePrincipalMSISecret); !ok {
+		t.Fatal("SPT secret was not of MSI type")
+	}
+
+	if spt.resource != resource {
+		t.Fatal("SPT came back with incorrect resource")
+	}
+
+	if len(spt.refreshCallbacks) != 1 {
+		t.Fatal("SPT had incorrect refresh callbacks.")
 	}
 }
 


### PR DESCRIPTION
This stacks on top of #122, please just look at the last commit.

I can't decide if it should be `NewServicePrincipalTokenFromMSI` or if it should be `NewServicePrincipalTokenFromMSIExtension`...

If it's the former, then in the future, it has to try to detect whether to use extension endpoint+api or the future endpoint+api.

If it's the latter, then in the future, application code has to be updated, rather than just updating the SDK to take advantage of MSI in the new endpoint.