### PR TITLE
Make retry logic use the request's context.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## v10.5.0
+
+### New Features
+
+- Added NewPollingRequestWithContext() for use with polling asynchronous operations.
+
+### Bug Fixes
+
+- Make retry logic use the request's context instead of the deprecated Cancel object.
+
 ## v10.4.0
 
 ### New Features

--- a/autorest/autorest.go
+++ b/autorest/autorest.go
@@ -136,14 +136,14 @@ func NewPollingRequest(resp *http.Response, cancel <-chan struct{}) (*http.Reque
 func NewPollingRequestWithContext(ctx context.Context, resp *http.Response) (*http.Request, error) {
 	location := GetLocation(resp)
 	if location == "" {
-		return nil, NewErrorWithResponse("autorest", "NewPollingRequest", resp, "Location header missing from response that requires polling")
+		return nil, NewErrorWithResponse("autorest", "NewPollingRequestWithContext", resp, "Location header missing from response that requires polling")
 	}
 
 	req, err := Prepare((&http.Request{}).WithContext(ctx),
 		AsGet(),
 		WithBaseURL(location))
 	if err != nil {
-		return nil, NewErrorWithError(err, "autorest", "NewPollingRequest", nil, "Failure creating poll request to %s", location)
+		return nil, NewErrorWithError(err, "autorest", "NewPollingRequestWithContext", nil, "Failure creating poll request to %s", location)
 	}
 
 	return req, nil

--- a/autorest/autorest.go
+++ b/autorest/autorest.go
@@ -72,6 +72,7 @@ package autorest
 //  limitations under the License.
 
 import (
+	"context"
 	"net/http"
 	"time"
 )
@@ -122,6 +123,23 @@ func NewPollingRequest(resp *http.Response, cancel <-chan struct{}) (*http.Reque
 	}
 
 	req, err := Prepare(&http.Request{Cancel: cancel},
+		AsGet(),
+		WithBaseURL(location))
+	if err != nil {
+		return nil, NewErrorWithError(err, "autorest", "NewPollingRequest", nil, "Failure creating poll request to %s", location)
+	}
+
+	return req, nil
+}
+
+// NewPollingRequestWithContext allocates and returns a new http.Request with the specified context to poll for the passed response.
+func NewPollingRequestWithContext(ctx context.Context, resp *http.Response) (*http.Request, error) {
+	location := GetLocation(resp)
+	if location == "" {
+		return nil, NewErrorWithResponse("autorest", "NewPollingRequest", resp, "Location header missing from response that requires polling")
+	}
+
+	req, err := Prepare((&http.Request{}).WithContext(ctx),
 		AsGet(),
 		WithBaseURL(location))
 	if err != nil {

--- a/autorest/azure/async.go
+++ b/autorest/azure/async.go
@@ -249,7 +249,7 @@ func DoPollForAsynchronous(delay time.Duration) autorest.SendDecorator {
 				if err != nil {
 					return resp, err
 				}
-				r.Cancel = resp.Request.Cancel
+				r = r.WithContext(resp.Request.Context())
 
 				delay = autorest.GetRetryAfter(resp, delay)
 				resp, err = autorest.SendWithSender(s, r,

--- a/autorest/sender.go
+++ b/autorest/sender.go
@@ -86,7 +86,7 @@ func SendWithSender(s Sender, r *http.Request, decorators ...SendDecorator) (*ht
 func AfterDelay(d time.Duration) SendDecorator {
 	return func(s Sender) Sender {
 		return SenderFunc(func(r *http.Request) (*http.Response, error) {
-			if !DelayForBackoff(d, 0, r.Cancel) {
+			if !DelayForBackoff(d, 0, r.Context().Done()) {
 				return nil, fmt.Errorf("autorest: AfterDelay canceled before full delay")
 			}
 			return s.Do(r)
@@ -165,7 +165,7 @@ func DoPollForStatusCodes(duration time.Duration, delay time.Duration, codes ...
 			resp, err = s.Do(r)
 
 			if err == nil && ResponseHasStatusCode(resp, codes...) {
-				r, err = NewPollingRequest(resp, r.Cancel)
+				r, err = NewPollingRequestWithContext(r.Context(), resp)
 
 				for err == nil && ResponseHasStatusCode(resp, codes...) {
 					Respond(resp,
@@ -198,7 +198,9 @@ func DoRetryForAttempts(attempts int, backoff time.Duration) SendDecorator {
 				if err == nil {
 					return resp, err
 				}
-				DelayForBackoff(backoff, attempt, r.Cancel)
+				if !DelayForBackoff(backoff, attempt, r.Context().Done()) {
+					return nil, r.Context().Err()
+				}
 			}
 			return resp, err
 		})
@@ -226,9 +228,9 @@ func DoRetryForStatusCodes(attempts int, backoff time.Duration, codes ...int) Se
 				if err == nil && !ResponseHasStatusCode(resp, codes...) || IsTokenRefreshError(err) {
 					return resp, err
 				}
-				delayed := DelayWithRetryAfter(resp, r.Cancel)
-				if !delayed {
-					DelayForBackoff(backoff, attempt, r.Cancel)
+				delayed := DelayWithRetryAfter(resp, r.Context().Done())
+				if !delayed && !DelayForBackoff(backoff, attempt, r.Context().Done()) {
+					return nil, r.Context().Err()
 				}
 				// don't count a 429 against the number of attempts
 				// so that we continue to retry until it succeeds
@@ -277,7 +279,9 @@ func DoRetryForDuration(d time.Duration, backoff time.Duration) SendDecorator {
 				if err == nil {
 					return resp, err
 				}
-				DelayForBackoff(backoff, attempt, r.Cancel)
+				if !DelayForBackoff(backoff, attempt, r.Context().Done()) {
+					return nil, r.Context().Err()
+				}
 			}
 			return resp, err
 		})

--- a/autorest/sender_test.go
+++ b/autorest/sender_test.go
@@ -16,6 +16,7 @@ package autorest
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"log"
 	"net/http"
@@ -179,24 +180,30 @@ func TestAfterDelayWaits(t *testing.T) {
 
 func TestAfterDelay_Cancels(t *testing.T) {
 	client := mocks.NewSender()
-	cancel := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
 	delay := 5 * time.Second
 
 	var wg sync.WaitGroup
 	wg.Add(1)
-	tt := time.Now()
+	start := time.Now()
+	end := time.Now()
+	var err error
 	go func() {
 		req := mocks.NewRequest()
-		req.Cancel = cancel
-		wg.Done()
-		SendWithSender(client, req,
+		req = req.WithContext(ctx)
+		_, err = SendWithSender(client, req,
 			AfterDelay(delay))
+		end = time.Now()
+		wg.Done()
 	}()
+	cancel()
 	wg.Wait()
-	close(cancel)
 	time.Sleep(5 * time.Millisecond)
-	if time.Since(tt) >= delay {
-		t.Fatal("autorest: AfterDelay failed to cancel")
+	if end.Sub(start) >= delay {
+		t.Fatal("autorest: AfterDelay elapsed")
+	}
+	if err == nil {
+		t.Fatal("autorest: AfterDelay didn't cancel")
 	}
 }
 

--- a/autorest/version.go
+++ b/autorest/version.go
@@ -16,5 +16,5 @@ package autorest
 
 // Version returns the semantic version (see http://semver.org).
 func Version() string {
-	return "v10.3.0"
+	return "v10.5.0"
 }


### PR DESCRIPTION
When polling, use the request's context object instead of the deprecated
Cancel object to see if polling should continue or not.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.