### PR TITLE
Finished Text, Binary, and JSON for UnixTime

### DIFF
--- a/autorest/date/unixtime.go
+++ b/autorest/date/unixtime.go
@@ -1,0 +1,101 @@
+package date
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"time"
+)
+
+// unixEpoch is the moment in time that should be treated as timestamp 0.
+var unixEpoch = time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC)
+
+// UnixTime marshals and unmarshals a time that is represented as the number
+// of seconds (ignoring skip-seconds) since the Unix Epoch.
+type UnixTime time.Time
+
+// Duration returns the time as a Duration since the UnixEpoch.
+func (t UnixTime) Duration() time.Duration {
+	return time.Time(t).Sub(unixEpoch)
+}
+
+// FromSeconds creates a UnixTime as a number of seconds from the UnixEpoch.
+func FromSeconds(seconds float64) UnixTime {
+	return UnixTime(UnixEpoch().Add(time.Duration(seconds * float64(time.Second))))
+}
+
+// FromNanoseconds creates a UnixTime as a number of nanoseconds from the UnixEpoch.
+func FromNanoseconds(nanoseconds int64) UnixTime {
+	return UnixTime(UnixEpoch().Add(time.Duration(nanoseconds)))
+}
+
+// UnixEpoch retreives the moment considered the Unix Epoch. I.e. The time represented by '0'
+func UnixEpoch() time.Time {
+	return unixEpoch
+}
+
+// MarshalJSON preserves the UnixTime as a JSON number conforming to Unix Timestamp requirements.
+// (i.e. the number of seconds since midnight January 1st, 1970 not considering leap seconds.)
+func (t UnixTime) MarshalJSON() ([]byte, error) {
+	buffer := &bytes.Buffer{}
+	enc := json.NewEncoder(buffer)
+	enc.Encode(float64(time.Time(t).Unix()))
+	return buffer.Bytes(), nil
+}
+
+// UnmarshalJSON reconstitures a UnixTime saved as a JSON number of the number of seconds since
+// midnight January 1st, 1970.
+func (t *UnixTime) UnmarshalJSON(text []byte) error {
+	dec := json.NewDecoder(bytes.NewReader(text))
+
+	var secondsSinceEpoch float64
+	if err := dec.Decode(&secondsSinceEpoch); err != nil {
+		return err
+	}
+
+	*t = FromSeconds(secondsSinceEpoch)
+
+	return nil
+}
+
+// MarshalText stores the number of seconds since the Unix Epoch as a textual floating point number.
+func (t UnixTime) MarshalText() ([]byte, error) {
+	cast := time.Time(t)
+	return cast.MarshalText()
+}
+
+// UnmarshalText populates a UnixTime with a value stored textually as a floating point number of seconds since the Unix Epoch.
+func (t *UnixTime) UnmarshalText(raw []byte) error {
+	var unmarshaled time.Time
+
+	if err := unmarshaled.UnmarshalText(raw); err != nil {
+		return err
+	}
+
+	*t = UnixTime(unmarshaled)
+	return nil
+}
+
+// MarshalBinary converts a UnixTime into a binary.LittleEndian float64 of nanoseconds since the epoch.
+func (t UnixTime) MarshalBinary() ([]byte, error) {
+	buf := &bytes.Buffer{}
+
+	payload := int64(t.Duration())
+
+	if err := binary.Write(buf, binary.LittleEndian, &payload); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// UnmarshalBinary converts a from a binary.LittleEndian float64 of nanoseconds since the epoch into a UnixTime.
+func (t *UnixTime) UnmarshalBinary(raw []byte) error {
+	var secondsSinceEpoch int64
+
+	if err := binary.Read(bytes.NewReader(raw), binary.LittleEndian, &secondsSinceEpoch); err != nil {
+		return err
+	}
+	*t = FromNanoseconds(secondsSinceEpoch)
+	return nil
+}

--- a/autorest/date/unixtime.go
+++ b/autorest/date/unixtime.go
@@ -19,14 +19,19 @@ func (t UnixTime) Duration() time.Duration {
 	return time.Time(t).Sub(unixEpoch)
 }
 
-// FromSeconds creates a UnixTime as a number of seconds from the UnixEpoch.
-func FromSeconds(seconds float64) UnixTime {
-	return UnixTime(UnixEpoch().Add(time.Duration(seconds * float64(time.Second))))
+// NewUnixTimeFromSeconds creates a UnixTime as a number of seconds from the UnixEpoch.
+func NewUnixTimeFromSeconds(seconds float64) UnixTime {
+	return NewUnixTimeFromDuration(time.Duration(seconds * float64(time.Second)))
 }
 
-// FromNanoseconds creates a UnixTime as a number of nanoseconds from the UnixEpoch.
-func FromNanoseconds(nanoseconds int64) UnixTime {
-	return UnixTime(UnixEpoch().Add(time.Duration(nanoseconds)))
+// NewUnixTimeFromNanoseconds creates a UnixTime as a number of nanoseconds from the UnixEpoch.
+func NewUnixTimeFromNanoseconds(nanoseconds int64) UnixTime {
+	return NewUnixTimeFromDuration(time.Duration(nanoseconds))
+}
+
+// NewUnixTimeFromDuration creates a UnixTime as a duration of time since the UnixEpoch.
+func NewUnixTimeFromDuration(dur time.Duration) UnixTime {
+	return UnixTime(unixEpoch.Add(dur))
 }
 
 // UnixEpoch retreives the moment considered the Unix Epoch. I.e. The time represented by '0'
@@ -53,7 +58,7 @@ func (t *UnixTime) UnmarshalJSON(text []byte) error {
 		return err
 	}
 
-	*t = FromSeconds(secondsSinceEpoch)
+	*t = NewUnixTimeFromSeconds(secondsSinceEpoch)
 
 	return nil
 }
@@ -91,11 +96,11 @@ func (t UnixTime) MarshalBinary() ([]byte, error) {
 
 // UnmarshalBinary converts a from a binary.LittleEndian float64 of nanoseconds since the epoch into a UnixTime.
 func (t *UnixTime) UnmarshalBinary(raw []byte) error {
-	var secondsSinceEpoch int64
+	var nanosecondsSinceEpoch int64
 
-	if err := binary.Read(bytes.NewReader(raw), binary.LittleEndian, &secondsSinceEpoch); err != nil {
+	if err := binary.Read(bytes.NewReader(raw), binary.LittleEndian, &nanosecondsSinceEpoch); err != nil {
 		return err
 	}
-	*t = FromNanoseconds(secondsSinceEpoch)
+	*t = NewUnixTimeFromNanoseconds(nanosecondsSinceEpoch)
 	return nil
 }

--- a/autorest/date/unixtime.go
+++ b/autorest/date/unixtime.go
@@ -39,7 +39,7 @@ func UnixEpoch() time.Time {
 func (t UnixTime) MarshalJSON() ([]byte, error) {
 	buffer := &bytes.Buffer{}
 	enc := json.NewEncoder(buffer)
-	enc.Encode(float64(time.Time(t).Unix()))
+	enc.Encode(float64(time.Time(t).UnixNano()) / 1e9)
 	return buffer.Bytes(), nil
 }
 

--- a/autorest/date/unixtime_test.go
+++ b/autorest/date/unixtime_test.go
@@ -1,0 +1,247 @@
+package date_test
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/marstr/go-autorest/autorest/date"
+)
+
+func ExampleUnixTime_MarshalJSON() {
+	epoch := date.UnixTime(date.UnixEpoch())
+	text, _ := json.Marshal(epoch)
+	fmt.Print(string(text))
+	// Output: 0
+}
+
+func ExampleUnixTime_UnmarshalSON() {
+	var myTime date.UnixTime
+	json.Unmarshal([]byte("1.3e2"), &myTime)
+	fmt.Printf("%v", time.Time(myTime))
+	// Output: 1970-01-01 00:02:10 +0000 UTC
+}
+
+func TestUnixTime_MarshalJSON(t *testing.T) {
+	testCases := []time.Time{
+		date.UnixEpoch().Add(-1 * time.Second),                   // One second befote the Unix Epoch
+		time.Date(2017, time.April, 14, 20, 27, 47, 0, time.UTC), // The time this test was written
+	}
+
+	for _, tc := range testCases {
+		t.Run("", func(subT *testing.T) {
+			target := date.UnixTime(tc)
+
+			expected := string([]byte(fmt.Sprintf("%d", tc.Unix())))
+			if actual, err := json.Marshal(target); err != nil {
+				subT.Error(err)
+			} else if expected != string(actual) {
+				subT.Logf("got: \t%s\nwant:\t%s", string(actual), expected)
+				subT.Fail()
+			} else {
+				subT.Logf("passed with value: %s", string(actual))
+			}
+		})
+	}
+}
+
+func TestUnixTime_UnmarshalJSON(t *testing.T) {
+	testCases := []struct {
+		text     string
+		expected time.Time
+	}{
+		{"1", date.UnixEpoch().Add(time.Second)},
+		{"0", date.UnixEpoch()},
+		{"1492203742", time.Date(2017, time.April, 14, 21, 02, 22, 0, time.UTC)}, // The time this test was written
+		{"-1", time.Date(1969, time.December, 31, 23, 59, 59, 0, time.UTC)},
+		{"1.5", date.UnixEpoch().Add(1500 * time.Millisecond)},
+		{"0e1", date.UnixEpoch()}, // See http://json.org for 'number' format definition.
+		{"1.3e+2", date.UnixEpoch().Add(130 * time.Second)},
+		{"1.6E-10", date.UnixEpoch()}, // This is so small, it should get truncated into the UnixEpoch
+		{"2E-6", date.UnixEpoch().Add(2 * time.Microsecond)},
+		{"1.289345e9", date.UnixEpoch().Add(1289345000 * time.Second)},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.text, func(subT *testing.T) {
+			var rehydrated date.UnixTime
+			if err := json.Unmarshal([]byte(tc.text), &rehydrated); err != nil {
+				subT.Error(err)
+				return
+			}
+
+			if time.Time(rehydrated) != tc.expected {
+				subT.Logf("\ngot: \t%v\nwant:\t%v\ndiff:\t%v", time.Time(rehydrated), tc.expected, time.Time(rehydrated).Sub(tc.expected))
+				subT.Fail()
+			} else {
+				subT.Logf("rehydrated matched expected '%v'", tc.expected)
+			}
+		})
+	}
+}
+
+func TestUnixTime_JSONRoundTrip(t *testing.T) {
+	testCases := []time.Time{
+		date.UnixEpoch(),
+		time.Date(2005, time.November, 5, 0, 0, 0, 0, time.UTC), // The day V for Vendetta (film) was released.
+		date.UnixEpoch().Add(-6 * time.Second),
+		date.UnixEpoch().Add(800 & time.Hour),
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.String(), func(subT *testing.T) {
+			subject := date.UnixTime(tc)
+			var marshaled []byte
+			if temp, err := json.Marshal(subject); err == nil {
+				marshaled = temp
+			} else {
+				t.Error(err)
+				return
+			}
+
+			var unmarshaled date.UnixTime
+			if err := json.Unmarshal(marshaled, &unmarshaled); err != nil {
+				t.Error(err)
+				return
+			} else if time.Time(subject) != time.Time(unmarshaled) {
+				t.Logf("round trip failed for: %v", time.Time(subject))
+				t.Fail()
+			}
+		})
+	}
+}
+
+func TestUnixTime_MarshalBinary(t *testing.T) {
+	testCases := []struct {
+		expected int64
+		subject  time.Time
+	}{
+		{0, date.UnixEpoch()},
+		{-15 * int64(time.Second), date.UnixEpoch().Add(-15 * time.Second)},
+		{54, date.UnixEpoch().Add(54 * time.Nanosecond)},
+	}
+
+	for _, tc := range testCases {
+		t.Run("", func(subT *testing.T) {
+			var marshaled []byte
+
+			if temp, err := date.UnixTime(tc.subject).MarshalBinary(); err == nil {
+				marshaled = temp
+			} else {
+				subT.Error(err)
+				return
+			}
+
+			var unmarshaled int64
+			if err := binary.Read(bytes.NewReader(marshaled), binary.LittleEndian, &unmarshaled); err != nil {
+				subT.Error(err)
+				return
+			}
+
+			if unmarshaled != tc.expected {
+				subT.Logf("\ngot: \t%d\nwant:\t%d", unmarshaled, tc.expected)
+				subT.Fail()
+			}
+		})
+	}
+}
+
+func TestUnixTime_BinaryRoundTrip(t *testing.T) {
+	testCases := []time.Time{
+		date.UnixEpoch(),
+		date.UnixEpoch().Add(800 * time.Minute),
+		date.UnixEpoch().Add(7 * time.Hour),
+		date.UnixEpoch().Add(-1 * time.Nanosecond),
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.String(), func(subT *testing.T) {
+			original := date.UnixTime(tc)
+			var marshaled []byte
+
+			if temp, err := original.MarshalBinary(); err == nil {
+				marshaled = temp
+			} else {
+				subT.Error(err)
+				return
+			}
+
+			var traveled date.UnixTime
+			if err := traveled.UnmarshalBinary(marshaled); err != nil {
+				subT.Error(err)
+				return
+			}
+
+			if traveled != original {
+				subT.Logf("\ngot: \t%s\nwant:\t%s", time.Time(original).String(), time.Time(traveled).String())
+				subT.Fail()
+			}
+		})
+	}
+}
+
+func TestUnixTime_MarshalText(t *testing.T) {
+	testCases := []time.Time{
+		date.UnixEpoch(),
+		date.UnixEpoch().Add(45 * time.Second),
+		date.UnixEpoch().Add(time.Nanosecond),
+		date.UnixEpoch().Add(-100000 * time.Second),
+	}
+
+	for _, tc := range testCases {
+		expected, _ := tc.MarshalText()
+		t.Run("", func(subT *testing.T) {
+			var marshaled []byte
+
+			if temp, err := date.UnixTime(tc).MarshalText(); err == nil {
+				marshaled = temp
+			} else {
+				subT.Error(err)
+				return
+			}
+
+			if string(marshaled) != string(expected) {
+				subT.Logf("\ngot: \t%s\nwant:\t%s", string(marshaled), string(expected))
+				subT.Fail()
+			}
+		})
+	}
+}
+
+func TestUnixTime_TextRoundTrip(t *testing.T) {
+	testCases := []time.Time{
+		date.UnixEpoch(),
+		date.UnixEpoch().Add(-1 * time.Nanosecond),
+		date.UnixEpoch().Add(1 * time.Nanosecond),
+		time.Date(2017, time.April, 17, 21, 00, 00, 00, time.UTC),
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.String(), func(subT *testing.T) {
+			unixTC := date.UnixTime(tc)
+
+			var marshaled []byte
+
+			if temp, err := unixTC.MarshalText(); err == nil {
+				marshaled = temp
+			} else {
+				subT.Error(err)
+				return
+			}
+
+			var unmarshaled date.UnixTime
+			if err := unmarshaled.UnmarshalText(marshaled); err != nil {
+				subT.Error(err)
+				return
+			}
+
+			if unmarshaled != unixTC {
+				t.Logf("\ngot: \t%s\nwant:\t%s", time.Time(unmarshaled).String(), tc.String())
+				t.Fail()
+			}
+		})
+	}
+}

