### PR TITLE
clarify support for AAD auth lib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,14 @@ sudo: false
 language: go
 
 go:
-  - 1.9
-  - 1.8
+  - master
+  - 1.10.x
+  - 1.9.x
+  - 1.8.x
+
+matrix:
+  allow_failures:
+    - go: master
 
 install:
   - go get -u github.com/golang/lint/golint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## v10.1.3
+
+### Bug Fixes
+
+- In Client.Do() invoke WithInspection() last so that it will inspect WithAuthorization().
+- Fixed authorization methods to invoke p.Prepare() first, aligning them with the other preparers.
+
 ## v10.1.2
 
 - Corrected comment for auth.NewAuthorizerFromFile() function.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v10.2.0
+
+### New Features
+
+- Added endpoints for batch management.
+
 ## v10.1.3
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -1,11 +1,22 @@
 # go-autorest
 
-[![GoDoc](https://godoc.org/github.com/Azure/go-autorest/autorest?status.png)](https://godoc.org/github.com/Azure/go-autorest/autorest) [![Build Status](https://travis-ci.org/Azure/go-autorest.svg?branch=master)](https://travis-ci.org/Azure/go-autorest) [![Go Report Card](https://goreportcard.com/badge/Azure/go-autorest)](https://goreportcard.com/report/Azure/go-autorest)
+[![GoDoc](https://godoc.org/github.com/Azure/go-autorest/autorest?status.png)](https://godoc.org/github.com/Azure/go-autorest/autorest)
+[![Build Status](https://travis-ci.org/Azure/go-autorest.svg?branch=master)](https://travis-ci.org/Azure/go-autorest)
+[![Go Report Card](https://goreportcard.com/badge/Azure/go-autorest)](https://goreportcard.com/report/Azure/go-autorest)
 
-## Usage
-Package autorest implements an HTTP request pipeline suitable for use across multiple go-routines
-and provides the shared routines relied on by AutoRest (see https://github.com/Azure/autorest/)
-generated Go code.
+Package go-autorest provides an HTTP request client for use with [Autorest](https://github.com/Azure/autorest.go)-generated API client packages.
+
+An authentication client tested with Azure Active Directory (AAD) is also
+provided in this repo in the package
+`github.com/Azure/go-autorest/autorest/adal`.  Despite its name, this package
+is maintained only as part of the Azure Go SDK and is not related to other
+"ADAL" libraries in [github.com/AzureAD](https://github.com/AzureAD).
+
+## Overview
+
+Package go-autorest implements an HTTP request pipeline suitable for use across
+multiple goroutines and provides the shared routines used by packages generated
+by [Autorest](https://github.com/Azure/autorest.go).
 
 The package breaks sending and responding to HTTP requests into three phases: Preparing, Sending,
 and Responding. A typical pattern is:
@@ -129,4 +140,10 @@ go get github.com/Azure/go-autorest/autorest/to
 See LICENSE file.
 
 -----
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+
+This project has adopted the [Microsoft Open Source Code of
+Conduct](https://opensource.microsoft.com/codeofconduct/). For more information
+see the [Code of Conduct
+FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact
+[opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional
+questions or comments.

--- a/autorest/adal/README.md
+++ b/autorest/adal/README.md
@@ -1,19 +1,24 @@
-# Azure Active Directory library for Go
+# Azure Active Directory authentication for Go
 
-This project provides a stand alone Azure Active Directory library for Go. The code was extracted
-from [go-autorest](https://github.com/Azure/go-autorest/) project, which is used as a base for
-[azure-sdk-for-go](https://github.com/Azure/azure-sdk-for-go).
+This is a standalone package for authenticating with Azure Active
+Directory from other Go libraries and applications, in particular the [Azure SDK
+for Go](https://github.com/Azure/azure-sdk-for-go).
 
+Note: Despite the package's name it is not related to other "ADAL" libraries
+maintained in the [github.com/AzureAD](https://github.com/AzureAD) org. Issues
+should be opened in [this repo's](https://github.com/Azure/go-autorest/issues)
+or [the SDK's](https://github.com/Azure/azure-sdk-for-go/issues) issue
+trackers.
 
-## Installation
+## Install
 
-```
+```bash
 go get -u github.com/Azure/go-autorest/autorest/adal
 ```
 
 ## Usage
 
-An Active Directory application is required in order to use this library. An application can be registered in the [Azure Portal](https://portal.azure.com/) follow these [guidelines](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-integrating-applications) or using the [Azure CLI](https://github.com/Azure/azure-cli).
+An Active Directory application is required in order to use this library. An application can be registered in the [Azure Portal](https://portal.azure.com/) by following these [guidelines](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-integrating-applications) or using the [Azure CLI](https://github.com/Azure/azure-cli).
 
 ### Register an Azure AD Application with secret
 

--- a/autorest/authorization.go
+++ b/autorest/authorization.go
@@ -104,10 +104,6 @@ func NewBearerAuthorizer(tp adal.OAuthTokenProvider) *BearerAuthorizer {
 	return &BearerAuthorizer{tokenProvider: tp}
 }
 
-func (ba *BearerAuthorizer) withBearerAuthorization() PrepareDecorator {
-	return WithHeader(headerAuthorization, fmt.Sprintf("Bearer %s", ba.tokenProvider.OAuthToken()))
-}
-
 // WithAuthorization returns a PrepareDecorator that adds an HTTP Authorization header whose
 // value is "Bearer " followed by the token.
 //
@@ -115,19 +111,23 @@ func (ba *BearerAuthorizer) withBearerAuthorization() PrepareDecorator {
 func (ba *BearerAuthorizer) WithAuthorization() PrepareDecorator {
 	return func(p Preparer) Preparer {
 		return PreparerFunc(func(r *http.Request) (*http.Request, error) {
-			refresher, ok := ba.tokenProvider.(adal.Refresher)
-			if ok {
-				err := refresher.EnsureFresh()
-				if err != nil {
-					var resp *http.Response
-					if tokError, ok := err.(adal.TokenRefreshError); ok {
-						resp = tokError.Response()
+			r, err := p.Prepare(r)
+			if err == nil {
+				refresher, ok := ba.tokenProvider.(adal.Refresher)
+				if ok {
+					err := refresher.EnsureFresh()
+					if err != nil {
+						var resp *http.Response
+						if tokError, ok := err.(adal.TokenRefreshError); ok {
+							resp = tokError.Response()
+						}
+						return r, NewErrorWithError(err, "azure.BearerAuthorizer", "WithAuthorization", resp,
+							"Failed to refresh the Token for request to %s", r.URL)
 					}
-					return r, NewErrorWithError(err, "azure.BearerAuthorizer", "WithAuthorization", resp,
-						"Failed to refresh the Token for request to %s", r.URL)
 				}
+				return Prepare(r, WithHeader(headerAuthorization, fmt.Sprintf("Bearer %s", ba.tokenProvider.OAuthToken())))
 			}
-			return (ba.withBearerAuthorization()(p)).Prepare(r)
+			return r, err
 		})
 	}
 }
@@ -157,25 +157,28 @@ func NewBearerAuthorizerCallback(sender Sender, callback BearerAuthorizerCallbac
 func (bacb *BearerAuthorizerCallback) WithAuthorization() PrepareDecorator {
 	return func(p Preparer) Preparer {
 		return PreparerFunc(func(r *http.Request) (*http.Request, error) {
-			// make a copy of the request and remove the body as it's not
-			// required and avoids us having to create a copy of it.
-			rCopy := *r
-			removeRequestBody(&rCopy)
+			r, err := p.Prepare(r)
+			if err == nil {
+				// make a copy of the request and remove the body as it's not
+				// required and avoids us having to create a copy of it.
+				rCopy := *r
+				removeRequestBody(&rCopy)
 
-			resp, err := bacb.sender.Do(&rCopy)
-			if err == nil && resp.StatusCode == 401 {
-				defer resp.Body.Close()
-				if hasBearerChallenge(resp) {
-					bc, err := newBearerChallenge(resp)
-					if err != nil {
-						return r, err
-					}
-					if bacb.callback != nil {
-						ba, err := bacb.callback(bc.values[tenantID], bc.values["resource"])
+				resp, err := bacb.sender.Do(&rCopy)
+				if err == nil && resp.StatusCode == 401 {
+					defer resp.Body.Close()
+					if hasBearerChallenge(resp) {
+						bc, err := newBearerChallenge(resp)
 						if err != nil {
 							return r, err
 						}
-						return ba.WithAuthorization()(p).Prepare(r)
+						if bacb.callback != nil {
+							ba, err := bacb.callback(bc.values[tenantID], bc.values["resource"])
+							if err != nil {
+								return r, err
+							}
+							return Prepare(r, ba.WithAuthorization())
+						}
 					}
 				}
 			}

--- a/autorest/azure/environments.go
+++ b/autorest/azure/environments.go
@@ -45,6 +45,7 @@ type Environment struct {
 	KeyVaultEndpoint             string `json:"keyVaultEndpoint"`
 	GraphEndpoint                string `json:"graphEndpoint"`
 	ServiceBusEndpoint           string `json:"serviceBusEndpoint"`
+	BatchManagementEndpoint      string `json:"batchManagementEndpoint"`
 	StorageEndpointSuffix        string `json:"storageEndpointSuffix"`
 	SQLDatabaseDNSSuffix         string `json:"sqlDatabaseDNSSuffix"`
 	TrafficManagerDNSSuffix      string `json:"trafficManagerDNSSuffix"`
@@ -68,6 +69,7 @@ var (
 		KeyVaultEndpoint:             "https://vault.azure.net/",
 		GraphEndpoint:                "https://graph.windows.net/",
 		ServiceBusEndpoint:           "https://servicebus.windows.net/",
+		BatchManagementEndpoint:      "https://batch.core.windows.net/",
 		StorageEndpointSuffix:        "core.windows.net",
 		SQLDatabaseDNSSuffix:         "database.windows.net",
 		TrafficManagerDNSSuffix:      "trafficmanager.net",
@@ -90,6 +92,7 @@ var (
 		KeyVaultEndpoint:             "https://vault.usgovcloudapi.net/",
 		GraphEndpoint:                "https://graph.windows.net/",
 		ServiceBusEndpoint:           "https://servicebus.usgovcloudapi.net/",
+		BatchManagementEndpoint:      "https://batch.core.usgovcloudapi.net/",
 		StorageEndpointSuffix:        "core.usgovcloudapi.net",
 		SQLDatabaseDNSSuffix:         "database.usgovcloudapi.net",
 		TrafficManagerDNSSuffix:      "usgovtrafficmanager.net",
@@ -112,6 +115,7 @@ var (
 		KeyVaultEndpoint:             "https://vault.azure.cn/",
 		GraphEndpoint:                "https://graph.chinacloudapi.cn/",
 		ServiceBusEndpoint:           "https://servicebus.chinacloudapi.cn/",
+		BatchManagementEndpoint:      "https://batch.chinacloudapi.cn/",
 		StorageEndpointSuffix:        "core.chinacloudapi.cn",
 		SQLDatabaseDNSSuffix:         "database.chinacloudapi.cn",
 		TrafficManagerDNSSuffix:      "trafficmanager.cn",
@@ -134,6 +138,7 @@ var (
 		KeyVaultEndpoint:             "https://vault.microsoftazure.de/",
 		GraphEndpoint:                "https://graph.cloudapi.de/",
 		ServiceBusEndpoint:           "https://servicebus.cloudapi.de/",
+		BatchManagementEndpoint:      "https://batch.cloudapi.de/",
 		StorageEndpointSuffix:        "core.cloudapi.de",
 		SQLDatabaseDNSSuffix:         "database.cloudapi.de",
 		TrafficManagerDNSSuffix:      "azuretrafficmanager.de",

--- a/autorest/client.go
+++ b/autorest/client.go
@@ -203,9 +203,10 @@ func (c Client) Do(r *http.Request) (*http.Response, error) {
 		r, _ = Prepare(r,
 			WithUserAgent(c.UserAgent))
 	}
+	// NOTE: c.WithInspection() must be last in the list so that it can inspect all preceding operations
 	r, err := Prepare(r,
-		c.WithInspection(),
-		c.WithAuthorization())
+		c.WithAuthorization(),
+		c.WithInspection())
 	if err != nil {
 		var resp *http.Response
 		if detErr, ok := err.(DetailedError); ok {

--- a/autorest/version.go
+++ b/autorest/version.go
@@ -16,5 +16,5 @@ package autorest
 
 // Version returns the semantic version (see http://semver.org).
 func Version() string {
-	return "v10.1.1"
+	return "v10.1.2"
 }


### PR DESCRIPTION
added a paragraph to the top-level README and autorest/adal/README explaining that the AAD auth lib in this repo is part of the SDK and not related to ADALs in github.com/AzureAD.