### PR TITLE
Fix race condition in token auto-refresh.

### DIFF
--- a/autorest/adal/cmd/adal.go
+++ b/autorest/adal/cmd/adal.go
@@ -281,7 +281,7 @@ func main() {
 			resource,
 			callback)
 		if err == nil {
-			err = saveToken(spt.Token)
+			err = saveToken(spt.Token())
 		}
 	case refreshMode:
 		_, err = refreshToken(

--- a/autorest/adal/token.go
+++ b/autorest/adal/token.go
@@ -27,6 +27,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Azure/go-autorest/autorest/date"
@@ -242,13 +243,13 @@ func (secret *ServicePrincipalCertificateSecret) SetAuthenticationValues(spt *Se
 
 // ServicePrincipalToken encapsulates a Token created for a Service Principal.
 type ServicePrincipalToken struct {
-	Token
-
+	token         Token
 	secret        ServicePrincipalSecret
 	oauthConfig   OAuthConfig
 	clientID      string
 	resource      string
 	autoRefresh   bool
+	refreshLock   *sync.RWMutex
 	refreshWithin time.Duration
 	sender        Sender
 
@@ -282,6 +283,7 @@ func NewServicePrincipalTokenWithSecret(oauthConfig OAuthConfig, id string, reso
 		clientID:         id,
 		resource:         resource,
 		autoRefresh:      true,
+		refreshLock:      &sync.RWMutex{},
 		refreshWithin:    defaultRefresh,
 		sender:           &http.Client{},
 		refreshCallbacks: callbacks,
@@ -313,7 +315,7 @@ func NewServicePrincipalTokenFromManualToken(oauthConfig OAuthConfig, clientID s
 		return nil, err
 	}
 
-	spt.Token = token
+	spt.token = token
 
 	return spt, nil
 }
@@ -499,6 +501,7 @@ func newServicePrincipalTokenFromMSI(msiEndpoint, resource string, userAssignedI
 		secret:           &ServicePrincipalMSISecret{},
 		resource:         resource,
 		autoRefresh:      true,
+		refreshLock:      &sync.RWMutex{},
 		refreshWithin:    defaultRefresh,
 		sender:           &http.Client{},
 		refreshCallbacks: callbacks,
@@ -534,8 +537,13 @@ func newTokenRefreshError(message string, resp *http.Response) TokenRefreshError
 // EnsureFresh will refresh the token if it will expire within the refresh window (as set by
 // RefreshWithin) and autoRefresh flag is on.
 func (spt *ServicePrincipalToken) EnsureFresh() error {
-	if spt.autoRefresh && spt.WillExpireIn(spt.refreshWithin) {
-		return spt.Refresh()
+	if spt.autoRefresh && spt.token.WillExpireIn(spt.refreshWithin) {
+		// take the write lock then check to see if the token was already refreshed
+		spt.refreshLock.Lock()
+		defer spt.refreshLock.Unlock()
+		if spt.token.WillExpireIn(spt.refreshWithin) {
+			return spt.refreshInternal(spt.resource)
+		}
 	}
 	return nil
 }
@@ -544,7 +552,7 @@ func (spt *ServicePrincipalToken) EnsureFresh() error {
 func (spt *ServicePrincipalToken) InvokeRefreshCallbacks(token Token) error {
 	if spt.refreshCallbacks != nil {
 		for _, callback := range spt.refreshCallbacks {
-			err := callback(spt.Token)
+			err := callback(spt.token)
 			if err != nil {
 				return fmt.Errorf("adal: TokenRefreshCallback handler failed. Error = '%v'", err)
 			}
@@ -555,11 +563,15 @@ func (spt *ServicePrincipalToken) InvokeRefreshCallbacks(token Token) error {
 
 // Refresh obtains a fresh token for the Service Principal.
 func (spt *ServicePrincipalToken) Refresh() error {
+	spt.refreshLock.Lock()
+	defer spt.refreshLock.Unlock()
 	return spt.refreshInternal(spt.resource)
 }
 
 // RefreshExchange refreshes the token, but for a different resource.
 func (spt *ServicePrincipalToken) RefreshExchange(resource string) error {
+	spt.refreshLock.Lock()
+	defer spt.refreshLock.Unlock()
 	return spt.refreshInternal(resource)
 }
 
@@ -579,9 +591,9 @@ func (spt *ServicePrincipalToken) refreshInternal(resource string) error {
 	v.Set("client_id", spt.clientID)
 	v.Set("resource", resource)
 
-	if spt.RefreshToken != "" {
+	if spt.token.RefreshToken != "" {
 		v.Set("grant_type", OAuthGrantTypeRefreshToken)
-		v.Set("refresh_token", spt.RefreshToken)
+		v.Set("refresh_token", spt.token.RefreshToken)
 	} else {
 		v.Set("grant_type", spt.getGrantType())
 		err := spt.secret.SetAuthenticationValues(spt, &v)
@@ -629,7 +641,7 @@ func (spt *ServicePrincipalToken) refreshInternal(resource string) error {
 		return fmt.Errorf("adal: Failed to unmarshal the service principal token during refresh. Error = '%v' JSON = '%s'", err, string(rb))
 	}
 
-	spt.Token = token
+	spt.token = token
 
 	return spt.InvokeRefreshCallbacks(token)
 }
@@ -649,3 +661,17 @@ func (spt *ServicePrincipalToken) SetRefreshWithin(d time.Duration) {
 // SetSender sets the http.Client used when obtaining the Service Principal token. An
 // undecorated http.Client is used by default.
 func (spt *ServicePrincipalToken) SetSender(s Sender) { spt.sender = s }
+
+// OAuthToken implements the OAuthTokenProvider interface.  It returns the current access token.
+func (spt *ServicePrincipalToken) OAuthToken() string {
+	spt.refreshLock.RLock()
+	defer spt.refreshLock.RUnlock()
+	return spt.token.OAuthToken()
+}
+
+// Token returns a copy of the current token.
+func (spt *ServicePrincipalToken) Token() Token {
+	spt.refreshLock.RLock()
+	defer spt.refreshLock.RUnlock()
+	return spt.token
+}

--- a/autorest/adal/token_test.go
+++ b/autorest/adal/token_test.go
@@ -445,12 +445,12 @@ func TestServicePrincipalTokenRefreshUnmarshals(t *testing.T) {
 	err := spt.Refresh()
 	if err != nil {
 		t.Fatalf("adal: ServicePrincipalToken#Refresh returned an unexpected error (%v)", err)
-	} else if spt.AccessToken != "accessToken" ||
-		spt.ExpiresIn != "3600" ||
-		spt.ExpiresOn != expiresOn ||
-		spt.NotBefore != expiresOn ||
-		spt.Resource != "resource" ||
-		spt.Type != "Bearer" {
+	} else if spt.token.AccessToken != "accessToken" ||
+		spt.token.ExpiresIn != "3600" ||
+		spt.token.ExpiresOn != expiresOn ||
+		spt.token.NotBefore != expiresOn ||
+		spt.token.Resource != "resource" ||
+		spt.token.Type != "Bearer" {
 		t.Fatalf("adal: ServicePrincipalToken#Refresh failed correctly unmarshal the JSON -- expected %v, received %v",
 			j, *spt)
 	}
@@ -458,7 +458,7 @@ func TestServicePrincipalTokenRefreshUnmarshals(t *testing.T) {
 
 func TestServicePrincipalTokenEnsureFreshRefreshes(t *testing.T) {
 	spt := newServicePrincipalToken()
-	expireToken(&spt.Token)
+	expireToken(&spt.token)
 
 	body := mocks.NewBody(newTokenJSON("test", "test"))
 	resp := mocks.NewResponseWithBodyAndStatus(body, http.StatusOK, "OK")
@@ -486,7 +486,7 @@ func TestServicePrincipalTokenEnsureFreshRefreshes(t *testing.T) {
 
 func TestServicePrincipalTokenEnsureFreshSkipsIfFresh(t *testing.T) {
 	spt := newServicePrincipalToken()
-	setTokenToExpireIn(&spt.Token, 1000*time.Second)
+	setTokenToExpireIn(&spt.token, 1000*time.Second)
 
 	f := false
 	c := mocks.NewSender()
@@ -553,7 +553,7 @@ func TestRefreshCallbackErrorPropagates(t *testing.T) {
 // This demonstrates the danger of manual token without a refresh token
 func TestServicePrincipalTokenManualRefreshFailsWithoutRefresh(t *testing.T) {
 	spt := newServicePrincipalTokenManual()
-	spt.RefreshToken = ""
+	spt.token.RefreshToken = ""
 	err := spt.Refresh()
 	if err == nil {
 		t.Fatalf("adal: ServicePrincipalToken#Refresh should have failed with a ManualTokenSecret without a refresh token")

--- a/autorest/authorization_test.go
+++ b/autorest/authorization_test.go
@@ -75,7 +75,7 @@ func TestServicePrincipalTokenWithAuthorizationNoRefresh(t *testing.T) {
 	req, err := Prepare(mocks.NewRequest(), ba.WithAuthorization())
 	if err != nil {
 		t.Fatalf("azure: BearerAuthorizer#WithAuthorization returned an error (%v)", err)
-	} else if req.Header.Get(http.CanonicalHeaderKey("Authorization")) != fmt.Sprintf("Bearer %s", spt.AccessToken) {
+	} else if req.Header.Get(http.CanonicalHeaderKey("Authorization")) != fmt.Sprintf("Bearer %s", spt.OAuthToken()) {
 		t.Fatal("azure: BearerAuthorizer#WithAuthorization failed to set Authorization header")
 	}
 }
@@ -120,7 +120,7 @@ func TestServicePrincipalTokenWithAuthorizationRefresh(t *testing.T) {
 	req, err := Prepare(mocks.NewRequest(), ba.WithAuthorization())
 	if err != nil {
 		t.Fatalf("azure: BearerAuthorizer#WithAuthorization returned an error (%v)", err)
-	} else if req.Header.Get(http.CanonicalHeaderKey("Authorization")) != fmt.Sprintf("Bearer %s", spt.AccessToken) {
+	} else if req.Header.Get(http.CanonicalHeaderKey("Authorization")) != fmt.Sprintf("Bearer %s", spt.OAuthToken()) {
 		t.Fatal("azure: BearerAuthorizer#WithAuthorization failed to set Authorization header")
 	}
 

--- a/autorest/azure/example/main.go
+++ b/autorest/azure/example/main.go
@@ -253,7 +253,7 @@ func main() {
 
 		// should save it as soon as you get it since Refresh won't be called for some time
 		if tokenCachePath != "" {
-			saveToken(spt.Token)
+			saveToken(spt.Token())
 		}
 	}
 


### PR DESCRIPTION
The previous fix was incomplete as the token could be read outside of
the lock.  Switched to a reader-writer lock for finer-grain access to
the token; this required decomposing Token from ServicePrincipalToken.
This is a breaking change.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.