### PR TITLE
Add method GetPollingDelay to Future.

### DIFF
--- a/autorest/azure/async.go
+++ b/autorest/azure/async.go
@@ -90,6 +90,28 @@ func (f *Future) Done(sender autorest.Sender) (bool, error) {
 	return false, err
 }
 
+// GetPollingDelay returns a duration the application should wait before checking
+// the status of the asynchronous request and true; this value is returned from
+// the service via the Retry-After response header.  If the header wasn't returned
+// then the function returns the zero-value time.Duration and false.
+func (f Future) GetPollingDelay() (time.Duration, bool) {
+	if f.resp == nil {
+		return 0, false
+	}
+
+	retry := f.resp.Header.Get(autorest.HeaderRetryAfter)
+	if retry == "" {
+		return 0, false
+	}
+
+	d, err := time.ParseDuration(retry + "s")
+	if err != nil {
+		panic(err)
+	}
+
+	return d, true
+}
+
 // if the operation failed the polling state will contain
 // error information and implements the error interface
 func (f *Future) errorInfo() error {

--- a/autorest/azure/async_test.go
+++ b/autorest/azure/async_test.go
@@ -1034,7 +1034,11 @@ func TestFuture_PollsUntilProvisioningStatusSucceeds(t *testing.T) {
 		if err != nil {
 			t.Fatalf("azure: TestFuture polling Done failed")
 		}
-		time.Sleep(1 * time.Millisecond)
+		delay, ok := future.GetPollingDelay()
+		if !ok {
+			t.Fatalf("expected Retry-After value")
+		}
+		time.Sleep(delay)
 	}
 
 	if client.Attempts() < 4 {


### PR DESCRIPTION
Some long-running operations will return a Retry-After response header
indicating how long a client should wait before checking the status.
Add a method exposing this information when present.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [x] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [x] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.