### PR TITLE
Don't count 429 as a retry attempt.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## v9.5.1
+
+### Bug Fixes
+
+- Don't count http.StatusTooManyRequests (429) against the retry cap.
+- Use retry logic when SkipResourceProviderRegistration is set to true.
+
 ## v9.5.0
 
 ### New Features

--- a/autorest/azure/rp.go
+++ b/autorest/azure/rp.go
@@ -30,9 +30,6 @@ import (
 func DoRetryWithRegistration(client autorest.Client) autorest.SendDecorator {
 	return func(s autorest.Sender) autorest.Sender {
 		return autorest.SenderFunc(func(r *http.Request) (resp *http.Response, err error) {
-			if client.SkipResourceProviderRegistration {
-				return autorest.SendWithSender(s, r)
-			}
 			rr := autorest.NewRetriableRequest(r)
 			for currentAttempt := 0; currentAttempt < client.RetryAttempts; currentAttempt++ {
 				err = rr.Prepare()
@@ -47,7 +44,7 @@ func DoRetryWithRegistration(client autorest.Client) autorest.SendDecorator {
 					return resp, err
 				}
 
-				if resp.StatusCode != http.StatusConflict {
+				if resp.StatusCode != http.StatusConflict || client.SkipResourceProviderRegistration {
 					return resp, err
 				}
 				var re RequestError

--- a/autorest/sender_test.go
+++ b/autorest/sender_test.go
@@ -781,7 +781,7 @@ func newAcceptedResponse() *http.Response {
 }
 
 func TestDelayWithRetryAfterWithSuccess(t *testing.T) {
-	after, retries := 5, 2
+	after, retries := 2, 2
 	totalSecs := after * retries
 
 	client := mocks.NewSender()
@@ -793,7 +793,7 @@ func TestDelayWithRetryAfterWithSuccess(t *testing.T) {
 	d := time.Second * time.Duration(totalSecs)
 	start := time.Now()
 	r, _ := SendWithSender(client, mocks.NewRequest(),
-		DoRetryForStatusCodes(5, time.Duration(time.Second), http.StatusTooManyRequests),
+		DoRetryForStatusCodes(1, time.Duration(time.Second), http.StatusTooManyRequests),
 	)
 
 	if time.Since(start) < d {


### PR DESCRIPTION
If an API returns a 429 don't include it in the retry count so that we
can keep retrying until the operation succeeds.
Don't skip retry logic when SkipResourceProviderRegistration is enabled.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [x] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [x] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.