### PR TITLE
Add key authorizer for event grid.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## v9.9.0
+
+### New Features
+
+- Added EventGridKeyAuthorizer for key authorization with event grid topics.
+
+### Bug Fixes
+
+- Fixed race condition when auto-refreshing service principal tokens.
+
 ## v9.8.1
 
 ### Bug Fixes

--- a/autorest/authorization.go
+++ b/autorest/authorization.go
@@ -233,3 +233,22 @@ func newBearerChallenge(resp *http.Response) (bc bearerChallenge, err error) {
 
 	return bc, err
 }
+
+// EventGridKeyAuthorizer implements authorization for event grid using key authentication.
+type EventGridKeyAuthorizer struct {
+	topicKey string
+}
+
+// NewEventGridKeyAuthorizer creates a new EventGridKeyAuthorizer
+// with the specified topic key.
+func NewEventGridKeyAuthorizer(topicKey string) EventGridKeyAuthorizer {
+	return EventGridKeyAuthorizer{topicKey: topicKey}
+}
+
+// WithAuthorization returns a PrepareDecorator that adds the aeg-sas-key authentication header.
+func (egta EventGridKeyAuthorizer) WithAuthorization() PrepareDecorator {
+	headers := map[string]interface{}{
+		"aeg-sas-key": egta.topicKey,
+	}
+	return NewAPIKeyAuthorizerWithHeaders(headers).WithAuthorization()
+}


### PR DESCRIPTION
Added type EventGridKeyAuthorizer for key authorization with an event
grid topic.
Fixed a race condition when auto-refreshing service principal tokens.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.