### PR TITLE
More complete error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # CHANGELOG
 
-## v9.1.2
-
-### Bug Fixes
-
-- `DoRetryWithRegistration` now returns the original request error too.
-
 ## v9.1.1
 
 - Fixes a bug regarding the cookie jar on `autorest.Client.Sender`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## v9.1.2
+
+### Bug Fixes
+
+- `DoRetryWithRegistration` now returns the original request error too.
 
 ## v9.1.1
 

--- a/autorest/azure/rp.go
+++ b/autorest/azure/rp.go
@@ -55,15 +55,16 @@ func DoRetryWithRegistration(client autorest.Client) autorest.SendDecorator {
 				if err != nil {
 					return resp, err
 				}
+				err = re
 
 				if re.ServiceError != nil && re.ServiceError.Code == "MissingSubscriptionRegistration" {
-					err = register(client, r, re)
-					if err != nil {
-						return resp, fmt.Errorf("failed auto registering Resource Provider: %s", err)
+					regErr := register(client, r, re)
+					if regErr != nil {
+						return resp, fmt.Errorf("failed auto registering Resource Provider: %s. Original error: %s", regErr, err)
 					}
 				}
 			}
-			return resp, errors.New("failed request and resource provider registration")
+			return resp, fmt.Errorf("failed request: %s", err)
 		})
 	}
 }


### PR DESCRIPTION
Errors that were not about the RP registration were not being shown.
PTAL @marstr @jhendrixMSFT @vladbarosan 

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [x] I've added Apache 2.0 Headers to the top of any new source files.
 - [x] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [x] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.