### PR TITLE
Add support for bearer authentication callbacks.

### DIFF
--- a/autorest/authorization.go
+++ b/autorest/authorization.go
@@ -3,8 +3,16 @@ package autorest
 import (
 	"fmt"
 	"net/http"
+	"net/url"
+	"strings"
 
 	"github.com/Azure/go-autorest/autorest/adal"
+)
+
+const (
+	bearerChallengeHeader = "Www-Authenticate"
+	bearer                = "Bearer"
+	tenantID              = "tenantID"
 )
 
 // Authorizer is the interface that provides a PrepareDecorator used to supply request
@@ -54,4 +62,103 @@ func (ba *BearerAuthorizer) WithAuthorization() PrepareDecorator {
 			return (ba.withBearerAuthorization()(p)).Prepare(r)
 		})
 	}
+}
+
+// BearerAuthorizerCallbackFunc is the authentication callback signature.
+type BearerAuthorizerCallbackFunc func(tenantID, resource string) (*BearerAuthorizer, error)
+
+// BearerAuthorizerCallback implements bearer authorization via a callback.
+type BearerAuthorizerCallback struct {
+	callback BearerAuthorizerCallbackFunc
+}
+
+// NewBearerAuthorizerCallback creates a bearer authorization callback.  The callback
+// is invoked when the HTTP request is submitted.
+func NewBearerAuthorizerCallback(callback BearerAuthorizerCallbackFunc) *BearerAuthorizerCallback {
+	return &BearerAuthorizerCallback{callback: callback}
+}
+
+// WithAuthorization returns a PrepareDecorator that adds an HTTP Authorization header whose value
+// is "Bearer " followed by the token.  The BearerAuthorizer is obtained via a user-supplied callback.
+//
+// By default, the token will be automatically refreshed through the Refresher interface.
+func (bacb *BearerAuthorizerCallback) WithAuthorization() PrepareDecorator {
+	return func(p Preparer) Preparer {
+		return PreparerFunc(func(r *http.Request) (*http.Request, error) {
+			// make a copy of the request and remove the body as it's not
+			// required and avoids us having to create a copy of it.
+			rCopy := *r
+			removeRequestBody(&rCopy)
+
+			c := http.Client{}
+			resp, err := c.Do(&rCopy)
+			if err == nil && resp.StatusCode == 401 {
+				defer resp.Body.Close()
+				if hasBearerChallenge(resp) {
+					bc, err := newBearerChallenge(resp)
+					if err != nil {
+						return r, err
+					}
+					if bacb.callback != nil {
+						ba, err := bacb.callback(bc.values[tenantID], bc.values["resource"])
+						if err != nil {
+							return r, err
+						}
+						return ba.WithAuthorization()(p).Prepare(r)
+					}
+				}
+			}
+			return r, err
+		})
+	}
+}
+
+// returns true if the HTTP response contains a bearer challenge
+func hasBearerChallenge(resp *http.Response) bool {
+	authHeader := resp.Header.Get(bearerChallengeHeader)
+	if len(authHeader) == 0 || strings.Index(authHeader, bearer) < 0 {
+		return false
+	}
+	return true
+}
+
+type bearerChallenge struct {
+	values map[string]string
+}
+
+func newBearerChallenge(resp *http.Response) (bc bearerChallenge, err error) {
+	challenge := strings.TrimSpace(resp.Header.Get(bearerChallengeHeader))
+	trimmedChallenge := challenge[len(bearer)+1:]
+
+	// challenge is a set of key=value pairs that are comma delimited
+	pairs := strings.Split(trimmedChallenge, ",")
+	if len(pairs) < 1 {
+		err = fmt.Errorf("challenge '%s' contains no pairs", challenge)
+		return bc, err
+	}
+
+	bc.values = make(map[string]string)
+	for i := range pairs {
+		trimmedPair := strings.TrimSpace(pairs[i])
+		pair := strings.Split(trimmedPair, "=")
+		if len(pair) == 2 {
+			// remove the enclosing quotes
+			key := strings.Trim(pair[0], "\"")
+			value := strings.Trim(pair[1], "\"")
+
+			switch key {
+			case "authorization", "authorization_uri":
+				// strip the tenant ID from the authorization URL
+				asURL, err := url.Parse(value)
+				if err != nil {
+					return bc, err
+				}
+				bc.values[tenantID] = asURL.Path[1:]
+			default:
+				bc.values[key] = value
+			}
+		}
+	}
+
+	return bc, err
 }

--- a/autorest/authorization_test.go
+++ b/autorest/authorization_test.go
@@ -142,8 +142,7 @@ func TestBearerAuthorizerCallback(t *testing.T) {
 
 	s := mocks.NewSender()
 	resp := mocks.NewResponseWithStatus("401 Unauthorized", http.StatusUnauthorized)
-	resp.Header = make(http.Header)
-	resp.Header[bearerChallengeHeader] = []string{bearer + " \"authorization\"=\"https://fake.net/" + tenantString + "\",\"resource\"=\"" + resourceString + "\""}
+	mocks.SetResponseHeader(resp, bearerChallengeHeader, bearer+" \"authorization\"=\"https://fake.net/"+tenantString+"\",\"resource\"=\""+resourceString+"\"")
 	s.AppendResponse(resp)
 
 	auth := NewBearerAuthorizerCallback(s, func(tenantID, resource string) (*BearerAuthorizer, error) {

--- a/autorest/retriablerequest_1.7.go
+++ b/autorest/retriablerequest_1.7.go
@@ -37,3 +37,8 @@ func (rr *RetriableRequest) Prepare() (err error) {
 	}
 	return err
 }
+
+func removeRequestBody(req *http.Request) {
+	req.Body = nil
+	req.ContentLength = 0
+}

--- a/autorest/retriablerequest_1.8.go
+++ b/autorest/retriablerequest_1.8.go
@@ -48,3 +48,9 @@ func (rr *RetriableRequest) Prepare() (err error) {
 	}
 	return err
 }
+
+func removeRequestBody(req *http.Request) {
+	req.Body = nil
+	req.GetBody = nil
+	req.ContentLength = 0
+}


### PR DESCRIPTION
Creation of bearer authorization requires the tenant ID and resource URL
and in some cases it can be tricky to obtain the correct values leading
to authentication failures.  To simplify this we can rely on the bearer
authorization header to obtain the correct tenant ID and resource URL,
providing these bits of data via an authorization callback that's
invoked when a request is submitted.