### PR TITLE
Support for parsing the list of profiles from the Azure CLI entries

### DIFF
--- a/autorest/adal/cli.go
+++ b/autorest/adal/cli.go
@@ -20,9 +20,30 @@ type AzureCLIToken struct {
 	UserID           string `json:"userId"`
 }
 
+// AzureCLIProfile represents a Profile from the Azure CLI
+type AzureCLIProfile struct {
+	InstallationID string                 `json:"installationId"`
+	Subscriptions  []AzureCLISubscription `json:"subscriptions"`
+}
+
+// AzureCLISubscription represents a Subscription from the Azure CLI
+type AzureCLISubscription struct {
+	EnvironmentName string `json:"environmentName"`
+	Id              string `json:"id"`
+	IsDefault       bool   `json:"isDefault"`
+	Name            string `json:"name"`
+	State           string `json:"state"`
+	TenantId        string `json:"tenantId"`
+}
+
 // AzureCLIAccessTokensPath returns the path where access tokens are stored from the Azure CLI
 func AzureCLIAccessTokensPath() (string, error) {
 	return homedir.Expand("~/.azure/accessTokens.json")
+}
+
+// AzureCLIProfilePath returns the path where the Azure Profile is stored from the Azure CLI
+func AzureCLIProfilePath() (string, error) {
+	return homedir.Expand("~/.azure/azureProfile.json")
 }
 
 // ToToken converts an AzureCLIToken to a Token

--- a/autorest/adal/cli.go
+++ b/autorest/adal/cli.go
@@ -29,11 +29,11 @@ type AzureCLIProfile struct {
 // AzureCLISubscription represents a Subscription from the Azure CLI
 type AzureCLISubscription struct {
 	EnvironmentName string `json:"environmentName"`
-	Id              string `json:"id"`
+	ID              string `json:"id"`
 	IsDefault       bool   `json:"isDefault"`
 	Name            string `json:"name"`
 	State           string `json:"state"`
-	TenantId        string `json:"tenantId"`
+	TenantID        string `json:"tenantId"`
 }
 
 // AzureCLIAccessTokensPath returns the path where access tokens are stored from the Azure CLI

--- a/autorest/adal/persist.go
+++ b/autorest/adal/persist.go
@@ -1,11 +1,14 @@
 package adal
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"github.com/dimchansky/utfbom"
 )
 
 // LoadToken restores a Token object from a file located at 'path'.
@@ -37,10 +40,28 @@ func LoadCLITokens(path string) ([]AzureCLIToken, error) {
 
 	dec := json.NewDecoder(file)
 	if err = dec.Decode(&tokens); err != nil {
-		return nil, fmt.Errorf("failed to decode contents of file (%s) into AzureCLIToken representation: %v", path, err)
+		return nil, fmt.Errorf("failed to decode contents of file (%s) into a AzureCLIToken representation: %v", path, err)
 	}
 
 	return tokens, nil
+}
+
+// LoadCLIProfile restores an AzureCLIProfile object from a file located at 'path'.
+func LoadCLIProfile(path string) (AzureCLIProfile, error) {
+	var profile AzureCLIProfile
+
+	contents, err := ioutil.ReadFile(path)
+	if err != nil {
+		return profile, fmt.Errorf("failed to open file (%s) while loading token: %v", path, err)
+	}
+	reader := utfbom.SkipOnly(bytes.NewReader(contents))
+
+	dec := json.NewDecoder(reader)
+	if err = dec.Decode(&profile); err != nil {
+		return profile, fmt.Errorf("failed to decode contents of file (%s) into a AzureCLIProfile representation: %v", path, err)
+	}
+
+	return profile, nil
 }
 
 // SaveToken persists an oauth token at the given location on disk.

--- a/glide.lock
+++ b/glide.lock
@@ -1,38 +1,40 @@
-hash: 5e2681e794f14699a7fea0835f0947f59ff16d24dcbed0a53c462c7c69d09e3a
-updated: 2017-08-22T11:59:00.914426089+01:00
+hash: 6e0121d946623e7e609280b1b18627e1c8a767fdece54cb97c4447c1167cbc46
+updated: 2017-08-31T13:58:01.034822883+01:00
 imports:
 - name: github.com/dgrijalva/jwt-go
   version: 2268707a8f0843315e2004ee4f1d021dc08baedf
   subpackages:
   - .
+- name: github.com/dimchansky/utfbom
+  version: 6c6132ff69f0f6c088739067407b5d32c52e1d0f
 - name: github.com/mitchellh/go-homedir
   version: b8bc1bf767474819792c23f32d8286a45736f1c6
 - name: golang.org/x/crypto
-  version: eb71ad9bd329b5ac0fd0148dd99bd62e8be8e035
+  version: 81e90905daefcd6fd217b62423c0908922eadb30
   repo: https://github.com/golang/crypto.git
   vcs: git
   subpackages:
   - pkcs12
   - pkcs12/internal/rc2
 - name: golang.org/x/net
-  version: 1c05540f6879653db88113bc4a2b70aec4bd491f
+  version: 66aacef3dd8a676686c7ae3716979581e8b03c47
   repo: https://github.com/golang/net.git
   vcs: git
   subpackages:
   - .
 - name: golang.org/x/text
-  version: e56139fd9c5bc7244c76116c68e500765bb6db6b
+  version: 21e35d45962262c8ee80f6cb048dcf95ad0e9d79
   repo: https://github.com/golang/text.git
   vcs: git
   subpackages:
   - .
 testImports:
 - name: github.com/davecgh/go-spew
-  version: adab96458c51a58dc1783b3335dcce5461522e75
+  version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
   subpackages:
   - spew
 - name: github.com/pmezard/go-difflib
-  version: 792786c7400a136282c1664665ae0a8db921c6c2
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
 - name: github.com/stretchr/testify

--- a/glide.yaml
+++ b/glide.yaml
@@ -19,3 +19,4 @@ import:
   subpackages:
   - .
 - package: github.com/mitchellh/go-homedir
+- package: github.com/dimchansky/utfbom


### PR DESCRIPTION
This PR adds support for parsing the list of profiles out of the Azure CLI files. Unfortunately the file written by the Python CLI writes a UTF8BOM at the start of the file, which the built-in JSON parser isn't so happy about and as such we need to filter the request out first; hence why I've brought in github.com/dimchansky/utfbom (which is licensed under Apache2)
