### PR TITLE
Add token refresh operations that take a context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v10.7.0
+
+### New Features
+
+- Added *WithContext() methods to ADAL token refresh operations.
+
 ## v10.6.2
 
 - Fixed a bug on device authentication.

--- a/autorest/version.go
+++ b/autorest/version.go
@@ -16,5 +16,5 @@ package autorest
 
 // Version returns the semantic version (see http://semver.org).
 func Version() string {
-	return "v10.5.0"
+	return "v10.7.0"
 }


### PR DESCRIPTION
Token refresh operations make HTTP requests, thus they should support
contexts so they can be cancelled etc.
Simplified retry logic in refreshInternal().

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.