### PR TITLE
Use case-insensitive string comparison for polling state.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 ### Bug Fixes
 
 - Update the AccessTokensPath() to read access tokens path through AZURE_ACCESS_TOKEN_FILE. If this
-environment variable is not set, it will fall back to use default path set by Azure CLI.
+  environment variable is not set, it will fall back to use default path set by Azure CLI.
+- Use case-insensitive string comparison for polling states.
 
 ## v9.4.0
 

--- a/autorest/azure/async.go
+++ b/autorest/azure/async.go
@@ -234,20 +234,15 @@ func getAsyncOperation(resp *http.Response) string {
 }
 
 func hasSucceeded(state string) bool {
-	return state == operationSucceeded
+	return strings.EqualFold(state, operationSucceeded)
 }
 
 func hasTerminated(state string) bool {
-	switch state {
-	case operationCanceled, operationFailed, operationSucceeded:
-		return true
-	default:
-		return false
-	}
+	return strings.EqualFold(state, operationCanceled) || strings.EqualFold(state, operationFailed) || strings.EqualFold(state, operationSucceeded)
 }
 
 func hasFailed(state string) bool {
-	return state == operationFailed
+	return strings.EqualFold(state, operationFailed)
 }
 
 type provisioningTracker interface {
@@ -426,7 +421,7 @@ func updatePollingState(resp *http.Response, ps *pollingState) error {
 		}
 	}
 
-	if ps.State == operationInProgress && ps.URI == "" {
+	if strings.EqualFold(ps.State, operationInProgress) && ps.URI == "" {
 		return autorest.NewError("azure", "updatePollingState", "Azure Polling Error - Unable to obtain polling URI for %s %s", resp.Request.Method, resp.Request.URL)
 	}
 


### PR DESCRIPTION
We have seen a case where the polling state string is all lower case
which caused an infinite loop while polling.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.