### PR TITLE
Features and fixes for v9.5.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # CHANGELOG
 
+## v9.5.0
+
+### New Features
+
+- Added support for username + password, API key, authoriazation code and cognitive services authentication.
+- Added field SkipResourceProviderRegistration to clients to provide a way to skip auto-registration of RPs.
+- Added utility function AsStringSlice() to convert its parameters to a string slice.
+
+### Bug Fixes
+
+- When checking for authentication failures look at the error type not the status code as it could vary.
+
 ## v9.4.2
 
 ### Bug Fixes

--- a/autorest/azure/rp.go
+++ b/autorest/azure/rp.go
@@ -30,6 +30,9 @@ import (
 func DoRetryWithRegistration(client autorest.Client) autorest.SendDecorator {
 	return func(s autorest.Sender) autorest.Sender {
 		return autorest.SenderFunc(func(r *http.Request) (resp *http.Response, err error) {
+			if client.SkipResourceProviderRegistration {
+				return autorest.SendWithSender(s, r)
+			}
 			rr := autorest.NewRetriableRequest(r)
 			for currentAttempt := 0; currentAttempt < client.RetryAttempts; currentAttempt++ {
 				err = rr.Prepare()

--- a/autorest/client.go
+++ b/autorest/client.go
@@ -166,6 +166,9 @@ type Client struct {
 	UserAgent string
 
 	Jar http.CookieJar
+
+	// Set to true to skip attempted registration of resource providers (false by default).
+	SkipResourceProviderRegistration bool
 }
 
 // NewClientWithUserAgent returns an instance of a Client with the UserAgent set to the passed

--- a/autorest/sender.go
+++ b/autorest/sender.go
@@ -223,7 +223,7 @@ func DoRetryForStatusCodes(attempts int, backoff time.Duration, codes ...int) Se
 				resp, err = s.Do(rr.Request())
 				// we want to retry if err is not nil (e.g. transient network failure).  note that for failed authentication
 				// resp and err will both have a value, so in this case we don't want to retry as it will never succeed.
-				if err == nil && !ResponseHasStatusCode(resp, codes...) || ResponseHasStatusCode(resp, http.StatusUnauthorized) {
+				if err == nil && !ResponseHasStatusCode(resp, codes...) || IsTokenRefreshError(err) {
 					return resp, err
 				}
 				delayed := DelayWithRetryAfter(resp, r.Cancel)

--- a/autorest/utility.go
+++ b/autorest/utility.go
@@ -25,6 +25,8 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+
+	"github.com/Azure/go-autorest/autorest/adal"
 )
 
 // EncodedAs is a series of constants specifying various data encodings
@@ -226,4 +228,16 @@ func ChangeToGet(req *http.Request) *http.Request {
 	req.ContentLength = 0
 	req.Header.Del("Content-Length")
 	return req
+}
+
+// IsTokenRefreshError returns true if the specified error implements the TokenRefreshError
+// interface.  If err is a DetailedError it will walk the chain of Original errors.
+func IsTokenRefreshError(err error) bool {
+	if _, ok := err.(adal.TokenRefreshError); ok {
+		return true
+	}
+	if de, ok := err.(DetailedError); ok {
+		return IsTokenRefreshError(de.Original)
+	}
+	return false
 }


### PR DESCRIPTION
Added field SkipResourceProviderRegistration to the Client struct so
that callers can opt out of automatic RP registration.
When checking for authentication failure look at the error's type
instead of checking a hard-coded list of HTTP status codes.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [x] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [x] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.