### PR TITLE
Add type RetriableRequest to wrap retrying an HTTP request.

### DIFF
--- a/autorest/retriablerequest.go
+++ b/autorest/retriablerequest.go
@@ -1,0 +1,68 @@
+package autorest
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"net/http"
+)
+
+// RetriableRequest provides facilities for retrying an HTTP request.
+type RetriableRequest struct {
+	req *http.Request
+	rc  io.ReadCloser
+	br  *bytes.Reader
+}
+
+// NewRetriableRequest returns a wrapper around an HTTP request that support retry logic.
+func NewRetriableRequest(req *http.Request) *RetriableRequest {
+	return &RetriableRequest{req: req}
+}
+
+// Request returns the wrapped HTTP request.
+func (rr *RetriableRequest) Request() *http.Request {
+	return rr.req
+}
+
+// Prepare signals that the request is about to be sent.
+func (rr *RetriableRequest) Prepare() (err error) {
+	// preserve the request body; this is to support retry logic as
+	// the underlying transport will always close the reqeust body
+	if rr.req.Body != nil {
+		if rr.req.GetBody != nil {
+			// this will allow us to preserve the body without having to
+			// make a copy.  note we need to do this on each iteration
+			rr.rc, err = rr.req.GetBody()
+			if err != nil {
+				return err
+			}
+		} else if rr.br == nil {
+			// fall back to making a copy (only do this once)
+			b := []byte{}
+			if rr.req.ContentLength > 0 {
+				b = make([]byte, rr.req.ContentLength)
+				_, err = io.ReadFull(rr.req.Body, b)
+				if err != nil {
+					return err
+				}
+			} else {
+				b, err = ioutil.ReadAll(rr.req.Body)
+				if err != nil {
+					return err
+				}
+			}
+			rr.br = bytes.NewReader(b)
+			rr.req.Body = ioutil.NopCloser(rr.br)
+		}
+	}
+	return err
+}
+
+// Reset indicates that the request will be sent again.
+func (rr *RetriableRequest) Reset() {
+	if rr.rc != nil {
+		rr.req.Body = rr.rc
+	} else if rr.br != nil {
+		rr.br.Seek(0, io.SeekStart)
+	}
+}

--- a/autorest/retriablerequest.go
+++ b/autorest/retriablerequest.go
@@ -7,11 +7,16 @@ import (
 	"net/http"
 )
 
+// NOTE: the GetBody() method on the http.Request object is new in 1.8.
+//       at present we support 1.7 and 1.8 so for now the branches specific
+//       to 1.8 have been commented out.
+
 // RetriableRequest provides facilities for retrying an HTTP request.
 type RetriableRequest struct {
 	req *http.Request
-	rc  io.ReadCloser
-	br  *bytes.Reader
+	//rc    io.ReadCloser
+	br    *bytes.Reader
+	reset bool
 }
 
 // NewRetriableRequest returns a wrapper around an HTTP request that support retry logic.
