### PR TITLE
Check for nil response before dereferencing it.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v9.5.2
+
+### Bug Fixes
+
+- Check for nil *http.Response before dereferencing it.
+
 ## v9.5.1
 
 ### Bug Fixes

--- a/autorest/sender.go
+++ b/autorest/sender.go
@@ -232,7 +232,7 @@ func DoRetryForStatusCodes(attempts int, backoff time.Duration, codes ...int) Se
 				}
 				// don't count a 429 against the number of attempts
 				// so that we continue to retry until it succeeds
-				if resp.StatusCode != http.StatusTooManyRequests {
+				if resp == nil || resp.StatusCode != http.StatusTooManyRequests {
 					attempt++
 				}
 			}

--- a/autorest/sender_test.go
+++ b/autorest/sender_test.go
@@ -809,3 +809,21 @@ func TestDelayWithRetryAfterWithSuccess(t *testing.T) {
 			r.Status, client.Attempts()-1)
 	}
 }
+
+func TestDoRetryForStatusCodes_NilResponse(t *testing.T) {
+	client := mocks.NewSender()
+	client.AppendResponse(nil)
+	client.SetError(fmt.Errorf("faux error"))
+
+	r, err := SendWithSender(client, mocks.NewRequest(),
+		DoRetryForStatusCodes(3, time.Duration(1*time.Second), StatusCodesForRetry...),
+	)
+
+	Respond(r,
+		ByDiscardingBody(),
+		ByClosing())
+
+	if err != nil || client.Attempts() != 2 {
+		t.Fatalf("autorest: Sender#TestDoRetryForStatusCodes_NilResponse -- Got: non-nil error or wrong number of attempts - %v", err)
+	}
+}


### PR DESCRIPTION
If we didn't receive a response in the retry loop don't dereference it
and just count it against the retry cap.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [x] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [x] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.