### PR TITLE
Add new type azure.AsyncOpIncompleteError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v9.8.0
+
+### New Features
+
+- Added type azure.AsyncOpIncompleteError to be returned from a future's Result() method when the operation has not completed.
+
 ## v9.7.1
 
 ### Bug Fixes

--- a/autorest/azure/async.go
+++ b/autorest/azure/async.go
@@ -458,3 +458,21 @@ func newPollingRequest(ps pollingState) (*http.Request, error) {
 
 	return reqPoll, nil
 }
+
+// AsyncOpIncompleteError is the type that's returned from a future that has not completed.
+type AsyncOpIncompleteError struct {
+	// FutureType is the name of the type composed of a azure.Future.
+	FutureType string
+}
+
+// Error returns an error message including the originating type name of the error.
+func (e AsyncOpIncompleteError) Error() string {
+	return fmt.Sprintf("%s: asynchronous operation has not completed", e.FutureType)
+}
+
+// NewAsyncOpIncompleteError creates a new AsyncOpIncompleteError with the specified parameters.
+func NewAsyncOpIncompleteError(futureType string) AsyncOpIncompleteError {
+	return AsyncOpIncompleteError{
+		FutureType: futureType,
+	}
+}


### PR DESCRIPTION
This new error type will be returned from generated Result() methods on
generated future types to better distinguish between a future that
hasn't completed vs. some other kind of failure.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.