### PR TITLE
Extend pollingState to use ServiceError

### DIFF
--- a/autorest/azure/async.go
+++ b/autorest/azure/async.go
@@ -462,18 +462,14 @@ func updatePollingState(resp *http.Response, ps *pollingState) error {
 	// -- Response
 	// -- Otherwise, Unknown
 	if ps.hasFailed() {
-		if ps.PollingMethod == PollingAsyncOperation {
-			or := pt.(*operationResource)
+		if or, ok := pt.(*operationResource); ok {
 			ps.ServiceError = &or.OperationError
+		} else if p, ok := pt.(*provisioningStatus); ok && p.hasProvisioningError() {
+			ps.ServiceError = &p.ProvisioningError
 		} else {
-			p := pt.(*provisioningStatus)
-			if p.hasProvisioningError() {
-				ps.ServiceError = &p.ProvisioningError
-			} else {
-				ps.ServiceError = &ServiceError{
-					Code:    "Unknown",
-					Message: "None",
-				}
+			ps.ServiceError = &ServiceError{
+				Code:    "Unknown",
+				Message: "None",
 			}
 		}
 	}

--- a/autorest/azure/async.go
+++ b/autorest/azure/async.go
@@ -81,8 +81,35 @@ func (f *Future) Done(sender autorest.Sender) (bool, error) {
 
 	resp, err := sender.Do(f.req)
 	f.resp = resp
-	if err != nil || !autorest.ResponseHasStatusCode(resp, pollingCodes[:]...) {
+	if err != nil {
 		return false, err
+	}
+
+	if !autorest.ResponseHasStatusCode(resp, pollingCodes[:]...) {
+		// check response body for error content
+		if resp.Body != nil {
+			type respErr struct {
+				ServiceError ServiceError `json:"error"`
+			}
+			re := respErr{}
+
+			defer resp.Body.Close()
+			b, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				return false, err
+			}
+			err = json.Unmarshal(b, &re)
+			if err != nil {
+				return false, err
+			}
+			return false, re.ServiceError
+		}
+
+		// try to return something meaningful
+		return false, ServiceError{
+			Code:    fmt.Sprintf("%v", resp.StatusCode),
+			Message: resp.Status,
+		}
 	}
 
 	err = updatePollingState(resp, &f.ps)
@@ -323,8 +350,7 @@ type pollingState struct {
 	PollingMethod PollingMethodType `json:"pollingMethod"`
 	URI           string            `json:"uri"`
 	State         string            `json:"state"`
-	Code          string            `json:"code"`
-	Message       string            `json:"message"`
+	ServiceError  *ServiceError     `json:"error,omitempty"`
 }
 
 func (ps pollingState) hasSucceeded() bool {
@@ -340,7 +366,11 @@ func (ps pollingState) hasFailed() bool {
 }
 
 func (ps pollingState) Error() string {
-	return fmt.Sprintf("Long running operation terminated with status '%s': Code=%q Message=%q", ps.State, ps.Code, ps.Message)
+	s := fmt.Sprintf("Long running operation terminated with status '%s'", ps.State)
+	if ps.ServiceError != nil {
+		s = fmt.Sprintf("%s: %+v", s, *ps.ServiceError)
+	}
+	return s
 }
 
 //	updatePollingState maps the operation status -- retrieved from either a provisioningState
@@ -434,16 +464,16 @@ func updatePollingState(resp *http.Response, ps *pollingState) error {
 	if ps.hasFailed() {
 		if ps.PollingMethod == PollingAsyncOperation {
 			or := pt.(*operationResource)
-			ps.Code = or.OperationError.Code
-			ps.Message = or.OperationError.Message
+			ps.ServiceError = &or.OperationError
 		} else {
 			p := pt.(*provisioningStatus)
 			if p.hasProvisioningError() {
-				ps.Code = p.ProvisioningError.Code
-				ps.Message = p.ProvisioningError.Message
+				ps.ServiceError = &p.ProvisioningError
 			} else {
-				ps.Code = "Unknown"
-				ps.Message = "None"
+				ps.ServiceError = &ServiceError{
+					Code:    "Unknown",
+					Message: "None",
+				}
 			}
 		}
 	}

--- a/autorest/azure/async_test.go
+++ b/autorest/azure/async_test.go
@@ -1081,11 +1081,8 @@ func TestFuture_Marshalling(t *testing.T) {
 		t.Fatalf("azure: TestFuture failed to unmarshal")
 	}
 
-	if future.ps.Code != future2.ps.Code {
-		t.Fatalf("azure: TestFuture marshalling codes don't match")
-	}
-	if future.ps.Message != future2.ps.Message {
-		t.Fatalf("azure: TestFuture marshalling messages don't match")
+	if future.ps.ServiceError != future2.ps.ServiceError {
+		t.Fatalf("azure: TestFuture marshalling ServiceError don't match")
 	}
 	if future.ps.PollingMethod != future2.ps.PollingMethod {
 		t.Fatalf("azure: TestFuture marshalling response formats don't match")
@@ -1095,6 +1092,23 @@ func TestFuture_Marshalling(t *testing.T) {
 	}
 	if future.ps.URI != future2.ps.URI {
 		t.Fatalf("azure: TestFuture marshalling URIs don't match")
+	}
+}
+
+func TestFuture_MarshallingWithServiceError(t *testing.T) {
+	client := mocks.NewSender()
+	client.AppendResponse(newAsynchronousResponseWithError("400 Bad Request", http.StatusBadRequest))
+
+	future := NewFuture(mocks.NewRequest())
+	done, err := future.Done(client)
+	if err == nil {
+		t.Fatalf("azure: TestFuture marshalling didn't fail")
+	}
+	if done {
+		t.Fatalf("azure: TestFuture marshalling shouldn't be done")
+	}
+	if future.PollingMethod() != "" {
+		t.Fatalf("azure: future shouldn't have polling method")
 	}
 }
 


### PR DESCRIPTION
LROs might return error information in OData v4 format, so change the
pollingState struct to capture the complete ServiceError object.
Updated Future.Done() to return a ServiceError object if the polling
failed and the response contains an error body.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.