### PR TITLE
Support for parsing the Tokens out of the Azure CLI AccessTokens file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 # Folders
 _obj
 _test
+.DS_Store
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 _obj
 _test
 .DS_Store
+.idea/
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/autorest/adal/cli_token.go
+++ b/autorest/adal/cli_token.go
@@ -1,0 +1,32 @@
+package adal
+
+import "strconv"
+
+type AzureCLIToken struct {
+	AccessToken      string `json:"accessToken"`
+	Authority        string `json:"_authority"`
+	ClientID         string `json:"_clientId"`
+	ExpiresIn        int     `json:"expiresIn"`
+	ExpiresOn        string `json:"expiresOn"`
+	IdentityProvider string `json:"identityProvider"`
+	IsMRRT           bool    `json:"isMRRT"`
+	RefreshToken     string `json:"refreshToken"`
+	Resource         string `json:"resource"`
+	TokenType        string `json:"tokenType"`
+	UserId           string `json:"userId"`
+}
+
+func AzureCLIAccessTokensPath() string {
+	return "~/.azure/accessTokens.json"
+}
+
+func (t AzureCLIToken) ToToken() Token {
+	return Token{
+		AccessToken: t.AccessToken,
+		Type: t.TokenType,
+		ExpiresIn: strconv.Itoa(t.ExpiresIn),
+		ExpiresOn: t.ExpiresOn,
+		RefreshToken: t.RefreshToken,
+		Resource: t.Resource,
+	}
+}

