### PR TITLE
Hotfix: update the logic to get path of access tokens.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v9.4.1
+
+### Bug Fixes
+
+- Update the logic to get path of access tokens through AZURE_ACCESS_TOKEN_FILE.
+
 ## v9.4.0
 
 ### New Features

--- a/autorest/azure/cli/token.go
+++ b/autorest/azure/cli/token.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/Azure/go-autorest/autorest/date"
-	"github.com/mitchellh/go-homedir"
 )
 
 // Token represents an AccessToken from the Azure CLI
@@ -63,7 +62,17 @@ func (t Token) ToADALToken() (converted adal.Token, err error) {
 
 // AccessTokensPath returns the path where access tokens are stored from the Azure CLI
 func AccessTokensPath() (string, error) {
-	return homedir.Expand("~/.azure/accessTokens.json")
+	// Azure-CLI allows user to customize the path of access tokens thorugh environment variable.
+	var accessTokenPath = os.Getenv("AZURE_ACCESS_TOKEN_FILE")
+	var err error
+
+	// Fallback logic to default path on non-cloud-shell environment.
+	// TODO(sushi): remove the dependency on hard-coding path.
+	if accessTokenPath == "" {
+		accessTokenPath, err = homedir.Expand("~/.azure/accessTokens.json")
+	}
+
+	return accessTokenPath, err
 }
 
 // ParseExpirationDate parses either a Azure CLI or CloudShell date into a time object


### PR DESCRIPTION
1. Add logic to read path of access tokens through environment variable.
2. Add fallback logic to default one.

Notice: this is short-term fix and require user to use latest version of provider in Cloud Shell.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [x] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.