### PR TITLE
Fix inspection of authorizors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## v10.1.3
+
+### Bug Fixes
+
+- In Client.Do() invoke WithInspection() last so that it will inspect WithAuthorization().
+- Fixed authorization methods to invoke p.Prepare() first, aligning them with the other preparers.
+
 ## v10.1.2
 
 - Corrected comment for auth.NewAuthorizerFromFile() function.

--- a/autorest/authorization.go
+++ b/autorest/authorization.go
@@ -115,19 +115,23 @@ func (ba *BearerAuthorizer) withBearerAuthorization() PrepareDecorator {
 func (ba *BearerAuthorizer) WithAuthorization() PrepareDecorator {
 	return func(p Preparer) Preparer {
 		return PreparerFunc(func(r *http.Request) (*http.Request, error) {
-			refresher, ok := ba.tokenProvider.(adal.Refresher)
-			if ok {
-				err := refresher.EnsureFresh()
-				if err != nil {
-					var resp *http.Response
-					if tokError, ok := err.(adal.TokenRefreshError); ok {
-						resp = tokError.Response()
+			r, err := p.Prepare(r)
+			if err == nil {
+				refresher, ok := ba.tokenProvider.(adal.Refresher)
+				if ok {
+					err := refresher.EnsureFresh()
+					if err != nil {
+						var resp *http.Response
+						if tokError, ok := err.(adal.TokenRefreshError); ok {
+							resp = tokError.Response()
+						}
+						return r, NewErrorWithError(err, "azure.BearerAuthorizer", "WithAuthorization", resp,
+							"Failed to refresh the Token for request to %s", r.URL)
 					}
-					return r, NewErrorWithError(err, "azure.BearerAuthorizer", "WithAuthorization", resp,
-						"Failed to refresh the Token for request to %s", r.URL)
 				}
+				return Prepare(r, WithHeader(headerAuthorization, fmt.Sprintf("Bearer %s", ba.tokenProvider.OAuthToken())))
 			}
-			return (ba.withBearerAuthorization()(p)).Prepare(r)
+			return r, err
 		})
 	}
 }
@@ -157,25 +161,28 @@ func NewBearerAuthorizerCallback(sender Sender, callback BearerAuthorizerCallbac
 func (bacb *BearerAuthorizerCallback) WithAuthorization() PrepareDecorator {
 	return func(p Preparer) Preparer {
 		return PreparerFunc(func(r *http.Request) (*http.Request, error) {
-			// make a copy of the request and remove the body as it's not
-			// required and avoids us having to create a copy of it.
-			rCopy := *r
-			removeRequestBody(&rCopy)
+			r, err := p.Prepare(r)
+			if err == nil {
+				// make a copy of the request and remove the body as it's not
+				// required and avoids us having to create a copy of it.
+				rCopy := *r
+				removeRequestBody(&rCopy)
 
-			resp, err := bacb.sender.Do(&rCopy)
-			if err == nil && resp.StatusCode == 401 {
-				defer resp.Body.Close()
-				if hasBearerChallenge(resp) {
-					bc, err := newBearerChallenge(resp)
-					if err != nil {
-						return r, err
-					}
-					if bacb.callback != nil {
-						ba, err := bacb.callback(bc.values[tenantID], bc.values["resource"])
+				resp, err := bacb.sender.Do(&rCopy)
+				if err == nil && resp.StatusCode == 401 {
+					defer resp.Body.Close()
+					if hasBearerChallenge(resp) {
+						bc, err := newBearerChallenge(resp)
 						if err != nil {
 							return r, err
 						}
-						return ba.WithAuthorization()(p).Prepare(r)
+						if bacb.callback != nil {
+							ba, err := bacb.callback(bc.values[tenantID], bc.values["resource"])
+							if err != nil {
+								return r, err
+							}
+							return Prepare(r, ba.WithAuthorization())
+						}
 					}
 				}
 			}

--- a/autorest/authorization.go
+++ b/autorest/authorization.go
@@ -104,10 +104,6 @@ func NewBearerAuthorizer(tp adal.OAuthTokenProvider) *BearerAuthorizer {
 	return &BearerAuthorizer{tokenProvider: tp}
 }
 
-func (ba *BearerAuthorizer) withBearerAuthorization() PrepareDecorator {
-	return WithHeader(headerAuthorization, fmt.Sprintf("Bearer %s", ba.tokenProvider.OAuthToken()))
-}
-
 // WithAuthorization returns a PrepareDecorator that adds an HTTP Authorization header whose
 // value is "Bearer " followed by the token.
 //

--- a/autorest/client.go
+++ b/autorest/client.go
@@ -203,9 +203,10 @@ func (c Client) Do(r *http.Request) (*http.Response, error) {
 		r, _ = Prepare(r,
 			WithUserAgent(c.UserAgent))
 	}
+	// NOTE: c.WithInspection() must be last in the list so that it can inspect all preceding operations
 	r, err := Prepare(r,
-		c.WithInspection(),
-		c.WithAuthorization())
+		c.WithAuthorization(),
+		c.WithInspection())
 	if err != nil {
 		var resp *http.Response
 		if detErr, ok := err.(DetailedError); ok {

--- a/autorest/version.go
+++ b/autorest/version.go
@@ -16,5 +16,5 @@ package autorest
 
 // Version returns the semantic version (see http://semver.org).
 func Version() string {
-	return "v10.1.1"
+	return "v10.1.2"
 }


### PR DESCRIPTION
Preparers are executed in declared order so move the call to
c.WithInspection() to the end of the list so it can inspect any
preceding operations.
Fixed authorizors to call p.Prepare() first so they behave like the
other preparers.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.