### PR TITLE
Uncomment retry logic codepaths that depend on Go 1.8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 language: go
 
 go: 
-  - 1.7
   - 1.8
 
 install:

--- a/autorest/retriablerequest.go
+++ b/autorest/retriablerequest.go
@@ -7,14 +7,10 @@ import (
 	"net/http"
 )
 
-// NOTE: the GetBody() method on the http.Request object is new in 1.8.
-//       at present we support 1.7 and 1.8 so for now the branches specific
-//       to 1.8 have been commented out.
-
 // RetriableRequest provides facilities for retrying an HTTP request.
 type RetriableRequest struct {
-	req *http.Request
-	//rc    io.ReadCloser
+	req   *http.Request
+	rc    io.ReadCloser
 	br    *bytes.Reader
 	reset bool
 }
@@ -35,9 +31,9 @@ func (rr *RetriableRequest) Prepare() (err error) {
 	// the underlying transport will always close the reqeust body
 	if rr.req.Body != nil {
 		if rr.reset {
-			/*if rr.rc != nil {
+			if rr.rc != nil {
 				rr.req.Body = rr.rc
-			} else */if rr.br != nil {
+			} else if rr.br != nil {
 				_, err = rr.br.Seek(0, io.SeekStart)
 			}
 			rr.reset = false
@@ -45,14 +41,14 @@ func (rr *RetriableRequest) Prepare() (err error) {
 				return err
 			}
 		}
-		/*if rr.req.GetBody != nil {
+		if rr.req.GetBody != nil {
 			// this will allow us to preserve the body without having to
 			// make a copy.  note we need to do this on each iteration
 			rr.rc, err = rr.req.GetBody()
 			if err != nil {
 				return err
 			}
-		} else */if rr.br == nil {
+		} else if rr.br == nil {
 			// fall back to making a copy (only do this once)
 			b := []byte{}
 			if rr.req.ContentLength > 0 {


### PR DESCRIPTION
Now that Go 1.7 has been removed from CI we can enable this
optimization that relies on GetBody() which was added in 1.8.