### PR TITLE
Add support for application/octet-stream MIME types.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v9.7.0
+
+### New Features
+
+- Added support for application/octet-stream MIME types.
+
 ## v9.6.1
 
 ### Bug Fixes

--- a/autorest/preparer.go
+++ b/autorest/preparer.go
@@ -27,8 +27,9 @@ import (
 )
 
 const (
-	mimeTypeJSON     = "application/json"
-	mimeTypeFormPost = "application/x-www-form-urlencoded"
+	mimeTypeJSON        = "application/json"
+	mimeTypeOctetStream = "application/octet-stream"
+	mimeTypeFormPost    = "application/x-www-form-urlencoded"
 
 	headerAuthorization = "Authorization"
 	headerContentType   = "Content-Type"
@@ -162,6 +163,11 @@ func AsFormURLEncoded() PrepareDecorator {
 // "application/json".
 func AsJSON() PrepareDecorator {
 	return AsContentType(mimeTypeJSON)
+}
+
+// AsOctetStream returns a PrepareDecorator that adds the "application/octet-stream" Content-Type header.
+func AsOctetStream() PrepareDecorator {
+	return AsContentType(mimeTypeOctetStream)
 }
 
 // WithMethod returns a PrepareDecorator that sets the HTTP method of the passed request. The


### PR DESCRIPTION
Added a new preparer decorator for application/octet-streams.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [x] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [x] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.