### PR TITLE
Fix for missing authorization header.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v9.6.1
+
+### Bug Fixes
+
+- Ensure Authorization header is added to request when polling for registration status.
+
 ## v9.6.0
 
 ### New Features

--- a/autorest/azure/rp.go
+++ b/autorest/azure/rp.go
@@ -159,7 +159,7 @@ func register(client autorest.Client, originalReq *http.Request, re RequestError
 		}
 		req.Cancel = originalReq.Cancel
 
-		resp, err := autorest.SendWithSender(client.Sender, req,
+		resp, err := autorest.SendWithSender(client, req,
 			autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...),
 		)
 		if err != nil {


### PR DESCRIPTION
When polling for RP registration status use the client object so that
its Do() method is invoked which will add the Authorization header.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [x] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [x] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.