### PR TITLE
Update LRO polling to accept StatusNoContent (204)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## v9.8.1
+
+### Bug Fixes
+
+- Added http.StatusNoContent (204) to the list of expected status codes for long-running operations.
+- Updated runtime version info so it's current.
+
 ## v9.8.0
 
 ### New Features

--- a/autorest/azure/async.go
+++ b/autorest/azure/async.go
@@ -39,7 +39,7 @@ const (
 	operationSucceeded  string = "Succeeded"
 )
 
-var pollingCodes = [...]int{http.StatusAccepted, http.StatusCreated, http.StatusOK}
+var pollingCodes = [...]int{http.StatusNoContent, http.StatusAccepted, http.StatusCreated, http.StatusOK}
 
 // Future provides a mechanism to access the status and results of an asynchronous request.
 // Since futures are stateful they should be passed by value to avoid race conditions.

--- a/autorest/version.go
+++ b/autorest/version.go
@@ -22,9 +22,9 @@ import (
 )
 
 const (
-	major = 8
-	minor = 0
-	patch = 0
+	major = 9
+	minor = 8
+	patch = 1
 	tag   = ""
 )
 


### PR DESCRIPTION
Some LROs can return a 204 as the final response so add it to the list
of expected polling codes.
Updated version info as it's sorely outdated.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.