### PR TITLE
Fix unmarshalling of ServiceError.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## v10.0.0
+
+### Breaking Changes
+
+- Make the ServiceError.Details field conform to the OData v4 spec for error responses.
+
+### Bug Fixes
+
+- Fixed unmarshalling of JSON into ServiceError for services that don't conform to the spec.
+
 ## v9.7.0
 
 ### New Features

--- a/autorest/azure/async.go
+++ b/autorest/azure/async.go
@@ -300,7 +300,9 @@ func (ps provisioningStatus) hasTerminated() bool {
 }
 
 func (ps provisioningStatus) hasProvisioningError() bool {
-	return ps.ProvisioningError != ServiceError{}
+	return len(ps.ProvisioningError.Code) > 0 ||
+		len(ps.ProvisioningError.Message) > 0 ||
+		len(ps.ProvisioningError.Details) > 0
 }
 
 // PollingMethodType defines a type used for enumerating polling mechanisms.

--- a/autorest/azure/azure_test.go
+++ b/autorest/azure/azure_test.go
@@ -269,7 +269,7 @@ func TestWithErrorUnlessStatusCode_FoundAzureErrorWithDetails(t *testing.T) {
 	if azErr.ServiceError.Message == "" {
 		t.Fatalf("azure: error message is not unmarshaled properly")
 	}
-	b, _ := json.Marshal(*azErr.ServiceError.Details)
+	b, _ := json.Marshal(azErr.ServiceError.Details)
 	if string(b) != `[{"code":"conflict1","message":"error message1"},{"code":"conflict2","message":"error message2"}]` {
 		t.Fatalf("azure: error details is not unmarshaled properly")
 	}
@@ -398,7 +398,7 @@ func TestWithErrorUnlessStatusCode_UnwrappedError(t *testing.T) {
 	} else if azErr.ServiceError.Details == nil {
 		t.Logf("`ServiceError.Details` was nil when it should have been %q", expectedServiceErrorDetails)
 		t.Fail()
-	} else if details, _ := json.Marshal(*azErr.ServiceError.Details); expectedServiceErrorDetails != string(details) {
+	} else if details, _ := json.Marshal(azErr.ServiceError.Details); expectedServiceErrorDetails != string(details) {
 		t.Logf("Error detaisl was not unmarshaled properly.\n\tgot:  %q\n\twant: %q", string(details), expectedServiceErrorDetails)
 		t.Fail()
 	}
@@ -421,6 +421,35 @@ func TestRequestErrorString_WithError(t *testing.T) {
 			"code": "InternalError",
 			"message": "Conflict",
 			"details": [{"code": "conflict1", "message":"error message1"}]
+		}
+	}`
+	uuid := "71FDB9F4-5E49-4C12-B266-DE7B4FD999A6"
+	r := mocks.NewResponseWithContent(j)
+	mocks.SetResponseHeader(r, HeaderRequestID, uuid)
+	r.Request = mocks.NewRequest()
+	r.StatusCode = http.StatusInternalServerError
+	r.Status = http.StatusText(r.StatusCode)
+
+	err := autorest.Respond(r,
+		WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByClosing())
+
+	if err == nil {
+		t.Fatalf("azure: returned nil error for proper error response")
+	}
+	azErr, _ := err.(*RequestError)
+	expected := "autorest/azure: Service returned an error. Status=500 Code=\"InternalError\" Message=\"Conflict\" Details=[{\"code\":\"conflict1\",\"message\":\"error message1\"}]"
+	if expected != azErr.Error() {
+		t.Fatalf("azure: send wrong RequestError.\nexpected=%v\ngot=%v", expected, azErr.Error())
+	}
+}
+
+func TestRequestErrorString_WithErrorNonConforming(t *testing.T) {
+	j := `{
+		"error": {
+			"code": "InternalError",
+			"message": "Conflict",
+			"details": {"code": "conflict1", "message":"error message1"}
 		}
 	}`
 	uuid := "71FDB9F4-5E49-4C12-B266-DE7B4FD999A6"

--- a/autorest/azure/rp.go
+++ b/autorest/azure/rp.go
@@ -70,11 +70,8 @@ func DoRetryWithRegistration(client autorest.Client) autorest.SendDecorator {
 }
 
 func getProvider(re RequestError) (string, error) {
-	if re.ServiceError != nil {
-		if re.ServiceError.Details != nil && len(*re.ServiceError.Details) > 0 {
-			detail := (*re.ServiceError.Details)[0].(map[string]interface{})
-			return detail["target"].(string), nil
-		}
+	if re.ServiceError != nil && len(re.ServiceError.Details) > 0 {
+		return re.ServiceError.Details[0]["target"].(string), nil
 	}
 	return "", errors.New("provider was not found in the response")
 }


### PR DESCRIPTION
Some services don't conform to the OData spec, returning a single object
for details instead of an array with one object.  Added a custom
unmarshaler to ServiceError to handle both cases.
Fixed the Details field to conform to the spec; this is a breaking
change.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [x] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [x] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.