--- a/autorest/date/unixtime_test.go
+++ b/autorest/date/unixtime_test.go
@@ -1,4 +1,4 @@
-package date_test
+package date
 
 import (
 	"bytes"
@@ -7,19 +7,17 @@ import (
 	"fmt"
 	"testing"
 	"time"
-
-	"github.com/Azure/go-autorest/autorest/date"
 )
 
 func ExampleUnixTime_MarshalJSON() {
-	epoch := date.UnixTime(date.UnixEpoch())
+	epoch := UnixTime(UnixEpoch())
 	text, _ := json.Marshal(epoch)
 	fmt.Print(string(text))
 	// Output: 0
 }
 
 func ExampleUnixTime_UnmarshalSON() {
-	var myTime date.UnixTime
+	var myTime UnixTime
 	json.Unmarshal([]byte("1.3e2"), &myTime)
 	fmt.Printf("%v", time.Time(myTime))
 	// Output: 1970-01-01 00:02:10 +0000 UTC
@@ -27,22 +25,34 @@ func ExampleUnixTime_UnmarshalSON() {
 
 func TestUnixTime_MarshalJSON(t *testing.T) {
 	testCases := []time.Time{
-		date.UnixEpoch().Add(-1 * time.Second),                   // One second befote the Unix Epoch
+		UnixEpoch().Add(-1 * time.Second),                        // One second befote the Unix Epoch
 		time.Date(2017, time.April, 14, 20, 27, 47, 0, time.UTC), // The time this test was written
 	}
 
 	for _, tc := range testCases {
 		t.Run("", func(subT *testing.T) {
-			target := date.UnixTime(tc)
+			var actual, expected float64
+			var marshaled []byte
 
-			expected := string([]byte(fmt.Sprintf("%d", tc.Unix())))
-			if actual, err := json.Marshal(target); err != nil {
-				subT.Error(err)
-			} else if expected != string(actual) {
-				subT.Logf("got: \t%s\nwant:\t%s", string(actual), expected)
-				subT.Fail()
+			target := UnixTime(tc)
+			expected = target.Duration().Seconds()
+
+			if temp, err := json.Marshal(target); err == nil {
+				marshaled = temp
 			} else {
-				subT.Logf("passed with value: %s", string(actual))
+				subT.Error(err)
+				return
+			}
+
+			dec := json.NewDecoder(bytes.NewReader(marshaled))
+			if err := dec.Decode(&actual); err != nil {
+				subT.Error(err)
+				return
+			}
+
+			if actual != expected {
+				subT.Logf("\ngot :\t%g\nwant:\t%g", actual, expected)
+				subT.Fail()
 			}
 		})
 	}
@@ -53,21 +63,21 @@ func TestUnixTime_UnmarshalJSON(t *testing.T) {
 		text     string
 		expected time.Time
 	}{
-		{"1", date.UnixEpoch().Add(time.Second)},
-		{"0", date.UnixEpoch()},
+		{"1", UnixEpoch().Add(time.Second)},
+		{"0", UnixEpoch()},
 		{"1492203742", time.Date(2017, time.April, 14, 21, 02, 22, 0, time.UTC)}, // The time this test was written
 		{"-1", time.Date(1969, time.December, 31, 23, 59, 59, 0, time.UTC)},
-		{"1.5", date.UnixEpoch().Add(1500 * time.Millisecond)},
-		{"0e1", date.UnixEpoch()}, // See http://json.org for 'number' format definition.
-		{"1.3e+2", date.UnixEpoch().Add(130 * time.Second)},
-		{"1.6E-10", date.UnixEpoch()}, // This is so small, it should get truncated into the UnixEpoch
-		{"2E-6", date.UnixEpoch().Add(2 * time.Microsecond)},
-		{"1.289345e9", date.UnixEpoch().Add(1289345000 * time.Second)},
+		{"1.5", UnixEpoch().Add(1500 * time.Millisecond)},
+		{"0e1", UnixEpoch()}, // See http://json.org for 'number' format definition.
+		{"1.3e+2", UnixEpoch().Add(130 * time.Second)},
+		{"1.6E-10", UnixEpoch()}, // This is so small, it should get truncated into the UnixEpoch
+		{"2E-6", UnixEpoch().Add(2 * time.Microsecond)},
+		{"1.289345e9", UnixEpoch().Add(1289345000 * time.Second)},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.text, func(subT *testing.T) {
-			var rehydrated date.UnixTime
+			var rehydrated UnixTime
 			if err := json.Unmarshal([]byte(tc.text), &rehydrated); err != nil {
 				subT.Error(err)
 				return
@@ -76,8 +86,6 @@ func TestUnixTime_UnmarshalJSON(t *testing.T) {
 			if time.Time(rehydrated) != tc.expected {
 				subT.Logf("\ngot: \t%v\nwant:\t%v\ndiff:\t%v", time.Time(rehydrated), tc.expected, time.Time(rehydrated).Sub(tc.expected))
 				subT.Fail()
-			} else {
-				subT.Logf("rehydrated matched expected '%v'", tc.expected)
 			}
 		})
 	}
@@ -85,30 +93,29 @@ func TestUnixTime_UnmarshalJSON(t *testing.T) {
 
 func TestUnixTime_JSONRoundTrip(t *testing.T) {
 	testCases := []time.Time{
-		date.UnixEpoch(),
+		UnixEpoch(),
 		time.Date(2005, time.November, 5, 0, 0, 0, 0, time.UTC), // The day V for Vendetta (film) was released.
-		date.UnixEpoch().Add(-6 * time.Second),
-		date.UnixEpoch().Add(800 & time.Hour),
+		UnixEpoch().Add(-6 * time.Second),
+		UnixEpoch().Add(800 & time.Hour),
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.String(), func(subT *testing.T) {
-			subject := date.UnixTime(tc)
+			subject := UnixTime(tc)
 			var marshaled []byte
 			if temp, err := json.Marshal(subject); err == nil {
 				marshaled = temp
 			} else {
-				t.Error(err)
+				subT.Error(err)
 				return
 			}
 
-			var unmarshaled date.UnixTime
+			var unmarshaled UnixTime
 			if err := json.Unmarshal(marshaled, &unmarshaled); err != nil {
-				t.Error(err)
-				return
+				subT.Error(err)
 			} else if time.Time(subject) != time.Time(unmarshaled) {
-				t.Logf("round trip failed for: %v", time.Time(subject))
-				t.Fail()
+				subT.Logf("round trip failed for: %v", time.Time(subject))
+				subT.Fail()
 			}
 		})
 	}
@@ -119,16 +126,16 @@ func TestUnixTime_MarshalBinary(t *testing.T) {
 		expected int64
 		subject  time.Time
 	}{
-		{0, date.UnixEpoch()},
-		{-15 * int64(time.Second), date.UnixEpoch().Add(-15 * time.Second)},
-		{54, date.UnixEpoch().Add(54 * time.Nanosecond)},
+		{0, UnixEpoch()},
+		{-15 * int64(time.Second), UnixEpoch().Add(-15 * time.Second)},
+		{54, UnixEpoch().Add(54 * time.Nanosecond)},
 	}
 
 	for _, tc := range testCases {
 		t.Run("", func(subT *testing.T) {
 			var marshaled []byte
 
-			if temp, err := date.UnixTime(tc.subject).MarshalBinary(); err == nil {
+			if temp, err := UnixTime(tc.subject).MarshalBinary(); err == nil {
 				marshaled = temp
 			} else {
 				subT.Error(err)
@@ -151,15 +158,15 @@ func TestUnixTime_MarshalBinary(t *testing.T) {
 
 func TestUnixTime_BinaryRoundTrip(t *testing.T) {
 	testCases := []time.Time{
-		date.UnixEpoch(),
-		date.UnixEpoch().Add(800 * time.Minute),
-		date.UnixEpoch().Add(7 * time.Hour),
-		date.UnixEpoch().Add(-1 * time.Nanosecond),
+		UnixEpoch(),
+		UnixEpoch().Add(800 * time.Minute),
+		UnixEpoch().Add(7 * time.Hour),
+		UnixEpoch().Add(-1 * time.Nanosecond),
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.String(), func(subT *testing.T) {
-			original := date.UnixTime(tc)
+			original := UnixTime(tc)
 			var marshaled []byte
 
 			if temp, err := original.MarshalBinary(); err == nil {
@@ -169,7 +176,7 @@ func TestUnixTime_BinaryRoundTrip(t *testing.T) {
 				return
 			}
 
-			var traveled date.UnixTime
+			var traveled UnixTime
 			if err := traveled.UnmarshalBinary(marshaled); err != nil {
 				subT.Error(err)
 				return
@@ -185,10 +192,10 @@ func TestUnixTime_BinaryRoundTrip(t *testing.T) {
 
 func TestUnixTime_MarshalText(t *testing.T) {
 	testCases := []time.Time{
-		date.UnixEpoch(),
-		date.UnixEpoch().Add(45 * time.Second),
-		date.UnixEpoch().Add(time.Nanosecond),
-		date.UnixEpoch().Add(-100000 * time.Second),
+		UnixEpoch(),
+		UnixEpoch().Add(45 * time.Second),
+		UnixEpoch().Add(time.Nanosecond),
+		UnixEpoch().Add(-100000 * time.Second),
 	}
 
 	for _, tc := range testCases {
@@ -196,7 +203,7 @@ func TestUnixTime_MarshalText(t *testing.T) {
 		t.Run("", func(subT *testing.T) {
 			var marshaled []byte
 
-			if temp, err := date.UnixTime(tc).MarshalText(); err == nil {
+			if temp, err := UnixTime(tc).MarshalText(); err == nil {
 				marshaled = temp
 			} else {
 				subT.Error(err)
@@ -213,15 +220,15 @@ func TestUnixTime_MarshalText(t *testing.T) {
 
 func TestUnixTime_TextRoundTrip(t *testing.T) {
 	testCases := []time.Time{
-		date.UnixEpoch(),
-		date.UnixEpoch().Add(-1 * time.Nanosecond),
-		date.UnixEpoch().Add(1 * time.Nanosecond),
+		UnixEpoch(),
+		UnixEpoch().Add(-1 * time.Nanosecond),
+		UnixEpoch().Add(1 * time.Nanosecond),
 		time.Date(2017, time.April, 17, 21, 00, 00, 00, time.UTC),
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.String(), func(subT *testing.T) {
-			unixTC := date.UnixTime(tc)
+			unixTC := UnixTime(tc)
 
 			var marshaled []byte
 
@@ -232,7 +239,7 @@ func TestUnixTime_TextRoundTrip(t *testing.T) {
 				return
 			}
 
-			var unmarshaled date.UnixTime
+			var unmarshaled UnixTime
 			if err := unmarshaled.UnmarshalText(marshaled); err != nil {
 				subT.Error(err)
 				return

--- a/autorest/date/unixtime_test.go
+++ b/autorest/date/unixtime_test.go
@@ -102,7 +102,9 @@ func TestUnixTime_JSONRoundTrip(t *testing.T) {
 		UnixEpoch(),
 		time.Date(2005, time.November, 5, 0, 0, 0, 0, time.UTC), // The day V for Vendetta (film) was released.
 		UnixEpoch().Add(-6 * time.Second),
-		UnixEpoch().Add(800 & time.Hour),
+		UnixEpoch().Add(800 * time.Hour),
+		UnixEpoch().Add(time.Nanosecond),
+		time.Date(2015, time.September, 05, 4, 30, 12, 9992, time.UTC),
 	}
 
 	for _, tc := range testCases {
@@ -119,8 +121,13 @@ func TestUnixTime_JSONRoundTrip(t *testing.T) {
 			var unmarshaled UnixTime
 			if err := json.Unmarshal(marshaled, &unmarshaled); err != nil {
 				subT.Error(err)
-			} else if time.Time(subject) != time.Time(unmarshaled) {
-				subT.Logf("round trip failed for: %v", time.Time(subject))
+			}
+
+			actual := time.Time(unmarshaled)
+			diff := actual.Sub(tc)
+			subT.Logf("\ngot :\t%s\nwant:\t%s\ndiff:\t%s", actual.String(), tc.String(), diff.String())
+
+			if diff > time.Duration(100) { // We lose some precision be working in floats. We shouldn't lose more than 100 nanoseconds.
 				subT.Fail()
 			}
 		})

--- a/autorest/date/unixtime_test.go
+++ b/autorest/date/unixtime_test.go
@@ -16,7 +16,7 @@ func ExampleUnixTime_MarshalJSON() {
 	// Output: 0
 }
 
-func ExampleUnixTime_UnmarshalSON() {
+func ExampleUnixTime_UnmarshalJSON() {
 	var myTime UnixTime
 	json.Unmarshal([]byte("1.3e2"), &myTime)
 	fmt.Printf("%v", time.Time(myTime))

--- a/autorest/date/unixtime_test.go
+++ b/autorest/date/unixtime_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/marstr/go-autorest/autorest/date"
+	"github.com/Azure/go-autorest/autorest/date"
 )
 
 func ExampleUnixTime_MarshalJSON() {

--- a/autorest/date/unixtime_test.go
+++ b/autorest/date/unixtime_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"math"
 	"testing"
 	"time"
 )
@@ -27,6 +28,8 @@ func TestUnixTime_MarshalJSON(t *testing.T) {
 	testCases := []time.Time{
 		UnixEpoch().Add(-1 * time.Second),                        // One second befote the Unix Epoch
 		time.Date(2017, time.April, 14, 20, 27, 47, 0, time.UTC), // The time this test was written
+		UnixEpoch(),
+		time.Date(1800, 01, 01, 0, 0, 0, 0, time.UTC),
 	}
 
 	for _, tc := range testCases {
@@ -50,8 +53,8 @@ func TestUnixTime_MarshalJSON(t *testing.T) {
 				return
 			}
 
-			if actual != expected {
-				subT.Logf("\ngot :\t%g\nwant:\t%g", actual, expected)
+			if diff := math.Abs(actual - expected); diff > .0000000001 { //Must be within 1 nanosecond of one another
+				subT.Logf("\ngot :\t%g\nwant:\t%g\ndiff:\t%g", actual, expected, diff)
 				subT.Fail()
 			}
 		})
@@ -73,6 +76,7 @@ func TestUnixTime_UnmarshalJSON(t *testing.T) {
 		{"1.6E-10", UnixEpoch()}, // This is so small, it should get truncated into the UnixEpoch
 		{"2E-6", UnixEpoch().Add(2 * time.Microsecond)},
 		{"1.289345e9", UnixEpoch().Add(1289345000 * time.Second)},
+		{"1e-9", UnixEpoch().Add(time.Nanosecond)},
 	}
 
 	for _, tc := range testCases {

--- a/autorest/date/unixtime_test.go
+++ b/autorest/date/unixtime_test.go
@@ -30,15 +30,16 @@ func TestUnixTime_MarshalJSON(t *testing.T) {
 		time.Date(2017, time.April, 14, 20, 27, 47, 0, time.UTC), // The time this test was written
 		UnixEpoch(),
 		time.Date(1800, 01, 01, 0, 0, 0, 0, time.UTC),
+		time.Date(2200, 12, 29, 00, 01, 37, 82, time.UTC),
 	}
 
 	for _, tc := range testCases {
-		t.Run("", func(subT *testing.T) {
+		t.Run(tc.String(), func(subT *testing.T) {
 			var actual, expected float64
 			var marshaled []byte
 
 			target := UnixTime(tc)
-			expected = target.Duration().Seconds()
+			expected = float64(target.Duration().Nanoseconds()) / 1e9
 
 			if temp, err := json.Marshal(target); err == nil {
 				marshaled = temp
@@ -53,8 +54,9 @@ func TestUnixTime_MarshalJSON(t *testing.T) {
 				return
 			}
 
-			if diff := math.Abs(actual - expected); diff > .0000000001 { //Must be within 1 nanosecond of one another
-				subT.Logf("\ngot :\t%g\nwant:\t%g\ndiff:\t%g", actual, expected, diff)
+			diff := math.Abs(actual - expected)
+			subT.Logf("\ngot :\t%g\nwant:\t%g\ndiff:\t%g", actual, expected, diff)
+			if diff > 1e-9 { //Must be within 1 nanosecond of one another
 				subT.Fail()
 			}
 		})


### PR DESCRIPTION
In support of Azure/azure-sdk-for-go#587, I've implemented UnixTime for marshaling and unmarshaling Swaggers that include Unix Timestamps. Next will be updating the generator to recognize this as a well-known type.