### PR TITLE
Add validation.NewErrorWithValidationError() back.

### DIFF
--- a/autorest/validation/validation.go
+++ b/autorest/validation/validation.go
@@ -387,3 +387,11 @@ func createError(x reflect.Value, v Constraint, err string) error {
 	return fmt.Errorf("autorest/validation: validation failed: parameter=%s constraint=%s value=%#v details: %s",
 		v.Target, v.Name, getInterfaceValue(x), err)
 }
+
+// NewErrorWithValidationError appends package type and method name in
+// validation error.
+//
+// Deprecated: Please use validation.NewError() instead.
+func NewErrorWithValidationError(err error, packageType, method string) error {
+	return NewError(packageType, method, err.Error())
+}

--- a/autorest/validation/validation_test.go
+++ b/autorest/validation/validation_test.go
@@ -2431,3 +2431,20 @@ func TestNewError(t *testing.T) {
 		err.Error())
 	require.Equal(t, NewError("batch.AccountClient", "Create", err.Error()).Error(), z)
 }
+
+func TestNewErrorWithValidationError(t *testing.T) {
+	p := &Product{}
+	v := []Validation{
+		{p, []Constraint{{"p", Null, true,
+			[]Constraint{{"p.C", Null, true,
+				[]Constraint{{"p.C.I", Empty, true, nil}}},
+			},
+		}}},
+	}
+	err := createError(reflect.ValueOf(p.C), v[0].Constraints[0].Chain[0], "value can not be null; required parameter")
+	z := fmt.Sprintf("batch.AccountClient#Create: Invalid input: %s",
+		err.Error())
+	valError := NewErrorWithValidationError(err, "batch.AccountClient", "Create")
+	require.IsType(t, valError, Error{})
+	require.Equal(t, valError.Error(), z)
+}


### PR DESCRIPTION
Add this function back to avoid a breaking change.  The function has
been marked as deprecated and can be removed in the future.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [x] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [x] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.