### PR TITLE
Fix unmarshalling of ServiceError.

### DIFF
--- a/autorest/azure/async.go
+++ b/autorest/azure/async.go
@@ -300,10 +300,9 @@ func (ps provisioningStatus) hasTerminated() bool {
 }
 
 func (ps provisioningStatus) hasProvisioningError() bool {
+	// code and message are required fields so only check them
 	return len(ps.ProvisioningError.Code) > 0 ||
-		len(ps.ProvisioningError.Message) > 0 ||
-		ps.ProvisioningError.Details != nil ||
-		len(ps.ProvisioningError.InnerError) > 0
+		len(ps.ProvisioningError.Message) > 0
 }
 
 // PollingMethodType defines a type used for enumerating polling mechanisms.

--- a/autorest/azure/azure.go
+++ b/autorest/azure/azure.go
@@ -1,8 +1,5 @@
-/*
-Package azure provides Azure-specific implementations used with AutoRest.
-
-See the included examples for more detail.
-*/
+// Package azure provides Azure-specific implementations used with AutoRest.
+// See the included examples for more detail.
 package azure
 
 // Copyright 2017 Microsoft Corporation
@@ -43,12 +40,13 @@ const (
 )
 
 // ServiceError encapsulates the error response from an Azure service.
+// It adhears to the OData v4 specification for error responses.
 type ServiceError struct {
-	Code       string                 `json:"code"`
-	Message    string                 `json:"message"`
-	Target     *string                `json:"target"`
-	Details    *[]interface{}         `json:"details"`
-	InnerError map[string]interface{} `json:"innererror"`
+	Code       string                   `json:"code"`
+	Message    string                   `json:"message"`
+	Target     *string                  `json:"target"`
+	Details    []map[string]interface{} `json:"details"`
+	InnerError map[string]interface{}   `json:"innererror"`
 }
 
 func (se ServiceError) Error() string {
@@ -59,9 +57,9 @@ func (se ServiceError) Error() string {
 	}
 
 	if se.Details != nil {
-		d, err := json.Marshal(*(se.Details))
+		d, err := json.Marshal(se.Details)
 		if err != nil {
-			result += fmt.Sprintf(" Details=%v", *se.Details)
+			result += fmt.Sprintf(" Details=%v", se.Details)
 		}
 		result += fmt.Sprintf(" Details=%v", string(d))
 	}
@@ -75,6 +73,55 @@ func (se ServiceError) Error() string {
 	}
 
 	return result
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface for the ServiceError type.
+func (se *ServiceError) UnmarshalJSON(b []byte) error {
+	// per the OData v4 spec the details field must be an array of JSON objects.
+	// unfortunately not all services adhear to the spec and just return a single
+	// object instead of an array with one object.  so we have to perform some
+	// shenanigans to accommodate both cases.
+	// http://docs.oasis-open.org/odata/odata-json-format/v4.0/os/odata-json-format-v4.0-os.html#_Toc372793091
+
+	type serviceError1 struct {
+		Code       string                   `json:"code"`
+		Message    string                   `json:"message"`
+		Target     *string                  `json:"target"`
+		Details    []map[string]interface{} `json:"details"`
+		InnerError map[string]interface{}   `json:"innererror"`
+	}
+
+	type serviceError2 struct {
+		Code       string                 `json:"code"`
+		Message    string                 `json:"message"`
+		Target     *string                `json:"target"`
+		Details    map[string]interface{} `json:"details"`
+		InnerError map[string]interface{} `json:"innererror"`
+	}
+
+	se1 := serviceError1{}
+	err := json.Unmarshal(b, &se1)
+	if err == nil {
+		se.populate(se1.Code, se1.Message, se1.Target, se1.Details, se1.InnerError)
+		return nil
+	}
+
+	se2 := serviceError2{}
+	err = json.Unmarshal(b, &se2)
+	if err == nil {
+		se.populate(se2.Code, se2.Message, se2.Target, nil, se2.InnerError)
+		se.Details = append(se.Details, se2.Details)
+		return nil
+	}
+	return err
+}
+
+func (se *ServiceError) populate(code, message string, target *string, details []map[string]interface{}, inner map[string]interface{}) {
+	se.Code = code
+	se.Message = message
+	se.Target = target
+	se.Details = details
+	se.InnerError = inner
 }
 
 // RequestError describes an error response returned by Azure service.

--- a/autorest/azure/rp.go
+++ b/autorest/azure/rp.go
@@ -70,11 +70,8 @@ func DoRetryWithRegistration(client autorest.Client) autorest.SendDecorator {
 }
 
 func getProvider(re RequestError) (string, error) {
-	if re.ServiceError != nil {
-		if re.ServiceError.Details != nil && len(*re.ServiceError.Details) > 0 {
-			detail := (*re.ServiceError.Details)[0].(map[string]interface{})
-			return detail["target"].(string), nil
-		}
+	if re.ServiceError != nil && len(re.ServiceError.Details) > 0 {
+		return re.ServiceError.Details[0]["target"].(string), nil
 	}
 	return "", errors.New("provider was not found in the response")
 }


### PR DESCRIPTION
Some services don't conform to the OData spec, returning a single object
for details instead of an array with one object. Added a custom
unmarshaler to ServiceError to handle both cases.
Fixed the Details field to conform to the spec; this is a breaking
change.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.