### PR TITLE
Add type Future used to track status of long-running operations.

### DIFF
--- a/autorest/azure/async.go
+++ b/autorest/azure/async.go
@@ -16,6 +16,7 @@ package azure
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -36,6 +37,80 @@ const (
 	operationFailed     string = "Failed"
 	operationSucceeded  string = "Succeeded"
 )
+
+// Future provides a mechanism to access the status and results of an asynchronous request.
+// Since futures are stateful they should be passed by value to avoid race conditions.
+type Future struct {
+	req  *http.Request
+	resp *http.Response
+	ps   pollingState
+}
+
+// NewFuture returns a new Future object initialized with the specified request.
+func NewFuture(req *http.Request) Future {
+	return Future{req: req}
+}
+
+// Response returns the last HTTP response or nil if there isn't one.
+func (f Future) Response() *http.Response {
+	return f.resp
+}
+
+// Status returns the last status message of the operation.
+func (f Future) Status() string {
+	if f.ps.State == "" {
+		return "Unknown"
+	}
+	return f.ps.State
+}
+
+// Done queries the service to see if the operation has completed.
+func (f *Future) Done(sender autorest.Sender) (bool, error) {
+	// exit early if this future has terminated
+	if f.ps.hasTerminated() {
+		return f.terminalReturn()
+	}
+
+	resp, err := sender.Do(f.req)
+	f.resp = resp
+	if err != nil {
+		return false, err
+	}
+
+	err = updatePollingState(resp, &f.ps)
+	if err != nil {
+		return false, err
+	}
+
+	if f.ps.hasTerminated() {
+		return f.terminalReturn()
+	}
+
+	f.req, err = newPollingRequest(f.ps)
+	return false, err
+}
+
+func (f *Future) terminalReturn() (bool, error) {
+	if !f.ps.hasSucceeded() {
+		return true, f.ps
+	}
+	return true, nil
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (f Future) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&f.ps)
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (f *Future) UnmarshalJSON(data []byte) error {
+	err := json.Unmarshal(data, &f.ps)
+	if err != nil {
+		return err
+	}
+	f.req, err = newPollingRequest(f.ps)
+	return err
+}
 
 // DoPollForAsynchronous returns a SendDecorator that polls if the http.Response is for an Azure
 // long-running operation. It will delay between requests for the duration specified in the
@@ -66,10 +141,11 @@ func DoPollForAsynchronous(delay time.Duration) autorest.SendDecorator {
 					break
 				}
 
-				r, err = newPollingRequest(resp, ps)
+				r, err = newPollingRequest(ps)
 				if err != nil {
 					return resp, err
 				}
