### PR TITLE
Expose the polling URL for futures.

### DIFF
--- a/autorest/azure/async.go
+++ b/autorest/azure/async.go
@@ -78,7 +78,6 @@ func (f *Future) Done(sender autorest.Sender) (bool, error) {
 	if f.ps.hasTerminated() {
 		return true, f.errorInfo()
 	}
-
 	resp, err := sender.Do(f.req)
 	f.resp = resp
 	if err != nil {
@@ -210,6 +209,12 @@ func (f *Future) UnmarshalJSON(data []byte) error {
 	}
 	f.req, err = newPollingRequest(f.ps)
 	return err
+}
+
+// PollingURL returns the URL used for retrieving the status of the long-running operation.
+// For LROs that use the Location header the final URL value is used to retrieve the result.
+func (f Future) PollingURL() string {
+	return f.ps.URI
 }
 
 // DoPollForAsynchronous returns a SendDecorator that polls if the http.Response is for an Azure


### PR DESCRIPTION
LROs that return the Location header will use its value for polling and
for retrieving the final result of the LRO.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.