--- a/autorest/adal/cli_token.go
+++ b/autorest/adal/cli_token.go
@@ -7,10 +7,10 @@ type AzureCLIToken struct {
 	AccessToken      string `json:"accessToken"`
 	Authority        string `json:"_authority"`
 	ClientID         string `json:"_clientId"`
-	ExpiresIn        int     `json:"expiresIn"`
+	ExpiresIn        int    `json:"expiresIn"`
 	ExpiresOn        string `json:"expiresOn"`
 	IdentityProvider string `json:"identityProvider"`
-	IsMRRT           bool    `json:"isMRRT"`
+	IsMRRT           bool   `json:"isMRRT"`
 	RefreshToken     string `json:"refreshToken"`
 	Resource         string `json:"resource"`
 	TokenType        string `json:"tokenType"`
@@ -25,11 +25,11 @@ func AzureCLIAccessTokensPath() string {
 // ToToken converts an AzureCLIToken to a Token
 func (t AzureCLIToken) ToToken() Token {
 	return Token{
-		AccessToken: t.AccessToken,
-		Type: t.TokenType,
-		ExpiresIn: strconv.Itoa(t.ExpiresIn),
-		ExpiresOn: t.ExpiresOn,
+		AccessToken:  t.AccessToken,
+		Type:         t.TokenType,
+		ExpiresIn:    strconv.Itoa(t.ExpiresIn),
+		ExpiresOn:    t.ExpiresOn,
 		RefreshToken: t.RefreshToken,
-		Resource: t.Resource,
+		Resource:     t.Resource,
 	}
 }

--- a/autorest/adal/cli_token.go
+++ b/autorest/adal/cli_token.go
@@ -1,6 +1,9 @@
 package adal
 
-import "strconv"
+import (
+	"strconv"
+	"github.com/mitchellh/go-homedir"
+)
 
 // AzureCLIToken represents an AccessToken from the Azure CLI
 type AzureCLIToken struct {
@@ -18,8 +21,8 @@ type AzureCLIToken struct {
 }
 
 // AzureCLIAccessTokensPath returns the path where access tokens are stored from the Azure CLI
-func AzureCLIAccessTokensPath() string {
-	return "~/.azure/accessTokens.json"
+func AzureCLIAccessTokensPath() (string, error) {
+	return homedir.Expand("~/.azure/accessTokens.json")
 }
 
 // ToToken converts an AzureCLIToken to a Token

--- a/autorest/adal/cli_token.go
+++ b/autorest/adal/cli_token.go
@@ -2,6 +2,7 @@ package adal
 
 import "strconv"
 
+// AzureCLIToken represents an AccessToken from the Azure CLI
 type AzureCLIToken struct {
 	AccessToken      string `json:"accessToken"`
 	Authority        string `json:"_authority"`
@@ -13,13 +14,15 @@ type AzureCLIToken struct {
 	RefreshToken     string `json:"refreshToken"`
 	Resource         string `json:"resource"`
 	TokenType        string `json:"tokenType"`
-	UserId           string `json:"userId"`
+	UserID           string `json:"userId"`
 }
 
+// AzureCLIAccessTokensPath returns the path where access tokens are stored from the Azure CLI
 func AzureCLIAccessTokensPath() string {
 	return "~/.azure/accessTokens.json"
 }
 
+// ToToken converts an AzureCLIToken to a Token
 func (t AzureCLIToken) ToToken() Token {
 	return Token{
 		AccessToken: t.AccessToken,

--- a/autorest/adal/cli_token.go
+++ b/autorest/adal/cli_token.go
@@ -1,8 +1,8 @@
 package adal
 
 import (
-	"strconv"
 	"github.com/mitchellh/go-homedir"
+	"strconv"
 )
 
 // AzureCLIToken represents an AccessToken from the Azure CLI

--- a/autorest/adal/persist.go
+++ b/autorest/adal/persist.go
@@ -25,6 +25,24 @@ func LoadToken(path string) (*Token, error) {
 	return &token, nil
 }
 
+// LoadCLITokens restores a set of AzureCLIToken objects from a file located at 'path'.
+func LoadCLITokens(path string) (*[]AzureCLIToken, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file (%s) while loading token: %v", path, err)
+	}
+	defer file.Close()
+
+	var tokens []AzureCLIToken
+
+	dec := json.NewDecoder(file)
+	if err = dec.Decode(&tokens); err != nil {
+		return nil, fmt.Errorf("failed to decode contents of file (%s) into AzureCLIToken representation: %v", path, err)
+	}
+
+	return &tokens, nil
+}
+
 // SaveToken persists an oauth token at the given location on disk.
 // It moves the new file into place so it can safely be used to replace an existing file
 // that maybe accessed by multiple processes.

--- a/autorest/adal/persist.go
+++ b/autorest/adal/persist.go
@@ -26,7 +26,7 @@ func LoadToken(path string) (*Token, error) {
 }
 
 // LoadCLITokens restores a set of AzureCLIToken objects from a file located at 'path'.
-func LoadCLITokens(path string) (*[]AzureCLIToken, error) {
+func LoadCLITokens(path string) ([]AzureCLIToken, error) {
 	file, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file (%s) while loading token: %v", path, err)
@@ -40,7 +40,7 @@ func LoadCLITokens(path string) (*[]AzureCLIToken, error) {
 		return nil, fmt.Errorf("failed to decode contents of file (%s) into AzureCLIToken representation: %v", path, err)
 	}
 
-	return &tokens, nil
+	return tokens, nil
 }
 
 // SaveToken persists an oauth token at the given location on disk.

--- a/glide.lock
+++ b/glide.lock
@@ -1,42 +1,42 @@
-hash: 51202aefdfe9c4a992f96ab58f6cacf21cdbd1b66efe955c9030bca736ac816d
-updated: 2017-02-14T17:07:23.015382703-08:00
+hash: 5e2681e794f14699a7fea0835f0947f59ff16d24dcbed0a53c462c7c69d09e3a
+updated: 2017-08-22T11:59:00.914426089+01:00
 imports:
 - name: github.com/dgrijalva/jwt-go
-  version: a601269ab70c205d26370c16f7c81e9017c14e04
+  version: 2268707a8f0843315e2004ee4f1d021dc08baedf
   subpackages:
   - .
+- name: github.com/mitchellh/go-homedir
+  version: b8bc1bf767474819792c23f32d8286a45736f1c6
 - name: golang.org/x/crypto
-  version: 453249f01cfeb54c3d549ddb75ff152ca243f9d8
+  version: eb71ad9bd329b5ac0fd0148dd99bd62e8be8e035
   repo: https://github.com/golang/crypto.git
   vcs: git
   subpackages:
   - pkcs12
   - pkcs12/internal/rc2
 - name: golang.org/x/net
-  version: 61557ac0112b576429a0df080e1c2cef5dfbb642
+  version: 1c05540f6879653db88113bc4a2b70aec4bd491f
   repo: https://github.com/golang/net.git
   vcs: git
   subpackages:
   - .
 - name: golang.org/x/text
-  version: 06d6eba81293389cafdff7fca90d75592194b2d9
+  version: e56139fd9c5bc7244c76116c68e500765bb6db6b
   repo: https://github.com/golang/text.git
   vcs: git
   subpackages:
   - .
 testImports:
 - name: github.com/davecgh/go-spew
-  version: 346938d642f2ec3594ed81d874461961cd0faa76
+  version: adab96458c51a58dc1783b3335dcce5461522e75
   subpackages:
   - spew
-- name: github.com/Masterminds/semver
-  version: 59c29afe1a994eacb71c833025ca7acf874bb1da
 - name: github.com/pmezard/go-difflib
   version: 792786c7400a136282c1664665ae0a8db921c6c2
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: 4d4bfba8f1d1027c4fdbe371823030df51419987
+  version: 890a5c3458b43e6104ff5da8dfa139d013d77544
   subpackages:
   - assert
   - require

--- a/glide.yaml
+++ b/glide.yaml
@@ -4,25 +4,18 @@ import:
   subpackages:
   - .
 - package: golang.org/x/crypto
-  vcs: git
   repo: https://github.com/golang/crypto.git
-  subpackages:
-  - /pkcs12
-- package: golang.org/x/net
   vcs: git
+  subpackages:
+  - pkcs12
+- package: golang.org/x/net
   repo: https://github.com/golang/net.git
+  vcs: git
   subpackages:
   - .
 - package: golang.org/x/text
-  vcs: git
   repo: https://github.com/golang/text.git
+  vcs: git
   subpackages:
   - .
-testImports:
-- package: github.com/stretchr/testify
-  vcs: git
-  repo: https://github.com/stretchr/testify.git
-  subpackages:
-  - /require
-- package: github.com/Masterminds/semver
-  version: ~1.2.2
+- package: github.com/mitchellh/go-homedir


### PR DESCRIPTION
Both the Node.JS and Python Azure CLI's store the authentication tokens generated from `az(ure) login` in `~/.azure/accessTokens.json`.
Attempting to load this file using `adal.LoadToken()` fails due to there being multiple Tokens within a single file with a different schema - as such I've added a new method to load the tokens out of the file generated by the Azure CLI.

I've tested this on macOS with multiple subscriptions associated with the Azure account and this seems to work, but I'm unaware of if the file contents is different for users with a single subscription on the account?