### PR TITLE
Add WaitForCompletion to Future type.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ go:
   - 1.9
   - 1.8
   - 1.7
-  - 1.6
 
 install:
   - go get -u github.com/golang/lint/golint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## v9.4.0
+
+### New Features
+
+- Added WaitForCompletion() to Future as a default polling implementation.
+
+### Bug Fixes
+
+- Method Future.Done() shouldn't update polling status for unexpected HTTP status codes.
+
 ## v9.3.1
 
 ### Bug Fixes

--- a/autorest/autorest.go
+++ b/autorest/autorest.go
@@ -87,6 +87,9 @@ const (
 // ResponseHasStatusCode returns true if the status code in the HTTP Response is in the passed set
 // and false otherwise.
 func ResponseHasStatusCode(resp *http.Response, codes ...int) bool {
+	if resp == nil {
+		return false
+	}
 	return containsInt(codes, resp.StatusCode)
 }
 

--- a/autorest/azure/async.go
+++ b/autorest/azure/async.go
@@ -16,6 +16,7 @@ package azure
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -37,6 +38,8 @@ const (
 	operationFailed     string = "Failed"
 	operationSucceeded  string = "Succeeded"
 )
+
+var pollingCodes = [...]int{http.StatusAccepted, http.StatusCreated, http.StatusOK}
 
 // Future provides a mechanism to access the status and results of an asynchronous request.
 // Since futures are stateful they should be passed by value to avoid race conditions.
@@ -78,7 +81,7 @@ func (f *Future) Done(sender autorest.Sender) (bool, error) {
 
 	resp, err := sender.Do(f.req)
 	f.resp = resp
-	if err != nil {
+	if err != nil || !autorest.ResponseHasStatusCode(resp, pollingCodes[:]...) {
 		return false, err
 	}
 
@@ -117,6 +120,48 @@ func (f Future) GetPollingDelay() (time.Duration, bool) {
 	return d, true
 }
 
+// WaitForCompletion will return when one of the following conditions is met: the long
+// running operation has completed, the provided context is cancelled, or the client's
+// polling duration has been exceeded.  It will retry failed polling attempts based on
+// the retry value defined in the client up to the maximum retry attempts.
+func (f Future) WaitForCompletion(ctx context.Context, client autorest.Client) error {
+	start := time.Now()
+	done, err := f.Done(client)
+	for attempts := 0; !done; done, err = f.Done(client) {
+		if time.Since(start) > client.PollingDuration {
+			return autorest.NewErrorWithResponse("azure", "WaitForCompletion", f.resp, "the polling duration has been exceeded")
+		}
+		if attempts >= client.RetryAttempts {
+			return autorest.NewErrorWithError(err, "azure", "WaitForCompletion", f.resp, "the number of retries has been exceeded")
+		}
+		// we want delayAttempt to be zero in the non-error case so
+		// that DelayForBackoff doesn't perform exponential back-off
+		var delayAttempt int
+		var delay time.Duration
+		if err == nil {
+			// check for Retry-After delay, if not present use the client's polling delay
+			var ok bool
+			delay, ok = f.GetPollingDelay()
+			if !ok {
+				delay = client.PollingDelay
+			}
+		} else {
+			// there was an error polling for status so perform exponential
+			// back-off based on the number of attempts using the client's retry
+			// duration.  update attempts after delayAttempt to avoid off-by-one.
+			delayAttempt = attempts
+			delay = client.RetryDuration
+			attempts++
+		}
+		// wait until the delay elapses or the context is cancelled
+		delayElapsed := autorest.DelayForBackoff(delay, delayAttempt, ctx.Done())
+		if !delayElapsed {
+			return ctx.Err()
+		}
+	}
+	return err
+}
+
 // if the operation failed the polling state will contain
 // error information and implements the error interface
 func (f *Future) errorInfo() error {
@@ -152,8 +197,7 @@ func DoPollForAsynchronous(delay time.Duration) autorest.SendDecorator {
 			if err != nil {
 				return resp, err
 			}
-			pollingCodes := []int{http.StatusAccepted, http.StatusCreated, http.StatusOK}
-			if !autorest.ResponseHasStatusCode(resp, pollingCodes...) {
+			if !autorest.ResponseHasStatusCode(resp, pollingCodes[:]...) {
 				return resp, nil
 			}
 

--- a/autorest/azure/async_test.go
+++ b/autorest/azure/async_test.go
@@ -15,7 +15,9 @@ package azure
 //  limitations under the License.
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -876,7 +878,7 @@ func TestDoPollForAsynchronous_ReturnsErrorForLastErrorResponse(t *testing.T) {
 	r1.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
 	r2 := newProvisioningStatusResponse("busy")
 	r2.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
-	r3 := newAsynchronousResponseWithError()
+	r3 := newAsynchronousResponseWithError("400 Bad Request", http.StatusBadRequest)
 	r3.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
 
 	client := mocks.NewSender()
@@ -923,7 +925,7 @@ func TestDoPollForAsynchronous_ReturnsOperationResourceErrorForFailedOperations(
 
 func TestDoPollForAsynchronous_ReturnsErrorForFirstPutRequest(t *testing.T) {
 	// Return 400 bad response with error code and message in first put
-	r1 := newAsynchronousResponseWithError()
+	r1 := newAsynchronousResponseWithError("400 Bad Request", http.StatusBadRequest)
 	client := mocks.NewSender()
 	client.AppendResponse(r1)
 
@@ -1096,6 +1098,46 @@ func TestFuture_Marshalling(t *testing.T) {
 	}
 }
 
+func TestFuture_WaitForCompletion(t *testing.T) {
+	r1 := newAsynchronousResponse()
+	r1.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
+	r2 := newProvisioningStatusResponse("busy")
+	r2.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
+	r3 := newAsynchronousResponseWithError("Internal server error", http.StatusInternalServerError)
+	r3.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
+	r4 := newProvisioningStatusResponse(operationSucceeded)
+	r4.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
+
+	sender := mocks.NewSender()
+	sender.AppendResponse(r1)
+	sender.AppendError(errors.New("transient network failure"))
+	sender.AppendAndRepeatResponse(r2, 2)
+	sender.AppendResponse(r3)
+	sender.AppendResponse(r4)
+
+	future := NewFuture(mocks.NewRequest())
+
+	client := autorest.Client{
+		PollingDelay:    autorest.DefaultPollingDelay,
+		PollingDuration: autorest.DefaultPollingDuration,
+		RetryAttempts:   autorest.DefaultRetryAttempts,
+		RetryDuration:   1 * time.Second,
+		Sender:          sender,
+	}
+
+	err := future.WaitForCompletion(context.Background(), client)
+	if err != nil {
+		t.Fatalf("azure: WaitForCompletion returned non-nil error")
+	}
+
+	if sender.Attempts() < 4 {
+		t.Fatalf("azure: TestFuture stopped polling before receiving a terminated OperationResource")
+	}
+
+	autorest.Respond(future.Response(),
+		autorest.ByClosing())
+}
+
 const (
 	operationResourceIllegal = `
 	This is not JSON and should fail...badly.
@@ -1171,8 +1213,8 @@ func newAsynchronousResponse() *http.Response {
 	return r
 }
 
-func newAsynchronousResponseWithError() *http.Response {
-	r := mocks.NewResponseWithStatus("400 Bad Request", http.StatusBadRequest)
+func newAsynchronousResponseWithError(response string, status int) *http.Response {
+	r := mocks.NewResponseWithStatus(response, status)
 	mocks.SetRetryHeader(r, retryDelay)
 	r.Request = mocks.NewRequestForURL(mocks.TestURL)
 	r.Body = mocks.NewBody(errorResponse)

--- a/autorest/azure/async_test.go
+++ b/autorest/azure/async_test.go
@@ -1105,6 +1105,7 @@ func TestFuture_WaitForCompletion(t *testing.T) {
 	r2.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
 	r3 := newAsynchronousResponseWithError("Internal server error", http.StatusInternalServerError)
 	r3.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
+	r3.Header.Del(http.CanonicalHeaderKey("Retry-After"))
 	r4 := newProvisioningStatusResponse(operationSucceeded)
 	r4.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
 
@@ -1118,7 +1119,7 @@ func TestFuture_WaitForCompletion(t *testing.T) {
 	future := NewFuture(mocks.NewRequest())
 
 	client := autorest.Client{
-		PollingDelay:    autorest.DefaultPollingDelay,
+		PollingDelay:    1 * time.Second,
 		PollingDuration: autorest.DefaultPollingDuration,
 		RetryAttempts:   autorest.DefaultRetryAttempts,
 		RetryDuration:   1 * time.Second,

--- a/autorest/azure/async_test.go
+++ b/autorest/azure/async_test.go
@@ -636,7 +636,7 @@ func TestDoPollForAsynchronous_PollsForStatusAccepted(t *testing.T) {
 	r, _ := autorest.SendWithSender(client, mocks.NewRequest(),
 		DoPollForAsynchronous(time.Millisecond))
 
-	if client.Attempts() < 4 {
+	if client.Attempts() < client.NumResponses() {
 		t.Fatalf("azure: DoPollForAsynchronous stopped polling before receiving a terminated OperationResource")
 	}
 
@@ -659,7 +659,7 @@ func TestDoPollForAsynchronous_PollsForStatusCreated(t *testing.T) {
 	r, _ := autorest.SendWithSender(client, mocks.NewRequest(),
 		DoPollForAsynchronous(time.Millisecond))
 
-	if client.Attempts() < 4 {
+	if client.Attempts() < client.NumResponses() {
 		t.Fatalf("azure: DoPollForAsynchronous stopped polling before receiving a terminated OperationResource")
 	}
 
@@ -683,7 +683,7 @@ func TestDoPollForAsynchronous_PollsUntilProvisioningStatusTerminates(t *testing
 	r, _ := autorest.SendWithSender(client, mocks.NewRequest(),
 		DoPollForAsynchronous(time.Millisecond))
 
-	if client.Attempts() < 4 {
+	if client.Attempts() < client.NumResponses() {
 		t.Fatalf("azure: DoPollForAsynchronous stopped polling before receiving a terminated OperationResource")
 	}
 
@@ -707,7 +707,7 @@ func TestDoPollForAsynchronous_PollsUntilProvisioningStatusSucceeds(t *testing.T
 	r, _ := autorest.SendWithSender(client, mocks.NewRequest(),
 		DoPollForAsynchronous(time.Millisecond))
 
-	if client.Attempts() < 4 {
+	if client.Attempts() < client.NumResponses() {
 		t.Fatalf("azure: DoPollForAsynchronous stopped polling before receiving a terminated OperationResource")
 	}
 
@@ -728,7 +728,7 @@ func TestDoPollForAsynchronous_PollsUntilOperationResourceHasTerminated(t *testi
 	r, _ := autorest.SendWithSender(client, mocks.NewRequest(),
 		DoPollForAsynchronous(time.Millisecond))
 
-	if client.Attempts() < 4 {
+	if client.Attempts() < client.NumResponses() {
 		t.Fatalf("azure: DoPollForAsynchronous stopped polling before receiving a terminated OperationResource")
 	}
 
@@ -749,7 +749,7 @@ func TestDoPollForAsynchronous_PollsUntilOperationResourceHasSucceeded(t *testin
 	r, _ := autorest.SendWithSender(client, mocks.NewRequest(),
 		DoPollForAsynchronous(time.Millisecond))
 
-	if client.Attempts() < 4 {
+	if client.Attempts() < client.NumResponses() {
 		t.Fatalf("azure: DoPollForAsynchronous stopped polling before receiving a terminated OperationResource")
 	}
 
@@ -1046,7 +1046,7 @@ func TestFuture_PollsUntilProvisioningStatusSucceeds(t *testing.T) {
 		time.Sleep(delay)
 	}
 
-	if client.Attempts() < 4 {
+	if client.Attempts() < client.NumResponses() {
 		t.Fatalf("azure: TestFuture stopped polling before receiving a terminated OperationResource")
 	}
 
@@ -1131,7 +1131,7 @@ func TestFuture_WaitForCompletion(t *testing.T) {
 		t.Fatalf("azure: WaitForCompletion returned non-nil error")
 	}
 
-	if sender.Attempts() < 6 {
+	if sender.Attempts() < sender.NumResponses() {
 		t.Fatalf("azure: TestFuture stopped polling before receiving a terminated OperationResource")
 	}
 

--- a/autorest/client.go
+++ b/autorest/client.go
@@ -35,6 +35,9 @@ const (
 
 	// DefaultRetryAttempts is number of attempts for retry status codes (5xx).
 	DefaultRetryAttempts = 3
+
+	// DefaultRetryDuration is the duration to wait between retries.
+	DefaultRetryDuration = 30 * time.Second
 )
 
 var (
@@ -172,7 +175,7 @@ func NewClientWithUserAgent(ua string) Client {
 		PollingDelay:    DefaultPollingDelay,
 		PollingDuration: DefaultPollingDuration,
 		RetryAttempts:   DefaultRetryAttempts,
-		RetryDuration:   30 * time.Second,
+		RetryDuration:   DefaultRetryDuration,
 		UserAgent:       defaultUserAgent,
 	}
 	c.Sender = c.sender()

--- a/autorest/mocks/mocks.go
+++ b/autorest/mocks/mocks.go
@@ -90,6 +90,7 @@ type response struct {
 type Sender struct {
 	attempts       int
 	responses      []response
+	numResponses   int
 	repeatResponse []int
 	err            error
 	repeatError    int
@@ -181,6 +182,7 @@ func (c *Sender) appendAndRepeat(resp response, repeat int) {
 		c.responses = append(c.responses, resp)
 		c.repeatResponse = append(c.repeatResponse, repeat)
 	}
+	c.numResponses++
 }
 
 // Attempts returns the number of times Do was called.
@@ -203,6 +205,11 @@ func (c *Sender) SetAndRepeatError(err error, repeat int) {
 // SetEmitErrorAfter sets the number of attempts to be made before errors are emitted.
 func (c *Sender) SetEmitErrorAfter(ea int) {
 	c.emitErrorAfter = ea
+}
+
+// NumResponses returns the number of responses that have been added to the sender.
+func (c *Sender) NumResponses() int {
+	return c.numResponses
 }
 
 // T is a simple testing struct.


### PR DESCRIPTION
The WaitForCompletion method provides a default implementation that will
wait until a future has completed, is cancelled or times out.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [x] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [x] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.