### PR TITLE
Added support for unwrapped Azure API error responses

### DIFF
--- a/autorest/azure/azure.go
+++ b/autorest/azure/azure.go
@@ -165,7 +165,13 @@ func WithErrorUnlessStatusCode(codes ...int) autorest.RespondDecorator {
 				if decodeErr != nil {
 					return fmt.Errorf("autorest/azure: error response cannot be parsed: %q error: %v", b.String(), decodeErr)
 				} else if e.ServiceError == nil {
-					e.ServiceError = &ServiceError{Code: "Unknown", Message: "Unknown service error"}
+					// Check if error is unwrapped ServiceError
+					var se *ServiceError
+					if err := json.Unmarshal(b.Bytes(), &se); err == nil && se.Message != "" {
+						e.ServiceError = se
+					} else {
+						e.ServiceError = &ServiceError{Code: "Unknown", Message: "Unknown service error"}
+					}
 				}
 
 				e.RequestID = ExtractRequestID(resp)

--- a/autorest/azure/azure.go
+++ b/autorest/azure/azure.go
@@ -170,7 +170,10 @@ func WithErrorUnlessStatusCode(codes ...int) autorest.RespondDecorator {
 					if err := json.Unmarshal(b.Bytes(), &se); err == nil && se.Message != "" {
 						e.ServiceError = se
 					} else {
-						e.ServiceError = &ServiceError{Code: "Unknown", Message: "Unknown service error"}
+						e.ServiceError = &ServiceError{
+							Code:    "Unknown",
+							Message: "Unknown service error",
+						}
 					}
 				}
 

--- a/autorest/azure/azure_test.go
+++ b/autorest/azure/azure_test.go
@@ -353,7 +353,8 @@ func TestWithErrorUnlessStatusCode_UnwrappedError(t *testing.T) {
 		WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	if err == nil {
-		t.Fatalf("azure: returned nil error for proper error response")
+		t.Logf("azure: returned nil error for proper error response")
+		t.Fail()
 	}
 	azErr, ok := err.(*RequestError)
 	if !ok {
@@ -373,8 +374,8 @@ func TestWithErrorUnlessStatusCode_UnwrappedError(t *testing.T) {
 	}
 
 	details, _ := json.Marshal(*azErr.ServiceError.Details)
-	if string(details) != `[{"code":"conflict1","message":"error message1"},{"code":"conflict2","message":"error message2"}]` {
-		t.Fatalf("azure: error details is not unmarshaled properly")
+	if expected := `[{"code":"conflict1","message":"error message1"},{"code":"conflict2","message":"error message2"}]`; string(details) != expected {
+		t.Fatalf("azure: error details is not unmarshaled properly. Got=\"%s\"; Expected=\"%s\"", expected, string(details))
 	}
 
 	_ = azErr.Error()

--- a/autorest/azure/azure_test.go
+++ b/autorest/azure/azure_test.go
@@ -333,6 +333,64 @@ func TestWithErrorUnlessStatusCode_NoAzureError(t *testing.T) {
 
 }
 
+func TestWithErrorUnlessStatusCode_UnwrappedError(t *testing.T) {
+	j := `{
+		"target": null,
+		"code": "InternalError",
+		"message": "Azure is having trouble right now.",
+		"details": [{"code": "conflict1", "message":"error message1"},
+					{"code": "conflict2", "message":"error message2"}],
+		"innererror": []
+}`
+	uuid := "71FDB9F4-5E49-4C12-B266-DE7B4FD999A6"
+	r := mocks.NewResponseWithContent(j)
+	mocks.SetResponseHeader(r, HeaderRequestID, uuid)
+	r.Request = mocks.NewRequest()
+	r.StatusCode = http.StatusInternalServerError
+	r.Status = http.StatusText(r.StatusCode)
+
+	err := autorest.Respond(r,
+		WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByClosing())
+	if err == nil {
+		t.Fatalf("azure: returned nil error for proper error response")
+	}
+	azErr, ok := err.(*RequestError)
+	if !ok {
+		t.Fatalf("azure: returned error is not azure.RequestError: %T", err)
+	}
+
+	if expected := http.StatusInternalServerError; azErr.StatusCode != expected {
+		t.Fatalf("azure: got wrong StatusCode=%v Expected=%d", azErr.StatusCode, expected)
+	}
+
+	if expected := "Azure is having trouble right now."; azErr.ServiceError.Message != expected {
+		t.Fatalf("azure: got wrong Message=%s Expected=%s", azErr.Message, expected)
+	}
+
+	if expected := uuid; azErr.RequestID != expected {
+		t.Fatalf("azure: wrong request ID in error. expected=%q; got=%q", expected, azErr.RequestID)
+	}
+
+	details, _ := json.Marshal(*azErr.ServiceError.Details)
+	if string(details) != `[{"code":"conflict1","message":"error message1"},{"code":"conflict2","message":"error message2"}]` {
+		t.Fatalf("azure: error details is not unmarshaled properly")
+	}
+
+	_ = azErr.Error()
+
+	// the error body should still be there
+	defer r.Body.Close()
+	b, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != j {
+		t.Fatalf("response body is wrong. got=%q expected=%q", string(b), j)
+	}
+
+}
+
 func TestRequestErrorString_WithError(t *testing.T) {
 	j := `{
 		"error": {


### PR DESCRIPTION
Should solve problem described here: https://github.com/Azure/azure-sdk-for-go/issues/748
The problem is that result of API call is ServiceError itself, not ServiceError wrapped in error object. Which causes autorest to return 'Unknown' error instead.

Fixes: 748