### PR TITLE
response is sometimes nil when error is not nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v10.8.2
+
+### Bug Fixes
+
+- Add nil-gaurd to token retry logic.
+
 ## v10.8.1
 
 ### Bug Fixes

--- a/autorest/adal/token.go
+++ b/autorest/adal/token.go
@@ -715,7 +715,7 @@ func retry(sender Sender, req *http.Request) (resp *http.Response, err error) {
 	for attempt < maxAttempts {
 		resp, err = sender.Do(req)
 		// retry on temporary network errors, e.g. transient network failures.
-		if (err != nil && !isTemporaryNetworkError(err)) || resp.StatusCode == http.StatusOK || !containsInt(retries, resp.StatusCode) {
+		if (err != nil && !isTemporaryNetworkError(err)) || (err != nil && resp == nil) || resp.StatusCode == http.StatusOK || !containsInt(retries, resp.StatusCode) {
 			return
 		}
 


### PR DESCRIPTION
Let me know if this should target master or dev. It would be great to get this out as soon as we can. I'll do my best to mitigate in the Event Hub lib. 

https://github.com/Azure/azure-event-hubs-go/issues/38

This issue only seems to appear when retrying a MSI token.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [x] I've tested my changes, adding unit tests if applicable.
 - [x] I've added Apache 2.0 Headers to the top of any new source files.
 - [x] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.