### PR TITLE
Make validation failures return a unique error type.

### DIFF
--- a/autorest/validation/error.go
+++ b/autorest/validation/error.go
@@ -1,0 +1,48 @@
+package validation
+
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+import (
+	"fmt"
+)
+
+// Error is the type that's returned when the validation of an APIs arguments constraints fails.
+type Error struct {
+	// PackageType is the package type of the object emitting the error. For types, the value
+	// matches that produced the the '%T' format specifier of the fmt package. For other elements,
+	// such as functions, it is just the package name (e.g., "autorest").
+	PackageType string
+
+	// Method is the name of the method raising the error.
+	Method string
+
+	// Message is the error message.
+	Message string
+}
+
+// Error returns a string containing the details of the validation failure.
+func (e Error) Error() string {
+	return fmt.Sprintf("%s#%s: Invalid input: %s", e.PackageType, e.Method, e.Message)
+}
+
+// NewError creates a new Error object with the specified parameters.
+// message is treated as a format string to which the optional args apply.
+func NewError(packageType string, method string, message string, args ...interface{}) Error {
+	return Error{
+		PackageType: packageType,
+		Method:      method,
+		Message:     fmt.Sprintf(message, args...),
+	}
+}

--- a/autorest/validation/validation.go
+++ b/autorest/validation/validation.go
@@ -387,9 +387,3 @@ func createError(x reflect.Value, v Constraint, err string) error {
 	return fmt.Errorf("autorest/validation: validation failed: parameter=%s constraint=%s value=%#v details: %s",
 		v.Target, v.Name, getInterfaceValue(x), err)
 }
-
-// NewErrorWithValidationError appends package type and method name in
-// validation error.
-func NewErrorWithValidationError(err error, packageType, method string) error {
-	return fmt.Errorf("%s#%s: Invalid input: %v", packageType, method, err)
-}

--- a/autorest/validation/validation_test.go
+++ b/autorest/validation/validation_test.go
@@ -2417,7 +2417,7 @@ func TestValidate_StructInStruct(t *testing.T) {
 	require.Nil(t, Validate(v))
 }
 
-func TestNewErrorWithValidationError(t *testing.T) {
+func TestNewError(t *testing.T) {
 	p := &Product{}
 	v := []Validation{
 		{p, []Constraint{{"p", Null, true,
@@ -2429,5 +2429,5 @@ func TestNewErrorWithValidationError(t *testing.T) {
 	err := createError(reflect.ValueOf(p.C), v[0].Constraints[0].Chain[0], "value can not be null; required parameter")
 	z := fmt.Sprintf("batch.AccountClient#Create: Invalid input: %s",
 		err.Error())
-	require.Equal(t, NewErrorWithValidationError(err, "batch.AccountClient", "Create").Error(), z)
+	require.Equal(t, NewError("batch.AccountClient", "Create", err.Error()).Error(), z)
 }


### PR DESCRIPTION
Added type validation.Error to be returned when validation of an APIs
arguments fails one or more constraints.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [x] I've added Apache 2.0 Headers to the top of any new source files.
 - [x] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.