### PR TITLE
Add method PollingMethod() to Future.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## v9.3.0
+
+### New Features
+
+- Added PollingMethod() to Future so callers know what kind of polling mechanism is used.
+- Added azure.ChangeToGet() which transforms an http.Request into a GET (to be used with LROs).
+
 ## v9.2.0
 
 ### New Features

--- a/autorest/utility.go
+++ b/autorest/utility.go
@@ -20,6 +20,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"reflect"
 	"sort"
@@ -189,4 +190,15 @@ func createQuery(v url.Values) string {
 		}
 	}
 	return buf.String()
+}
+
+// ChangeToGet turns the specified http.Request into a GET (it assumes it wasn't).
+// This is mainly useful for long-running operations that use the Azure-AsyncOperation
+// header, so we change the initial PUT into a GET to retrieve the final result.
+func ChangeToGet(req *http.Request) *http.Request {
+	req.Method = "GET"
+	req.Body = nil
+	req.ContentLength = 0
+	req.Header.Del("Content-Length")
+	return req
 }


### PR DESCRIPTION
Make the type of polling used available to callers; this is required to
know if the end of a LRO requires an additional GET or not.
Add helper function ChangeToGet() to be used when retrieving the final
result of certain long-running operations.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [x] I've tested my changes, adding unit tests if applicable.
 - [x] I've added Apache 2.0 Headers to the top of any new source files.
 - [x] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [x] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.