### PR TITLE
Make RetriableRequest work with multiple versions of Go.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ language: go
 
 go: 
   - 1.8
+  - 1.7
+  - 1.6
 
 install:
   - go get -u github.com/golang/lint/golint

--- a/autorest/date/unixtime_test.go
+++ b/autorest/date/unixtime_test.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 package date
 
 import (

--- a/autorest/retriablerequest.go
+++ b/autorest/retriablerequest.go
@@ -7,14 +7,6 @@ import (
 	"net/http"
 )
 
-// RetriableRequest provides facilities for retrying an HTTP request.
-type RetriableRequest struct {
-	req   *http.Request
-	rc    io.ReadCloser
-	br    *bytes.Reader
-	reset bool
-}
-
 // NewRetriableRequest returns a wrapper around an HTTP request that support retry logic.
 func NewRetriableRequest(req *http.Request) *RetriableRequest {
 	return &RetriableRequest{req: req}
@@ -25,49 +17,22 @@ func (rr *RetriableRequest) Request() *http.Request {
 	return rr.req
 }
 
-// Prepare signals that the request is about to be sent.
-func (rr *RetriableRequest) Prepare() (err error) {
-	// preserve the request body; this is to support retry logic as
-	// the underlying transport will always close the reqeust body
-	if rr.req.Body != nil {
-		if rr.reset {
-			if rr.rc != nil {
-				rr.req.Body = rr.rc
-			} else if rr.br != nil {
-				_, err = rr.br.Seek(0, io.SeekStart)
-			}
-			rr.reset = false
-			if err != nil {
-				return err
-			}
+func (rr *RetriableRequest) prepareFromByteReader() (err error) {
+	// fall back to making a copy (only do this once)
+	b := []byte{}
+	if rr.req.ContentLength > 0 {
+		b = make([]byte, rr.req.ContentLength)
+		_, err = io.ReadFull(rr.req.Body, b)
+		if err != nil {
+			return err
 		}
-		if rr.req.GetBody != nil {
-			// this will allow us to preserve the body without having to
-			// make a copy.  note we need to do this on each iteration
-			rr.rc, err = rr.req.GetBody()
-			if err != nil {
-				return err
-			}
-		} else if rr.br == nil {
-			// fall back to making a copy (only do this once)
-			b := []byte{}
-			if rr.req.ContentLength > 0 {
-				b = make([]byte, rr.req.ContentLength)
-				_, err = io.ReadFull(rr.req.Body, b)
-				if err != nil {
-					return err
-				}
-			} else {
-				b, err = ioutil.ReadAll(rr.req.Body)
-				if err != nil {
-					return err
-				}
-			}
-			rr.br = bytes.NewReader(b)
-			rr.req.Body = ioutil.NopCloser(rr.br)
+	} else {
+		b, err = ioutil.ReadAll(rr.req.Body)
+		if err != nil {
+			return err
 		}
-		// indicates that the request body needs to be reset
-		rr.reset = true
 	}
+	rr.br = bytes.NewReader(b)
+	rr.req.Body = ioutil.NopCloser(rr.br)
 	return err
 }

--- a/autorest/retriablerequest_1.7.go
+++ b/autorest/retriablerequest_1.7.go
@@ -1,0 +1,39 @@
+// +build !go1.8
+
+package autorest
+
+import (
+	"bytes"
+	"net/http"
+)
+
+// RetriableRequest provides facilities for retrying an HTTP request.
+type RetriableRequest struct {
+	req   *http.Request
+	br    *bytes.Reader
+	reset bool
+}
+
+// Prepare signals that the request is about to be sent.
+func (rr *RetriableRequest) Prepare() (err error) {
+	// preserve the request body; this is to support retry logic as
+	// the underlying transport will always close the reqeust body
+	if rr.req.Body != nil {
+		if rr.reset {
+			if rr.br != nil {
+				_, err = rr.br.Seek(0, 0 /*io.SeekStart*/)
+			}
+			rr.reset = false
+			if err != nil {
+				return err
+			}
+		}
+		if rr.br == nil {
+			// fall back to making a copy (only do this once)
+			err = rr.prepareFromByteReader()
+		}
+		// indicates that the request body needs to be reset
+		rr.reset = true
+	}
+	return err
+}

--- a/autorest/retriablerequest_1.8.go
+++ b/autorest/retriablerequest_1.8.go
@@ -1,0 +1,50 @@
+// +build go1.8
+
+package autorest
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+)
+
+// RetriableRequest provides facilities for retrying an HTTP request.
+type RetriableRequest struct {
+	req   *http.Request
+	rc    io.ReadCloser
+	br    *bytes.Reader
+	reset bool
+}
+
+// Prepare signals that the request is about to be sent.
+func (rr *RetriableRequest) Prepare() (err error) {
+	// preserve the request body; this is to support retry logic as
+	// the underlying transport will always close the reqeust body
+	if rr.req.Body != nil {
+		if rr.reset {
+			if rr.rc != nil {
+				rr.req.Body = rr.rc
+			} else if rr.br != nil {
+				_, err = rr.br.Seek(0, io.SeekStart)
+			}
+			rr.reset = false
+			if err != nil {
+				return err
+			}
+		}
+		if rr.req.GetBody != nil {
+			// this will allow us to preserve the body without having to
+			// make a copy.  note we need to do this on each iteration
+			rr.rc, err = rr.req.GetBody()
+			if err != nil {
+				return err
+			}
+		} else if rr.br == nil {
+			// fall back to making a copy (only do this once)
+			err = rr.prepareFromByteReader()
+		}
+		// indicates that the request body needs to be reset
+		rr.reset = true
+	}
+	return err
+}


### PR DESCRIPTION
Moved version-specific code to source files with appropriate build tags
and added earlier versions of Go to travis CI.
Exclude the unixtime tests from 1.6 as they rely on functionality that
isn't available in 1.6.