### PR TITLE
Populate Environment Name if Empty

### DIFF
--- a/autorest/azure/environments.go
+++ b/autorest/azure/environments.go
@@ -153,6 +153,12 @@ func EnvironmentFromName(name string) (Environment, error) {
 		if err != nil {
 			return unmarshaled, err
 		}
+
+		// In general, environments can be rehydrated from any file, which is how the `EnironmentFromFile`
+		// method should be used. For Stack, we introduced an environment variable "AZURE_ENVIRONMENT_FILEPATH"
+		// which will be read by default when the environment name "AzureStackCloud" is used.
+		// In the event that the Azure Stack environment was used, and no name was specifed, the clause
+		// below assigns a default name with the casing as it was handed to this function.
 		if unmarshaled.Name == "" {
 			unmarshaled.Name = name
 		}

--- a/autorest/azure/environments.go
+++ b/autorest/azure/environments.go
@@ -149,7 +149,14 @@ func EnvironmentFromName(name string) (Environment, error) {
 	// directly call `EnvironmentFromFile`. Until then, we rely on dispatching Azure Stack environment creation
 	// from this method based on the name that is provided to us.
 	if strings.EqualFold(name, "AZURESTACKCLOUD") {
-		return EnvironmentFromFile(os.Getenv(EnvironmentFilepathName))
+		unmarshaled, err := EnvironmentFromFile(os.Getenv(EnvironmentFilepathName))
+		if err != nil {
+			return unmarshaled, err
+		}
+		if unmarshaled.Name == "" {
+			unmarshaled.Name = name
+		}
+		return unmarshaled, nil
 	}
 
 	name = strings.ToUpper(name)

--- a/autorest/azure/testdata/test_environment_2.json
+++ b/autorest/azure/testdata/test_environment_2.json
@@ -1,0 +1,18 @@
+{
+    "managementPortalURL":          "--management-portal-url",
+    "publishSettingsURL":           "--publish-settings-url--",
+    "serviceManagementEndpoint":    "--service-management-endpoint--",
+    "resourceManagerEndpoint":      "--resource-management-endpoint--",
+    "activeDirectoryEndpoint":      "--active-directory-endpoint--",
+    "galleryEndpoint":              "--gallery-endpoint--",
+    "keyVaultEndpoint":             "--key-vault--endpoint--",
+    "graphEndpoint":                "--graph-endpoint--",
+    "storageEndpointSuffix":        "--storage-endpoint-suffix--",
+    "sqlDatabaseDNSSuffix":         "--sql-database-dns-suffix--",
+    "trafficManagerDNSSuffix":      "--traffic-manager-dns-suffix--",
+    "keyVaultDNSSuffix":            "--key-vault-dns-suffix--",
+    "serviceBusEndpointSuffix":     "--service-bus-endpoint-suffix--",
+    "serviceManagementVMDNSSuffix": "--asm-vm-dns-suffix--",
+    "resourceManagerVMDNSSuffix":   "--arm-vm-dns-suffix--",
+    "containerRegistryDNSSuffix":   "--container-registry-dns-suffix--"
+}


### PR DESCRIPTION
When reading an environment from name, that name should be assumed by default when reading from the stack file.

This PR replaces #241 
---

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [x] I've tested my changes, adding unit tests if applicable.
 - [x] I've added Apache 2.0 Headers to the top of any new source files.
 - [x] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [x] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.