### PR TITLE
Add support for API calls with non string slice parameters

### DIFF
--- a/autorest/utility.go
+++ b/autorest/utility.go
@@ -138,33 +138,38 @@ func MapToValues(m map[string]interface{}) url.Values {
 	return v
 }
 
-// ToStringSlice method converts interface{} to []string.
-func ToStringSlice(s interface{}) []string {
-
+// AsStringSlice method converts interface{} to []string. This expects a
+//that the parameter passed to be a slice or array of a type that has the underlying
+//type a string.
+func AsStringSlice(s interface{}) ([]string, error) {
 	v := reflect.ValueOf(s)
-	stringSlice := make([]string, v.Len())
+	if v.Kind() != reflect.Slice && v.Kind() != reflect.Array {
+		return nil, NewError("autorest", "AsStringSlice", "the value's type is not an array.")
+	}
+	stringSlice := make([]string, 0, v.Len())
 
 	for i := 0; i < v.Len(); i++ {
-		stringSlice[i] = v.Index(i).String()
+		stringSlice = append(stringSlice, v.Index(i).String())
 	}
-
-	return stringSlice
+	return stringSlice, nil
 }
 
 // String method converts interface v to string. If interface is a list, it
-// joins list elements using separator.
+// joins list elements using the seperator. Note that only sep[0] will be used for
+// joining if any separator is specified.
 func String(v interface{}, sep ...string) string {
-	if len(sep) > 0 {
-		stringSlice, ok := v.([]string)
-
-		if ok == false {
-			stringSlice = ToStringSlice(v)
-		}
-		stringValue := strings.Join(stringSlice, strings.Join(sep, ""))
-		return ensureValueString(stringValue)
-
+	if len(sep) == 0 {
+		return ensureValueString(v)
 	}
-	return ensureValueString(v)
+	stringSlice, ok := v.([]string)
+	if ok == false {
+		var err error
+		stringSlice, err = AsStringSlice(v)
+		if err != nil {
+			panic(fmt.Sprintf("autorest: Couldn't convert value to a string %s.", err))
+		}
+	}
+	return ensureValueString(strings.Join(stringSlice, sep[0]))
 }
 
 // Encode method encodes url path and query parameters.

--- a/autorest/utility.go
+++ b/autorest/utility.go
@@ -138,11 +138,31 @@ func MapToValues(m map[string]interface{}) url.Values {
 	return v
 }
 
+// ToStringSlice method converts interface{} to []string.
+func ToStringSlice(s interface{}) []string {
+
+	v := reflect.ValueOf(s)
+	stringSlice := make([]string, v.Len())
+
+	for i := 0; i < v.Len(); i++ {
+		stringSlice[i] = v.Index(i).String()
+	}
+
+	return stringSlice
+}
+
 // String method converts interface v to string. If interface is a list, it
 // joins list elements using separator.
 func String(v interface{}, sep ...string) string {
 	if len(sep) > 0 {
-		return ensureValueString(strings.Join(v.([]string), sep[0]))
+		stringSlice, ok := v.([]string)
+
+		if ok == false {
+			stringSlice = ToStringSlice(v)
+		}
+		stringValue := strings.Join(stringSlice, strings.Join(sep, ""))
+		return ensureValueString(stringValue)
+
 	}
 	return ensureValueString(v)
 }

--- a/autorest/utility_test.go
+++ b/autorest/utility_test.go
@@ -229,9 +229,49 @@ func ExampleString() {
 
 func TestStringWithValidString(t *testing.T) {
 	i := 123
-	if String(i) != "123" {
-		t.Fatal("autorest: String method failed to convert integer 123 to string")
+	if got, want := String(i), "123"; got != want {
+		t.Logf("got:  %q\nwant: %q", got, want)
+		t.Fail()
 	}
+}
+
+func TestStringWithStringSlice(t *testing.T) {
+	s := []string{"string1", "string2"}
+	if got, want := String(s, ","), "string1,string2"; got != want {
+		t.Logf("got:  %q\nwant: %q", got, want)
+		t.Fail()
+	}
+}
+
+func TestStringWithEnum(t *testing.T) {
+	type TestEnumType string
+	s := TestEnumType("string1")
+	if got, want := String(s), "string1"; got != want {
+		t.Logf("got:  %q\nwant: %q", got, want)
+		t.Fail()
+	}
+}
+
+func TestStringWithEnumSlice(t *testing.T) {
+	type TestEnumType string
+	s := []TestEnumType{"string1", "string2"}
+	if got, want := String(s, ","), "string1,string2"; got != want {
+		t.Logf("got:  %q\nwant: %q", got, want)
+		t.Fail()
+	}
+}
+
+func ExampleAsStringSlice() {
+	type TestEnumType string
+
+	a := []TestEnumType{"value1", "value2"}
+	b, _ := AsStringSlice(a)
+	for _, c := range b {
+		fmt.Println(c)
+	}
+	// Output:
+	// value1
+	// value2
 }
 
 func TestEncodeWithValidPath(t *testing.T) {


### PR DESCRIPTION
Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [x] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.