@@ -29,14 +34,25 @@ func (rr *RetriableRequest) Prepare() (err error) {
 	// preserve the request body; this is to support retry logic as
 	// the underlying transport will always close the reqeust body
 	if rr.req.Body != nil {
-		if rr.req.GetBody != nil {
+		if rr.reset {
+			/*if rr.rc != nil {
+				rr.req.Body = rr.rc
+			} else */if rr.br != nil {
+				_, err = rr.br.Seek(0, io.SeekStart)
+			}
+			rr.reset = false
+			if err != nil {
+				return err
+			}
+		}
+		/*if rr.req.GetBody != nil {
 			// this will allow us to preserve the body without having to
 			// make a copy.  note we need to do this on each iteration
 			rr.rc, err = rr.req.GetBody()
 			if err != nil {
 				return err
 			}
-		} else if rr.br == nil {
+		} else */if rr.br == nil {
 			// fall back to making a copy (only do this once)
 			b := []byte{}
 			if rr.req.ContentLength > 0 {
@@ -54,19 +70,8 @@ func (rr *RetriableRequest) Prepare() (err error) {
 			rr.br = bytes.NewReader(b)
 			rr.req.Body = ioutil.NopCloser(rr.br)
 		}
+		// indicates that the request body needs to be reset
+		rr.reset = true
 	}
 	return err
-}
-
-// Reset indicates that the request will be sent again.
-func (rr *RetriableRequest) Reset() error {
-	if rr.rc != nil {
-		rr.req.Body = rr.rc
-	} else if rr.br != nil {
-		_, err := rr.br.Seek(0, io.SeekStart)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }

--- a/autorest/retriablerequest.go
+++ b/autorest/retriablerequest.go
@@ -59,10 +59,14 @@ func (rr *RetriableRequest) Prepare() (err error) {
 }
 
 // Reset indicates that the request will be sent again.
-func (rr *RetriableRequest) Reset() {
+func (rr *RetriableRequest) Reset() error {
 	if rr.rc != nil {
 		rr.req.Body = rr.rc
 	} else if rr.br != nil {
-		rr.br.Seek(0, io.SeekStart)
+		_, err := rr.br.Seek(0, io.SeekStart)
+		if err != nil {
+			return err
+		}
 	}
+	return nil
 }

--- a/autorest/sender.go
+++ b/autorest/sender.go
@@ -183,7 +183,10 @@ func DoRetryForAttempts(attempts int, backoff time.Duration) SendDecorator {
 				if err == nil {
 					return resp, err
 				}
-				rr.Reset()
+				err = rr.Reset()
+				if err != nil {
+					return resp, err
+				}
 				DelayForBackoff(backoff, attempt, r.Cancel)
 			}
 			return resp, err
@@ -210,7 +213,10 @@ func DoRetryForStatusCodes(attempts int, backoff time.Duration, codes ...int) Se
 				if err != nil || !ResponseHasStatusCode(resp, codes...) {
 					return resp, err
 				}
-				rr.Reset()
+				err = rr.Reset()
+				if err != nil {
+					return resp, err
+				}
 				DelayForBackoff(backoff, attempt, r.Cancel)
 			}
 			return resp, err
@@ -236,7 +242,10 @@ func DoRetryForDuration(d time.Duration, backoff time.Duration) SendDecorator {
 				if err == nil {
 					return resp, err
 				}
-				rr.Reset()
+				err = rr.Reset()
+				if err != nil {
+					return resp, err
+				}
 				DelayForBackoff(backoff, attempt, r.Cancel)
 			}
 			return resp, err

--- a/autorest/sender.go
+++ b/autorest/sender.go
@@ -183,10 +183,6 @@ func DoRetryForAttempts(attempts int, backoff time.Duration) SendDecorator {
 				if err == nil {
 					return resp, err
 				}
-				err = rr.Reset()
-				if err != nil {
-					return resp, err
-				}
 				DelayForBackoff(backoff, attempt, r.Cancel)
 			}
 			return resp, err
@@ -213,10 +209,6 @@ func DoRetryForStatusCodes(attempts int, backoff time.Duration, codes ...int) Se
 				if err != nil || !ResponseHasStatusCode(resp, codes...) {
 					return resp, err
 				}
-				err = rr.Reset()
-				if err != nil {
-					return resp, err
-				}
 				DelayForBackoff(backoff, attempt, r.Cancel)
 			}
 			return resp, err
@@ -240,10 +232,6 @@ func DoRetryForDuration(d time.Duration, backoff time.Duration) SendDecorator {
 				}
 				resp, err = s.Do(rr.Request())
 				if err == nil {
-					return resp, err
-				}
-				err = rr.Reset()
-				if err != nil {
 					return resp, err
 				}
 				DelayForBackoff(backoff, attempt, r.Cancel)

--- a/autorest/sender.go
+++ b/autorest/sender.go
@@ -1,9 +1,7 @@
 package autorest
 
 import (
-	"bytes"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math"
 	"net/http"
@@ -175,11 +173,17 @@ func DoPollForStatusCodes(duration time.Duration, delay time.Duration, codes ...
 func DoRetryForAttempts(attempts int, backoff time.Duration) SendDecorator {
 	return func(s Sender) Sender {
 		return SenderFunc(func(r *http.Request) (resp *http.Response, err error) {
+			rr := NewRetriableRequest(r)
 			for attempt := 0; attempt < attempts; attempt++ {
-				resp, err = s.Do(r)
+				err = rr.Prepare()
+				if err != nil {
+					return resp, err
+				}
+				resp, err = s.Do(rr.Request())
 				if err == nil {
 					return resp, err
 				}
+				rr.Reset()
 				DelayForBackoff(backoff, attempt, r.Cancel)
 			}
 			return resp, err
@@ -194,22 +198,19 @@ func DoRetryForAttempts(attempts int, backoff time.Duration) SendDecorator {
 func DoRetryForStatusCodes(attempts int, backoff time.Duration, codes ...int) SendDecorator {
 	return func(s Sender) Sender {
 		return SenderFunc(func(r *http.Request) (resp *http.Response, err error) {
-			b := []byte{}
-			if r.Body != nil {
-				b, err = ioutil.ReadAll(r.Body)
-				if err != nil {
-					return resp, err
-				}
-			}
-
+			rr := NewRetriableRequest(r)
 			// Increment to add the first call (attempts denotes number of retries)
 			attempts++
 			for attempt := 0; attempt < attempts; attempt++ {
-				r.Body = ioutil.NopCloser(bytes.NewBuffer(b))
-				resp, err = s.Do(r)
+				err = rr.Prepare()
+				if err != nil {
+					return resp, err
+				}
+				resp, err = s.Do(rr.Request())
 				if err != nil || !ResponseHasStatusCode(resp, codes...) {
 					return resp, err
 				}
+				rr.Reset()
 				DelayForBackoff(backoff, attempt, r.Cancel)
 			}
 			return resp, err
@@ -224,12 +225,18 @@ func DoRetryForStatusCodes(attempts int, backoff time.Duration, codes ...int) Se
 func DoRetryForDuration(d time.Duration, backoff time.Duration) SendDecorator {
 	return func(s Sender) Sender {
 		return SenderFunc(func(r *http.Request) (resp *http.Response, err error) {
+			rr := NewRetriableRequest(r)
 			end := time.Now().Add(d)
 			for attempt := 0; time.Now().Before(end); attempt++ {
-				resp, err = s.Do(r)
+				err = rr.Prepare()
+				if err != nil {
+					return resp, err
+				}
+				resp, err = s.Do(rr.Request())
 				if err == nil {
 					return resp, err
 				}
+				rr.Reset()
 				DelayForBackoff(backoff, attempt, r.Cancel)
 			}
 			return resp, err


### PR DESCRIPTION
The current retry logic always makes a copy of the request body by calling
ioutil.ReadAll() which is inefficient in some cases.  This change moves
the handling of the request body into type RetriableRequest and implements
a few different stratagies for preserving the request body.