### PR TITLE
Don't retry on non-temporary network errors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## v10.8.1
+
+### Bug Fixes
+
+- Return a TokenRefreshError if the sender fails on the initial request.
+- Don't retry on non-temporary network errors.
+
 ## v10.8.0
 
 - Added NewAuthorizerFromEnvironmentWithResource() helper function.

--- a/autorest/adal/token_test.go
+++ b/autorest/adal/token_test.go
@@ -518,6 +518,23 @@ func TestServicePrincipalTokenEnsureFreshRefreshes(t *testing.T) {
 	}
 }
 
+func TestServicePrincipalTokenEnsureFreshFails(t *testing.T) {
+	spt := newServicePrincipalToken()
+	expireToken(&spt.token)
+
+	c := mocks.NewSender()
+	c.SetError(fmt.Errorf("some failure"))
+
+	spt.SetSender(c)
+	err := spt.EnsureFresh()
+	if err == nil {
+		t.Fatal("adal: ServicePrincipalToken#EnsureFresh didn't return an error")
+	}
+	if _, ok := err.(TokenRefreshError); !ok {
+		t.Fatal("adal: ServicePrincipalToken#EnsureFresh didn't return a TokenRefreshError")
+	}
+}
+
 func TestServicePrincipalTokenEnsureFreshSkipsIfFresh(t *testing.T) {
 	spt := newServicePrincipalToken()
 	setTokenToExpireIn(&spt.token, 1000*time.Second)

--- a/autorest/sender.go
+++ b/autorest/sender.go
@@ -223,6 +223,10 @@ func DoRetryForStatusCodes(attempts int, backoff time.Duration, codes ...int) Se
 					return resp, err
 				}
 				resp, err = s.Do(rr.Request())
+				// if the error isn't temporary don't bother retrying
+				if err != nil && !IsTemporaryNetworkError(err) {
+					return nil, err
+				}
 				// we want to retry if err is not nil (e.g. transient network failure).  note that for failed authentication
 				// resp and err will both have a value, so in this case we don't want to retry as it will never succeed.
 				if err == nil && !ResponseHasStatusCode(resp, codes...) || IsTokenRefreshError(err) {

--- a/autorest/sender_test.go
+++ b/autorest/sender_test.go
@@ -817,7 +817,41 @@ func TestDelayWithRetryAfterWithSuccess(t *testing.T) {
 	}
 }
 
-func TestDoRetryForStatusCodes_NilResponse(t *testing.T) {
+type temporaryError struct {
+	message string
+}
+
+func (te temporaryError) Error() string {
+	return te.message
+}
+
+func (te temporaryError) Timeout() bool {
+	return true
+}
+
+func (te temporaryError) Temporary() bool {
+	return true
+}
+
+func TestDoRetryForStatusCodes_NilResponseTemporaryError(t *testing.T) {
+	client := mocks.NewSender()
+	client.AppendResponse(nil)
+	client.SetError(temporaryError{message: "faux error"})
+
+	r, err := SendWithSender(client, mocks.NewRequest(),
+		DoRetryForStatusCodes(3, time.Duration(1*time.Second), StatusCodesForRetry...),
+	)
+
+	Respond(r,
+		ByDiscardingBody(),
+		ByClosing())
+
+	if err != nil || client.Attempts() != 2 {
+		t.Fatalf("autorest: Sender#TestDoRetryForStatusCodes_NilResponseTemporaryError -- Got: non-nil error or wrong number of attempts - %v", err)
+	}
+}
+
+func TestDoRetryForStatusCodes_NilResponseFatalError(t *testing.T) {
 	client := mocks.NewSender()
 	client.AppendResponse(nil)
 	client.SetError(fmt.Errorf("faux error"))
@@ -830,7 +864,7 @@ func TestDoRetryForStatusCodes_NilResponse(t *testing.T) {
 		ByDiscardingBody(),
 		ByClosing())
 
-	if err != nil || client.Attempts() != 2 {
-		t.Fatalf("autorest: Sender#TestDoRetryForStatusCodes_NilResponse -- Got: non-nil error or wrong number of attempts - %v", err)
+	if err == nil || client.Attempts() > 1 {
+		t.Fatalf("autorest: Sender#TestDoRetryForStatusCodes_NilResponseFatalError -- Got: nil error or wrong number of attempts - %v", err)
 	}
 }

--- a/autorest/utility.go
+++ b/autorest/utility.go
@@ -20,6 +20,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -213,6 +214,14 @@ func IsTokenRefreshError(err error) bool {
 	}
 	if de, ok := err.(DetailedError); ok {
 		return IsTokenRefreshError(de.Original)
+	}
+	return false
+}
+
+// IsTemporaryNetworkError returns true if the specified error is a temporary network error.
+func IsTemporaryNetworkError(err error) bool {
+	if netErr, ok := err.(net.Error); ok && netErr.Temporary() {
+		return true
 	}
 	return false
 }

--- a/autorest/version.go
+++ b/autorest/version.go
@@ -16,5 +16,5 @@ package autorest
 
 // Version returns the semantic version (see http://semver.org).
 func Version() string {
-	return "v10.8.0"
+	return "v10.8.1"
 }


### PR DESCRIPTION
If Do() returns a non-temporary network error don't bother retrying.
Return a TokenRefreshError if the refresh request fails.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.