### PR TITLE
parse id_token field from adal token

### DIFF
--- a/autorest/azure/token.go
+++ b/autorest/azure/token.go
@@ -44,7 +44,7 @@ type TokenRefreshCallback func(Token) error
 type Token struct {
 	AccessToken  string `json:"access_token"`
 	RefreshToken string `json:"refresh_token"`
-	IDToken      string `json:"id_token"`
+	IDToken      string `json:"id_token,omitempty"`
 
 	ExpiresIn string `json:"expires_in"`
 	ExpiresOn string `json:"expires_on"`

--- a/autorest/azure/token.go
+++ b/autorest/azure/token.go
@@ -44,6 +44,7 @@ type TokenRefreshCallback func(Token) error
 type Token struct {
 	AccessToken  string `json:"access_token"`
 	RefreshToken string `json:"refresh_token"`
+	IDToken      string `json:"id_token"`
 
 	ExpiresIn string `json:"expires_in"`
 	ExpiresOn string `json:"expires_on"`


### PR DESCRIPTION
We (Azure Container Registry) are working on a feature that requires knowing client's tenant ID given an adal token. The way to do it was to unpack the id_token field from adal.Token and read the tenant id field from there.

Currently adal.Token object seem to ignore that field