+				r.Cancel = resp.Request.Cancel
 
 				delay = autorest.GetRetryAfter(resp, delay)
 				resp, err = autorest.SendWithSender(s, r,
@@ -169,27 +245,27 @@ const (
 )
 
 type pollingState struct {
-	responseFormat pollingResponseFormat
-	uri            string
-	state          string
-	code           string
-	message        string
+	ResponseFormat pollingResponseFormat `json:"responseFormat"`
+	URI            string                `json:"uri"`
+	State          string                `json:"state"`
+	Code           string                `json:"code"`
+	Message        string                `json:"message"`
 }
 
 func (ps pollingState) hasSucceeded() bool {
-	return hasSucceeded(ps.state)
+	return hasSucceeded(ps.State)
 }
 
 func (ps pollingState) hasTerminated() bool {
-	return hasTerminated(ps.state)
+	return hasTerminated(ps.State)
 }
 
 func (ps pollingState) hasFailed() bool {
-	return hasFailed(ps.state)
+	return hasFailed(ps.State)
 }
 
 func (ps pollingState) Error() string {
-	return fmt.Sprintf("Long running operation terminated with status '%s': Code=%q Message=%q", ps.state, ps.code, ps.message)
+	return fmt.Sprintf("Long running operation terminated with status '%s': Code=%q Message=%q", ps.State, ps.Code, ps.Message)
 }
 
 //	updatePollingState maps the operation status -- retrieved from either a provisioningState
@@ -204,7 +280,7 @@ func updatePollingState(resp *http.Response, ps *pollingState) error {
 	// -- The first response will always be a provisioningStatus response; only the polling requests,
 	//    depending on the header returned, may be something otherwise.
 	var pt provisioningTracker
-	if ps.responseFormat == usesOperationResponse {
+	if ps.ResponseFormat == usesOperationResponse {
 		pt = &operationResource{}
 	} else {
 		pt = &provisioningStatus{}
@@ -212,30 +288,30 @@ func updatePollingState(resp *http.Response, ps *pollingState) error {
 
 	// If this is the first request (that is, the polling response shape is unknown), determine how
 	// to poll and what to expect
-	if ps.responseFormat == formatIsUnknown {
+	if ps.ResponseFormat == formatIsUnknown {
 		req := resp.Request
 		if req == nil {
 			return autorest.NewError("azure", "updatePollingState", "Azure Polling Error - Original HTTP request is missing")
 		}
 
 		// Prefer the Azure-AsyncOperation header
-		ps.uri = getAsyncOperation(resp)
-		if ps.uri != "" {
-			ps.responseFormat = usesOperationResponse
+		ps.URI = getAsyncOperation(resp)
+		if ps.URI != "" {
+			ps.ResponseFormat = usesOperationResponse
 		} else {
-			ps.responseFormat = usesProvisioningStatus
+			ps.ResponseFormat = usesProvisioningStatus
 		}
 
 		// Else, use the Location header
-		if ps.uri == "" {
-			ps.uri = autorest.GetLocation(resp)
+		if ps.URI == "" {
+			ps.URI = autorest.GetLocation(resp)
 		}
 
 		// Lastly, requests against an existing resource, use the last request URI
-		if ps.uri == "" {
+		if ps.URI == "" {
 			m := strings.ToUpper(req.Method)
 			if m == http.MethodPatch || m == http.MethodPut || m == http.MethodGet {
-				ps.uri = req.URL.String()
+				ps.URI = req.URL.String()
 			}
 		}
 	}
@@ -256,23 +332,23 @@ func updatePollingState(resp *http.Response, ps *pollingState) error {
 	// -- Unknown states are per-service inprogress states
 	// -- Otherwise, infer state from HTTP status code
 	if pt.hasTerminated() {
-		ps.state = pt.state()
+		ps.State = pt.state()
 	} else if pt.state() != "" {
-		ps.state = operationInProgress
+		ps.State = operationInProgress
 	} else {
 		switch resp.StatusCode {
 		case http.StatusAccepted:
-			ps.state = operationInProgress
+			ps.State = operationInProgress
 
 		case http.StatusNoContent, http.StatusCreated, http.StatusOK:
-			ps.state = operationSucceeded
+			ps.State = operationSucceeded
 
 		default:
-			ps.state = operationFailed
+			ps.State = operationFailed
 		}
 	}
 
-	if ps.state == operationInProgress && ps.uri == "" {
+	if ps.State == operationInProgress && ps.URI == "" {
 		return autorest.NewError("azure", "updatePollingState", "Azure Polling Error - Unable to obtain polling URI for %s %s", resp.Request.Method, resp.Request.URL)
 	}
 
@@ -281,35 +357,30 @@ func updatePollingState(resp *http.Response, ps *pollingState) error {
 	// -- Response
 	// -- Otherwise, Unknown
 	if ps.hasFailed() {
-		if ps.responseFormat == usesOperationResponse {
+		if ps.ResponseFormat == usesOperationResponse {
 			or := pt.(*operationResource)
-			ps.code = or.OperationError.Code
-			ps.message = or.OperationError.Message
+			ps.Code = or.OperationError.Code
+			ps.Message = or.OperationError.Message
 		} else {
 			p := pt.(*provisioningStatus)
 			if p.hasProvisioningError() {
-				ps.code = p.ProvisioningError.Code
-				ps.message = p.ProvisioningError.Message
+				ps.Code = p.ProvisioningError.Code
+				ps.Message = p.ProvisioningError.Message
 			} else {
-				ps.code = "Unknown"
-				ps.message = "None"
+				ps.Code = "Unknown"
+				ps.Message = "None"
 			}
 		}
 	}
 	return nil
 }
 
-func newPollingRequest(resp *http.Response, ps pollingState) (*http.Request, error) {
-	req := resp.Request
-	if req == nil {
-		return nil, autorest.NewError("azure", "newPollingRequest", "Azure Polling Error - Original HTTP request is missing")
-	}
-
-	reqPoll, err := autorest.Prepare(&http.Request{Cancel: req.Cancel},
+func newPollingRequest(ps pollingState) (*http.Request, error) {
+	reqPoll, err := autorest.Prepare(&http.Request{},
 		autorest.AsGet(),
-		autorest.WithBaseURL(ps.uri))
+		autorest.WithBaseURL(ps.URI))
 	if err != nil {
-		return nil, autorest.NewErrorWithError(err, "azure", "newPollingRequest", nil, "Failure creating poll request to %s", ps.uri)
+		return nil, autorest.NewErrorWithError(err, "azure", "newPollingRequest", nil, "Failure creating poll request to %s", ps.URI)
 	}
 
 	return reqPoll, nil

--- a/autorest/azure/async.go
+++ b/autorest/azure/async.go
@@ -68,7 +68,7 @@ func (f Future) Status() string {
 func (f *Future) Done(sender autorest.Sender) (bool, error) {
 	// exit early if this future has terminated
 	if f.ps.hasTerminated() {
-		return f.terminalReturn()
+		return true, f.errorInfo()
 	}
 
 	resp, err := sender.Do(f.req)
@@ -83,18 +83,20 @@ func (f *Future) Done(sender autorest.Sender) (bool, error) {
 	}
 
 	if f.ps.hasTerminated() {
-		return f.terminalReturn()
+		return true, f.errorInfo()
 	}
 
 	f.req, err = newPollingRequest(f.ps)
 	return false, err
 }
 
-func (f *Future) terminalReturn() (bool, error) {
+// if the operation failed the polling state will contain
+// error information and implements the error interface
+func (f *Future) errorInfo() error {
 	if !f.ps.hasSucceeded() {
-		return true, f.ps
+		return f.ps
 	}
-	return true, nil
+	return nil
 }
 
 // MarshalJSON implements the json.Marshaler interface.

--- a/autorest/azure/async_test.go
+++ b/autorest/azure/async_test.go
@@ -1026,7 +1026,7 @@ func TestFuture_PollsUntilProvisioningStatusSucceeds(t *testing.T) {
 	client := mocks.NewSender()
 	client.AppendResponse(r1)
 	client.AppendAndRepeatResponse(r2, 2)
-	client.AppendAndRepeatResponse(r3, 1)
+	client.AppendResponse(r3)
 
 	future := NewFuture(mocks.NewRequest())
 

--- a/autorest/azure/async_test.go
+++ b/autorest/azure/async_test.go
@@ -15,6 +15,7 @@ package azure
 //  limitations under the License.
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -145,27 +146,27 @@ func TestProvisioningStatus_HasTerminatedReturnsFalseForUnknownStates(t *testing
 }
 
 func TestPollingState_HasSucceededReturnsFalseIfNotSuccess(t *testing.T) {
-	if (pollingState{state: "not a success string"}).hasSucceeded() {
+	if (pollingState{State: "not a success string"}).hasSucceeded() {
 		t.Fatalf("azure: pollingState#hasSucceeded failed to return false for a canceled operation")
 	}
 }
 
 func TestPollingState_HasSucceededReturnsTrueIfSuccessful(t *testing.T) {
-	if !(pollingState{state: operationSucceeded}).hasSucceeded() {
+	if !(pollingState{State: operationSucceeded}).hasSucceeded() {
 		t.Fatalf("azure: pollingState#hasSucceeded failed to return true for a successful operation")
 	}
 }
 
 func TestPollingState_HasTerminatedReturnsTrueForKnownStates(t *testing.T) {
 	for _, state := range []string{operationSucceeded, operationCanceled, operationFailed} {
-		if !(pollingState{state: state}).hasTerminated() {
+		if !(pollingState{State: state}).hasTerminated() {
 			t.Fatalf("azure: pollingState#hasTerminated failed to return true for the '%s' state", state)
 		}
 	}
 }
 
 func TestPollingState_HasTerminatedReturnsFalseForUnknownStates(t *testing.T) {
-	if (pollingState{state: "not a known state"}).hasTerminated() {
+	if (pollingState{State: "not a known state"}).hasTerminated() {
 		t.Fatalf("azure: pollingState#hasTerminated returned true for a non-terminal operation")
 	}
 }
@@ -182,7 +183,7 @@ func TestUpdatePollingState_ReturnsTerminatedForKnownProvisioningStates(t *testi
 	for _, state := range []string{operationSucceeded, operationCanceled, operationFailed} {
 		resp := mocks.NewResponseWithContent(fmt.Sprintf(pollingStateFormat, state))
 		resp.StatusCode = 42
-		ps := &pollingState{responseFormat: usesProvisioningStatus}
+		ps := &pollingState{ResponseFormat: usesProvisioningStatus}
 		updatePollingState(resp, ps)
 		if !ps.hasTerminated() {
 			t.Fatalf("azure: updatePollingState failed to return a terminating pollingState for the '%s' state", state)
@@ -193,7 +194,7 @@ func TestUpdatePollingState_ReturnsTerminatedForKnownProvisioningStates(t *testi
 func TestUpdatePollingState_ReturnsSuccessForSuccessfulProvisioningState(t *testing.T) {
 	resp := mocks.NewResponseWithContent(fmt.Sprintf(pollingStateFormat, operationSucceeded))
 	resp.StatusCode = 42
-	ps := &pollingState{responseFormat: usesProvisioningStatus}
+	ps := &pollingState{ResponseFormat: usesProvisioningStatus}
 	updatePollingState(resp, ps)
 	if !ps.hasSucceeded() {
 		t.Fatalf("azure: updatePollingState failed to return a successful pollingState for the '%s' state", operationSucceeded)
@@ -204,7 +205,7 @@ func TestUpdatePollingState_ReturnsInProgressForAllOtherProvisioningStates(t *te
 	s := "not a recognized state"
 	resp := mocks.NewResponseWithContent(fmt.Sprintf(pollingStateFormat, s))
 	resp.StatusCode = 42
-	ps := &pollingState{responseFormat: usesProvisioningStatus}
+	ps := &pollingState{ResponseFormat: usesProvisioningStatus}
 	updatePollingState(resp, ps)
 	if ps.hasTerminated() {
 		t.Fatalf("azure: updatePollingState returned terminated for unknown state '%s'", s)
@@ -215,7 +216,7 @@ func TestUpdatePollingState_ReturnsSuccessWhenProvisioningStateFieldIsAbsentForS
 	for _, sc := range []int{http.StatusOK, http.StatusCreated, http.StatusNoContent} {
 		resp := mocks.NewResponseWithContent(pollingStateEmpty)
 		resp.StatusCode = sc
-		ps := &pollingState{responseFormat: usesProvisioningStatus}
+		ps := &pollingState{ResponseFormat: usesProvisioningStatus}
 		updatePollingState(resp, ps)
 		if !ps.hasSucceeded() {
 			t.Fatalf("azure: updatePollingState failed to return success when the provisionState field is absent for Status Code %d", sc)
@@ -226,7 +227,7 @@ func TestUpdatePollingState_ReturnsSuccessWhenProvisioningStateFieldIsAbsentForS
 func TestUpdatePollingState_ReturnsInProgressWhenProvisioningStateFieldIsAbsentForAccepted(t *testing.T) {
 	resp := mocks.NewResponseWithContent(pollingStateEmpty)
 	resp.StatusCode = http.StatusAccepted
-	ps := &pollingState{responseFormat: usesProvisioningStatus}
+	ps := &pollingState{ResponseFormat: usesProvisioningStatus}
 	updatePollingState(resp, ps)
 	if ps.hasTerminated() {
 		t.Fatalf("azure: updatePollingState returned terminated when the provisionState field is absent for Status Code Accepted")
@@ -236,7 +237,7 @@ func TestUpdatePollingState_ReturnsInProgressWhenProvisioningStateFieldIsAbsentF
 func TestUpdatePollingState_ReturnsFailedWhenProvisioningStateFieldIsAbsentForUnknownStatusCodes(t *testing.T) {
 	resp := mocks.NewResponseWithContent(pollingStateEmpty)
 	resp.StatusCode = 42
-	ps := &pollingState{responseFormat: usesProvisioningStatus}
+	ps := &pollingState{ResponseFormat: usesProvisioningStatus}
 	updatePollingState(resp, ps)
 	if !ps.hasTerminated() || ps.hasSucceeded() {
 		t.Fatalf("azure: updatePollingState did not return failed when the provisionState field is absent for an unknown Status Code")
@@ -247,7 +248,7 @@ func TestUpdatePollingState_ReturnsTerminatedForKnownOperationResourceStates(t *
 	for _, state := range []string{operationSucceeded, operationCanceled, operationFailed} {
 		resp := mocks.NewResponseWithContent(fmt.Sprintf(operationResourceFormat, state))
 		resp.StatusCode = 42
-		ps := &pollingState{responseFormat: usesOperationResponse}
+		ps := &pollingState{ResponseFormat: usesOperationResponse}
 		updatePollingState(resp, ps)
 		if !ps.hasTerminated() {
 			t.Fatalf("azure: updatePollingState failed to return a terminating pollingState for the '%s' state", state)
@@ -258,7 +259,7 @@ func TestUpdatePollingState_ReturnsTerminatedForKnownOperationResourceStates(t *
 func TestUpdatePollingState_ReturnsSuccessForSuccessfulOperationResourceState(t *testing.T) {
 	resp := mocks.NewResponseWithContent(fmt.Sprintf(operationResourceFormat, operationSucceeded))
 	resp.StatusCode = 42
-	ps := &pollingState{responseFormat: usesOperationResponse}
+	ps := &pollingState{ResponseFormat: usesOperationResponse}
 	updatePollingState(resp, ps)
 	if !ps.hasSucceeded() {
 		t.Fatalf("azure: updatePollingState failed to return a successful pollingState for the '%s' state", operationSucceeded)
@@ -269,7 +270,7 @@ func TestUpdatePollingState_ReturnsInProgressForAllOtherOperationResourceStates(
 	s := "not a recognized state"
 	resp := mocks.NewResponseWithContent(fmt.Sprintf(operationResourceFormat, s))
 	resp.StatusCode = 42
-	ps := &pollingState{responseFormat: usesOperationResponse}
+	ps := &pollingState{ResponseFormat: usesOperationResponse}
 	updatePollingState(resp, ps)
 	if ps.hasTerminated() {
 		t.Fatalf("azure: updatePollingState returned terminated for unknown state '%s'", s)
@@ -280,7 +281,7 @@ func TestUpdatePollingState_CopiesTheResponseBody(t *testing.T) {
 	s := fmt.Sprintf(pollingStateFormat, operationSucceeded)
 	resp := mocks.NewResponseWithContent(s)
 	resp.StatusCode = 42
-	ps := &pollingState{responseFormat: usesOperationResponse}
+	ps := &pollingState{ResponseFormat: usesOperationResponse}
 	updatePollingState(resp, ps)
 	b, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
@@ -294,7 +295,7 @@ func TestUpdatePollingState_CopiesTheResponseBody(t *testing.T) {
 func TestUpdatePollingState_ClosesTheOriginalResponseBody(t *testing.T) {
 	resp := mocks.NewResponse()
 	b := resp.Body.(*mocks.Body)
-	ps := &pollingState{responseFormat: usesProvisioningStatus}
+	ps := &pollingState{ResponseFormat: usesProvisioningStatus}
 	updatePollingState(resp, ps)
 	if b.IsOpen() {
 		t.Fatal("azure: updatePollingState failed to close the original http.Response Body")
@@ -316,7 +317,7 @@ func TestUpdatePollingState_SetsTheResponseFormatWhenUsingTheAzureAsyncOperation
 	ps := pollingState{}
 	updatePollingState(newAsynchronousResponse(), &ps)
 
-	if ps.responseFormat != usesOperationResponse {
+	if ps.ResponseFormat != usesOperationResponse {
 		t.Fatal("azure: updatePollingState failed to set the correct response format when using the Azure-AsyncOperation header")
 	}
 }
@@ -328,7 +329,7 @@ func TestUpdatePollingState_SetsTheResponseFormatWhenUsingTheAzureAsyncOperation
 	ps := pollingState{}
 	updatePollingState(resp, &ps)
 
-	if ps.responseFormat != usesProvisioningStatus {
+	if ps.ResponseFormat != usesProvisioningStatus {
 		t.Fatal("azure: updatePollingState failed to set the correct response format when the Azure-AsyncOperation header is absent")
 	}
 }
@@ -337,10 +338,10 @@ func TestUpdatePollingState_DoesNotChangeAnExistingReponseFormat(t *testing.T) {
 	resp := newAsynchronousResponse()
 	resp.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
 
-	ps := pollingState{responseFormat: usesOperationResponse}
+	ps := pollingState{ResponseFormat: usesOperationResponse}
 	updatePollingState(resp, &ps)
 
-	if ps.responseFormat != usesOperationResponse {
+	if ps.ResponseFormat != usesOperationResponse {
 		t.Fatal("azure: updatePollingState failed to leave an existing response format setting")
 	}
 }
@@ -351,7 +352,7 @@ func TestUpdatePollingState_PrefersTheAzureAsyncOperationHeader(t *testing.T) {
 	ps := pollingState{}
 	updatePollingState(resp, &ps)
 
-	if ps.uri != mocks.TestAzureAsyncURL {
+	if ps.URI != mocks.TestAzureAsyncURL {
 		t.Fatal("azure: updatePollingState failed to prefer the Azure-AsyncOperation header")
 	}
 }
@@ -363,7 +364,7 @@ func TestUpdatePollingState_PrefersLocationWhenTheAzureAsyncOperationHeaderMissi
 	ps := pollingState{}
 	updatePollingState(resp, &ps)
 
-	if ps.uri != mocks.TestLocationURL {
+	if ps.URI != mocks.TestLocationURL {
 		t.Fatal("azure: updatePollingState failed to prefer the Location header when the Azure-AsyncOperation header is missing")
 	}
 }
@@ -377,7 +378,7 @@ func TestUpdatePollingState_UsesTheObjectLocationIfAsyncHeadersAreMissing(t *tes
 	ps := pollingState{}
 	updatePollingState(resp, &ps)
 
-	if ps.uri != mocks.TestURL {
+	if ps.URI != mocks.TestURL {
 		t.Fatal("azure: updatePollingState failed to use the Object URL when the asynchronous headers are missing")
 	}
 }
@@ -392,7 +393,7 @@ func TestUpdatePollingState_RecognizesLowerCaseHTTPVerbs(t *testing.T) {
 		ps := pollingState{}
 		updatePollingState(resp, &ps)
 
-		if ps.uri != mocks.TestURL {
+		if ps.URI != mocks.TestURL {
 			t.Fatalf("azure: updatePollingState failed to recognize the lower-case HTTP verb '%s'", m)
 		}
 	}
@@ -412,32 +413,22 @@ func TestUpdatePollingState_ReturnsAnErrorIfAsyncHeadersAreMissingForANewOrDelet
 	}
 }
 
-func TestNewPollingRequest_FailsWhenResponseLacksRequest(t *testing.T) {
-	resp := newAsynchronousResponse()
-	resp.Request = nil
-
-	_, err := newPollingRequest(resp, pollingState{})
-	if err == nil {
-		t.Fatal("azure: newPollingRequest failed to return an error when the http.Response lacked the original http.Request")
-	}
-}
-
 func TestNewPollingRequest_ReturnsAnErrorWhenPrepareFails(t *testing.T) {
-	_, err := newPollingRequest(newAsynchronousResponse(), pollingState{responseFormat: usesOperationResponse, uri: mocks.TestBadURL})
+	_, err := newPollingRequest(pollingState{ResponseFormat: usesOperationResponse, URI: mocks.TestBadURL})
 	if err == nil {
 		t.Fatal("azure: newPollingRequest failed to return an error when Prepare fails")
 	}
 }
 
 func TestNewPollingRequest_DoesNotReturnARequestWhenPrepareFails(t *testing.T) {
-	req, _ := newPollingRequest(newAsynchronousResponse(), pollingState{responseFormat: usesOperationResponse, uri: mocks.TestBadURL})
+	req, _ := newPollingRequest(pollingState{ResponseFormat: usesOperationResponse, URI: mocks.TestBadURL})
 	if req != nil {
 		t.Fatal("azure: newPollingRequest returned an http.Request when Prepare failed")
 	}
 }
 
 func TestNewPollingRequest_ReturnsAGetRequest(t *testing.T) {
-	req, _ := newPollingRequest(newAsynchronousResponse(), pollingState{responseFormat: usesOperationResponse, uri: mocks.TestAzureAsyncURL})
+	req, _ := newPollingRequest(pollingState{ResponseFormat: usesOperationResponse, URI: mocks.TestAzureAsyncURL})
 	if req.Method != "GET" {
 		t.Fatalf("azure: newPollingRequest did not create an HTTP GET request -- actual method %v", req.Method)
 	}
@@ -1022,6 +1013,77 @@ func TestDoPollForAsynchronous_StopsPollingIfItReceivesAnInvalidOperationResourc
 
 	autorest.Respond(r,
 		autorest.ByClosing())
+}
+
+func TestFuture_PollsUntilProvisioningStatusSucceeds(t *testing.T) {
+	r1 := newAsynchronousResponse()
+	r1.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
+	r2 := newProvisioningStatusResponse("busy")
+	r2.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
+	r3 := newProvisioningStatusResponse(operationSucceeded)
+	r3.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
+
+	client := mocks.NewSender()
+	client.AppendResponse(r1)
+	client.AppendAndRepeatResponse(r2, 2)
+	client.AppendAndRepeatResponse(r3, 1)
+
+	future := NewFuture(mocks.NewRequest())
+
+	for done, err := future.Done(client); !done; done, err = future.Done(client) {
+		if err != nil {
+			t.Fatalf("azure: TestFuture polling Done failed")
+		}
+		time.Sleep(1 * time.Millisecond)
+	}
+
+	if client.Attempts() < 4 {
+		t.Fatalf("azure: TestFuture stopped polling before receiving a terminated OperationResource")
+	}
+
+	autorest.Respond(future.Response(),
+		autorest.ByClosing())
+}
+
+func TestFuture_Marshalling(t *testing.T) {
+	client := mocks.NewSender()
+	client.AppendResponse(newAsynchronousResponse())
+
+	future := NewFuture(mocks.NewRequest())
+	done, err := future.Done(client)
+	if err != nil {
+		t.Fatalf("azure: TestFuture marshalling Done failed")
+	}
+	if done {
+		t.Fatalf("azure: TestFuture marshalling shouldn't be done")
+	}
+
+	data, err := json.Marshal(future)
+	if err != nil {
+		t.Fatalf("azure: TestFuture failed to marshal")
+	}
+
+	var future2 Future
+	err = json.Unmarshal(data, &future2)
+	if err != nil {
+		t.Fatalf("azure: TestFuture failed to unmarshal")
+	}
+
+	if future.ps.Code != future2.ps.Code {
+		t.Fatalf("azure: TestFuture marshalling codes don't match")
+	}
+	if future.ps.Message != future2.ps.Message {
+		t.Fatalf("azure: TestFuture marshalling messages don't match")
+	}
+	if future.ps.ResponseFormat != future2.ps.ResponseFormat {
+		t.Fatalf("azure: TestFuture marshalling response formats don't match")
+	}
+	if future.ps.State != future2.ps.State {
+		t.Fatalf("azure: TestFuture marshalling states don't match")
+	}
+	if future.ps.URI != future2.ps.URI {
+		t.Fatalf("azure: TestFuture marshalling URIs don't match")
+	}
 }
 
 const (


### PR DESCRIPTION
This change adds exported type Future which will be used by generated
response types for long-running operations.  It allows the caller to
track the status of a LRO and implement their own polling mechanism.
It builds on the existing and well-tested LRO infrastructure.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [x] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [x] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.