### PR TITLE
Adding http.Resonse to error so Headers can be read.

### DIFF
--- a/autorest/error.go
+++ b/autorest/error.go
@@ -31,6 +31,9 @@ type DetailedError struct {
 
 	// Service Error is the response body of failed API in bytes
 	ServiceError []byte
+
+	// Response is the response object that was returned during failure if applicable.
+	Response *http.Response
 }
 
 // NewError creates a new Error conforming object from the passed packageType, method, and
@@ -67,6 +70,7 @@ func NewErrorWithError(original error, packageType string, method string, resp *
 		Method:      method,
 		StatusCode:  statusCode,
 		Message:     fmt.Sprintf(message, args...),
+		Response:    resp,
 	}
 }
 


### PR DESCRIPTION
Adding a copy of the Response that was received as the failure occurred. That way we can read Headers and such as part of the error response instead of pulling up Fiddlr.