### PR TITLE
Future state machine rewrite.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@
 
 ### Deprecated Methods
 
-- azure.NewFuture() -> azure.NewFutureFromResponse()
-- Future.WaitForCompletion() -> Future.WaitForCompletionRef()
+| Old Method | New Method |
+|-------------:|:-----------:|
+|azure.NewFuture() | azure.NewFutureFromResponse()|
+|Future.WaitForCompletion() | Future.WaitForCompletionRef()|
 
 ### New Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## v10.9.0
 
+### Deprecated Methods
+
+- azure.NewFuture() -> azure.NewFutureFromResponse()
+- Future.WaitForCompletion() -> Future.WaitForCompletionRef()
+
 ### New Features
 
 - Added azure.NewFutureFromResponse() for creating a Future from the initial response from an async operation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+## v10.9.0
+
+### New Features
+
+- Added azure.NewFutureFromResponse() for creating a Future from the initial response from an async operation.
+- Added Future.GetResult() for making the final GET call to retrieve the result from an async operation.
+
+### Bug Fixes
+
+- Some futures failed to return their results, this should now be fixed.
+
 ## v10.8.2
 
 ### Bug Fixes

--- a/autorest/azure/async.go
+++ b/autorest/azure/async.go
@@ -155,7 +155,16 @@ func (f Future) GetPollingDelay() (time.Duration, bool) {
 // running operation has completed, the provided context is cancelled, or the client's
 // polling duration has been exceeded.  It will retry failed polling attempts based on
 // the retry value defined in the client up to the maximum retry attempts.
-func (f *Future) WaitForCompletion(ctx context.Context, client autorest.Client) error {
+// Deprecated: Please use WaitForCompletionRef() instead.
+func (f Future) WaitForCompletion(ctx context.Context, client autorest.Client) error {
+	return f.WaitForCompletionRef(ctx, client)
+}
+
+// WaitForCompletionRef will return when one of the following conditions is met: the long
+// running operation has completed, the provided context is cancelled, or the client's
+// polling duration has been exceeded.  It will retry failed polling attempts based on
+// the retry value defined in the client up to the maximum retry attempts.
+func (f *Future) WaitForCompletionRef(ctx context.Context, client autorest.Client) error {
 	ctx, cancel := context.WithTimeout(ctx, client.PollingDuration)
 	defer cancel()
 	done, err := f.Done(client)

--- a/autorest/azure/async.go
+++ b/autorest/azure/async.go
@@ -21,11 +21,11 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/date"
 )
 
 const (
@@ -44,84 +44,85 @@ var pollingCodes = [...]int{http.StatusNoContent, http.StatusAccepted, http.Stat
 // Future provides a mechanism to access the status and results of an asynchronous request.
 // Since futures are stateful they should be passed by value to avoid race conditions.
 type Future struct {
-	req  *http.Request
-	resp *http.Response
-	ps   pollingState
+	req *http.Request // legacy
+	pt  pollingTracker
 }
 
 // NewFuture returns a new Future object initialized with the specified request.
+// Deprecated: Please use NewFutureFromResponse instead.
 func NewFuture(req *http.Request) Future {
 	return Future{req: req}
 }
 
-// Response returns the last HTTP response or nil if there isn't one.
+// NewFutureFromResponse returns a new Future object initialized
+// with the initial response from an asynchronous operation.
+func NewFutureFromResponse(resp *http.Response) (Future, error) {
+	pt, err := createPollingTracker(resp)
+	if err != nil {
+		return Future{}, err
+	}
+	return Future{pt: pt}, nil
+}
+
+// Response returns the last HTTP response.
 func (f Future) Response() *http.Response {
-	return f.resp
+	if f.pt == nil {
+		return nil
+	}
+	return f.pt.lastResponse()
 }
 
 // Status returns the last status message of the operation.
 func (f Future) Status() string {
-	if f.ps.State == "" {
-		return "Unknown"
+	if f.pt == nil {
+		return ""
 	}
-	return f.ps.State
+	return f.pt.pollingStatus()
 }
 
 // PollingMethod returns the method used to monitor the status of the asynchronous operation.
 func (f Future) PollingMethod() PollingMethodType {
-	return f.ps.PollingMethod
+	if f.pt == nil {
+		return PollingUnknown
+	}
+	return f.pt.pollingMethod()
 }
 
 // Done queries the service to see if the operation has completed.
 func (f *Future) Done(sender autorest.Sender) (bool, error) {
-	// exit early if this future has terminated
-	if f.ps.hasTerminated() {
-		return true, f.errorInfo()
+	// support for legacy Future implementation
+	if f.req != nil {
+		resp, err := sender.Do(f.req)
+		if err != nil {
+			return false, err
+		}
+		pt, err := createPollingTracker(resp)
+		if err != nil {
+			return false, err
+		}
+		f.pt = pt
+		f.req = nil
 	}
-	resp, err := sender.Do(f.req)
-	f.resp = resp
-	if err != nil {
+	// end legacy
+	if f.pt == nil {
+		return false, autorest.NewError("Future", "Done", "future is not initialized")
+	}
+	if f.pt.hasTerminated() {
+		return true, f.pt.pollingError()
+	}
+	if err := f.pt.pollForStatus(sender); err != nil {
 		return false, err
 	}
-
-	if !autorest.ResponseHasStatusCode(resp, pollingCodes[:]...) {
-		// check response body for error content
-		if resp.Body != nil {
-			type respErr struct {
-				ServiceError ServiceError `json:"error"`
-			}
-			re := respErr{}
-
-			defer resp.Body.Close()
-			b, err := ioutil.ReadAll(resp.Body)
-			if err != nil {
-				return false, err
-			}
-			err = json.Unmarshal(b, &re)
-			if err != nil {
-				return false, err
-			}
-			return false, re.ServiceError
-		}
-
-		// try to return something meaningful
-		return false, ServiceError{
-			Code:    fmt.Sprintf("%v", resp.StatusCode),
-			Message: resp.Status,
-		}
+	if err := f.pt.checkForErrors(); err != nil {
+		return f.pt.hasTerminated(), err
 	}
-
-	err = updatePollingState(resp, &f.ps)
-	if err != nil {
+	if err := f.pt.updatePollingState(f.pt.provisioningStateApplicable()); err != nil {
 		return false, err
 	}
-
-	if f.ps.hasTerminated() {
-		return true, f.errorInfo()
+	if err := f.pt.updateHeaders(); err != nil {
+		return false, err
 	}
-
-	f.req, err = newPollingRequest(f.ps)
-	return false, err
+	return f.pt.hasTerminated(), f.pt.pollingError()
 }
 
 // GetPollingDelay returns a duration the application should wait before checking
@@ -129,11 +130,15 @@ func (f *Future) Done(sender autorest.Sender) (bool, error) {
 // the service via the Retry-After response header.  If the header wasn't returned
 // then the function returns the zero-value time.Duration and false.
 func (f Future) GetPollingDelay() (time.Duration, bool) {
-	if f.resp == nil {
+	if f.pt == nil {
+		return 0, false
+	}
+	resp := f.pt.lastResponse()
+	if resp == nil {
 		return 0, false
 	}
 
-	retry := f.resp.Header.Get(autorest.HeaderRetryAfter)
+	retry := resp.Header.Get(autorest.HeaderRetryAfter)
 	if retry == "" {
 		return 0, false
 	}
@@ -150,14 +155,13 @@ func (f Future) GetPollingDelay() (time.Duration, bool) {
 // running operation has completed, the provided context is cancelled, or the client's
 // polling duration has been exceeded.  It will retry failed polling attempts based on
 // the retry value defined in the client up to the maximum retry attempts.
-func (f Future) WaitForCompletion(ctx context.Context, client autorest.Client) error {
+func (f *Future) WaitForCompletion(ctx context.Context, client autorest.Client) error {
 	ctx, cancel := context.WithTimeout(ctx, client.PollingDuration)
 	defer cancel()
-
 	done, err := f.Done(client)
 	for attempts := 0; !done; done, err = f.Done(client) {
 		if attempts >= client.RetryAttempts {
-			return autorest.NewErrorWithError(err, "azure", "WaitForCompletion", f.resp, "the number of retries has been exceeded")
+			return autorest.NewErrorWithError(err, "Future", "WaitForCompletion", f.pt.lastResponse(), "the number of retries has been exceeded")
 		}
 		// we want delayAttempt to be zero in the non-error case so
 		// that DelayForBackoff doesn't perform exponential back-off
@@ -181,160 +185,684 @@ func (f Future) WaitForCompletion(ctx context.Context, client autorest.Client) e
 		// wait until the delay elapses or the context is cancelled
 		delayElapsed := autorest.DelayForBackoff(delay, delayAttempt, ctx.Done())
 		if !delayElapsed {
-			return autorest.NewErrorWithError(ctx.Err(), "azure", "WaitForCompletion", f.resp, "context has been cancelled")
+			return autorest.NewErrorWithError(ctx.Err(), "Future", "WaitForCompletion", f.pt.lastResponse(), "context has been cancelled")
 		}
 	}
 	return err
 }
 
-// if the operation failed the polling state will contain
-// error information and implements the error interface
-func (f *Future) errorInfo() error {
-	if !f.ps.hasSucceeded() {
-		return f.ps
-	}
-	return nil
-}
-
 // MarshalJSON implements the json.Marshaler interface.
 func (f Future) MarshalJSON() ([]byte, error) {
-	return json.Marshal(&f.ps)
+	return json.Marshal(f.pt)
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface.
 func (f *Future) UnmarshalJSON(data []byte) error {
-	err := json.Unmarshal(data, &f.ps)
+	// unmarshal into JSON object to determine the tracker type
+	obj := map[string]interface{}{}
+	err := json.Unmarshal(data, &obj)
 	if err != nil {
 		return err
 	}
-	f.req, err = newPollingRequest(f.ps)
-	return err
+	if obj["method"] == nil {
+		return autorest.NewError("Future", "UnmarshalJSON", "missing 'method' property")
+	}
+	method := obj["method"].(string)
+	switch strings.ToUpper(method) {
+	case http.MethodDelete:
+		f.pt = &pollingTrackerDelete{}
+	case http.MethodPatch:
+		f.pt = &pollingTrackerPatch{}
+	case http.MethodPost:
+		f.pt = &pollingTrackerPost{}
+	case http.MethodPut:
+		f.pt = &pollingTrackerPut{}
+	default:
+		return autorest.NewError("Future", "UnmarshalJSON", "unsupoorted method '%s'", method)
+	}
+	// now unmarshal into the tracker
+	return json.Unmarshal(data, &f.pt)
 }
 
 // PollingURL returns the URL used for retrieving the status of the long-running operation.
-// For LROs that use the Location header the final URL value is used to retrieve the result.
 func (f Future) PollingURL() string {
-	return f.ps.URI
+	if f.pt == nil {
+		return ""
+	}
+	return f.pt.pollingURL()
+}
+
+// GetResult should be called once polling has completed successfully.
+// It makes the final GET call to retrieve the resultant payload.
+func (f Future) GetResult(sender autorest.Sender) (*http.Response, error) {
+	if f.pt.finalGetURL() == "" {
+		return nil, nil
+	}
+	req, err := http.NewRequest(http.MethodGet, f.pt.finalGetURL(), nil)
+	if err != nil {
+		return nil, err
+	}
+	return sender.Do(req)
+}
+
+type pollingTracker interface {
+	// these methods can differ per tracker
+
+	// checks the response headers and status code to determine the polling mechanism
+	updateHeaders() error
+
+	// checks the response for tracker-specific error conditions
+	checkForErrors() error
+
+	// returns true if provisioning state should be checked
+	provisioningStateApplicable() bool
+
+	// methods common to all trackers
+
+	// initializes the tracker's internal state, call this when the tracker is created
+	initializeState() error
+
+	// makes an HTTP request to check the status of the LRO
+	pollForStatus(sender autorest.Sender) error
+
+	// updates internal tracker state, call this after each call to pollForStatus
+	updatePollingState(provStateApl bool) error
+
+	// returns the error response from the service, can be nil
+	pollingError() error
+
+	// returns the polling method being used
+	pollingMethod() PollingMethodType
+
+	// returns the state of the LRO as returned from the service
+	pollingStatus() string
+
+	// returns the URL used for polling status
+	pollingURL() string
+
+	// returns the URL used for the final GET to retrieve the resource
+	finalGetURL() string
+
+	// returns true if the LRO is in a terminal state
+	hasTerminated() bool
+
+	// returns true if the LRO is in a failed terminal state
+	hasFailed() bool
+
+	// returns true if the LRO is in a successful terminal state
+	hasSucceeded() bool
+
+	// returns the last HTTP response after a call to pollForStatus(), can be nil
+	lastResponse() *http.Response
+}
+
+type pollingTrackerBase struct {
+	// resp is the last response, either from the submission of the LRO or from polling
+	resp *http.Response
+
+	// method is the HTTP verb, this is needed for deserialization
+	Method string `json:"method"`
+
+	// rawBody is the raw JSON response body
+	rawBody map[string]interface{}
+
+	// denotes if polling is using async-operation or location header
+	Pm PollingMethodType `json:"pollingMethod"`
+
+	// the URL to poll for status
+	URI string `json:"pollingURI"`
+
+	// the state of the LRO as returned from the service
+	State string `json:"lroState"`
+
+	// the URL to GET for the final result
+	FinalGetURI string `json:"resultURI"`
+
+	// used to hold an error object returned from the service
+	Err *ServiceError `json:"error,omitempty"`
+}
+
+func (pt *pollingTrackerBase) initializeState() error {
+	// determine the initial polling state based on response body and/or HTTP status
+	// code.  this is applicable to the initial LRO response, not polling responses!
+	pt.Method = pt.resp.Request.Method
+	if err := pt.updateRawBody(); err != nil {
+		return err
+	}
+	switch pt.resp.StatusCode {
+	case http.StatusOK:
+		if ps := pt.getProvisioningState(); ps != nil {
+			pt.State = *ps
+		} else {
+			pt.State = operationSucceeded
+		}
+	case http.StatusCreated:
+		if ps := pt.getProvisioningState(); ps != nil {
+			pt.State = *ps
+		} else {
+			pt.State = operationInProgress
+		}
+	case http.StatusAccepted:
+		pt.State = operationInProgress
+	case http.StatusNoContent:
+		pt.State = operationSucceeded
+	default:
+		pt.State = operationFailed
+		pt.updateErrorFromResponse()
+	}
+	return nil
+}
+
+func (pt pollingTrackerBase) getProvisioningState() *string {
+	if pt.rawBody != nil && pt.rawBody["properties"] != nil {
+		p := pt.rawBody["properties"].(map[string]interface{})
+		if ps := p["provisioningState"]; ps != nil {
+			s := ps.(string)
+			return &s
+		}
+	}
+	return nil
+}
+
+func (pt *pollingTrackerBase) updateRawBody() error {
+	pt.rawBody = map[string]interface{}{}
+	if pt.resp.ContentLength != 0 {
+		defer pt.resp.Body.Close()
+		b, err := ioutil.ReadAll(pt.resp.Body)
+		if err != nil {
+			return autorest.NewErrorWithError(err, "pollingTrackerBase", "updateRawBody", nil, "failed to read response body")
+		}
+		// put the body back so it's available to other callers
+		pt.resp.Body = ioutil.NopCloser(bytes.NewReader(b))
+		if err = json.Unmarshal(b, &pt.rawBody); err != nil {
+			return autorest.NewErrorWithError(err, "pollingTrackerBase", "updateRawBody", nil, "failed to unmarshal response body")
+		}
+	}
+	return nil
+}
+
+func (pt *pollingTrackerBase) pollForStatus(sender autorest.Sender) error {
+	req, err := http.NewRequest(http.MethodGet, pt.URI, nil)
+	if err != nil {
+		return autorest.NewErrorWithError(err, "pollingTrackerBase", "pollForStatus", nil, "failed to create HTTP request")
+	}
+	// attach the context from the original request if available (it will be absent for deserialized futures)
+	if pt.resp != nil {
+		req = req.WithContext(pt.resp.Request.Context())
+	}
+	pt.resp, err = sender.Do(req)
+	if err != nil {
+		return autorest.NewErrorWithError(err, "pollingTrackerBase", "pollForStatus", nil, "failed to send HTTP request")
+	}
+	if autorest.ResponseHasStatusCode(pt.resp, pollingCodes[:]...) {
+		// reset the service error on success case
+		pt.Err = nil
+		err = pt.updateRawBody()
+	} else {
+		// check response body for error content
+		pt.updateErrorFromResponse()
+	}
+	return err
+}
+
+// attempts to unmarshal a ServiceError type from the response body.
+// if that fails then make a best attempt at creating something meaningful.
+func (pt *pollingTrackerBase) updateErrorFromResponse() {
+	var err error
+	if pt.resp.ContentLength != 0 {
+		type respErr struct {
+			ServiceError *ServiceError `json:"error"`
+		}
+		re := respErr{}
+		defer pt.resp.Body.Close()
+		var b []byte
+		b, err = ioutil.ReadAll(pt.resp.Body)
+		if err != nil {
+			goto Default
+		}
+		if err = json.Unmarshal(b, &re); err != nil {
+			goto Default
+		}
+		// unmarshalling the error didn't yield anything, try unwrapped error
+		if re.ServiceError == nil {
+			err = json.Unmarshal(b, &re.ServiceError)
+			if err != nil {
+				goto Default
+			}
+		}
+		if re.ServiceError != nil {
+			pt.Err = re.ServiceError
+			return
+		}
+	}
+Default:
+	se := &ServiceError{
+		Code:    fmt.Sprintf("HTTP status code %v", pt.resp.StatusCode),
+		Message: pt.resp.Status,
+	}
+	if err != nil {
+		se.InnerError = make(map[string]interface{})
+		se.InnerError["unmarshalError"] = err.Error()
+	}
+	pt.Err = se
+}
+
+func (pt *pollingTrackerBase) updatePollingState(provStateApl bool) error {
+	if pt.Pm == PollingAsyncOperation && pt.rawBody["status"] != nil {
+		pt.State = pt.rawBody["status"].(string)
+	} else {
+		if pt.resp.StatusCode == http.StatusAccepted {
+			pt.State = operationInProgress
+		} else if provStateApl {
+			if ps := pt.getProvisioningState(); ps != nil {
+				pt.State = *ps
+			} else {
+				pt.State = operationSucceeded
+			}
+		} else {
+			return autorest.NewError("pollingTrackerBase", "updatePollingState", "the response from the async operation has an invalid status code")
+		}
+	}
+	// if the operation has failed update the error state
+	if pt.hasFailed() {
+		pt.updateErrorFromResponse()
+	}
+	return nil
+}
+
+func (pt pollingTrackerBase) pollingError() error {
+	if pt.Err == nil {
+		return nil
+	}
+	return pt.Err
+}
+
+func (pt pollingTrackerBase) pollingMethod() PollingMethodType {
+	return pt.Pm
+}
+
+func (pt pollingTrackerBase) pollingStatus() string {
+	return pt.State
+}
+
+func (pt pollingTrackerBase) pollingURL() string {
+	return pt.URI
+}
+
+func (pt pollingTrackerBase) finalGetURL() string {
+	return pt.FinalGetURI
+}
+
+func (pt pollingTrackerBase) hasTerminated() bool {
+	return strings.EqualFold(pt.State, operationCanceled) || strings.EqualFold(pt.State, operationFailed) || strings.EqualFold(pt.State, operationSucceeded)
+}
+
+func (pt pollingTrackerBase) hasFailed() bool {
+	return strings.EqualFold(pt.State, operationCanceled) || strings.EqualFold(pt.State, operationFailed)
+}
+
+func (pt pollingTrackerBase) hasSucceeded() bool {
+	return strings.EqualFold(pt.State, operationSucceeded)
+}
+
+func (pt pollingTrackerBase) lastResponse() *http.Response {
+	return pt.resp
+}
+
+// error checking common to all trackers
+func (pt pollingTrackerBase) baseCheckForErrors() error {
+	// for Azure-AsyncOperations the response body cannot be nil or empty
+	if pt.Pm == PollingAsyncOperation {
+		if pt.resp.Body == nil || pt.resp.ContentLength == 0 {
+			return autorest.NewError("pollingTrackerBase", "baseCheckForErrors", "for Azure-AsyncOperation response body cannot be nil")
+		}
+		if pt.rawBody["status"] == nil {
+			return autorest.NewError("pollingTrackerBase", "baseCheckForErrors", "missing status property in Azure-AsyncOperation response body")
+		}
+	}
+	return nil
+}
+
+// DELETE
+
+type pollingTrackerDelete struct {
+	pollingTrackerBase
+}
+
+func (pt *pollingTrackerDelete) updateHeaders() error {
+	// for 201 the Location header is required
+	if pt.resp.StatusCode == http.StatusCreated {
+		if lh, err := getURLFromLocationHeader(pt.resp); err != nil {
+			return err
+		} else if lh == "" {
+			return autorest.NewError("pollingTrackerDelete", "updateHeaders", "missing Location header in 201 response")
+		} else {
+			pt.URI = lh
+		}
+		pt.Pm = PollingLocation
+		pt.FinalGetURI = pt.URI
+	}
+	// for 202 prefer the Azure-AsyncOperation header but fall back to Location if necessary
+	if pt.resp.StatusCode == http.StatusAccepted {
+		ao, err := getURLFromAsyncOpHeader(pt.resp)
+		if err != nil {
+			return err
+		} else if ao != "" {
+			pt.URI = ao
+			pt.Pm = PollingAsyncOperation
+		}
+		// if the Location header is invalid and we already have a polling URL
+		// then we don't care if the Location header URL is malformed.
+		if lh, err := getURLFromLocationHeader(pt.resp); err != nil && pt.URI == "" {
+			return err
+		} else if lh != "" {
+			if ao == "" {
+				pt.URI = lh
+				pt.Pm = PollingLocation
+			}
+			// when both headers are returned we use the value in the Location header for the final GET
+			pt.FinalGetURI = lh
+		}
+		// make sure a polling URL was found
+		if pt.URI == "" {
+			return autorest.NewError("pollingTrackerPost", "updateHeaders", "didn't get any suitable polling URLs in 202 response")
+		}
+	}
+	return nil
+}
+
+func (pt pollingTrackerDelete) checkForErrors() error {
+	return pt.baseCheckForErrors()
+}
+
+func (pt pollingTrackerDelete) provisioningStateApplicable() bool {
+	return pt.resp.StatusCode == http.StatusOK || pt.resp.StatusCode == http.StatusNoContent
+}
+
+// PATCH
+
+type pollingTrackerPatch struct {
+	pollingTrackerBase
+}
+
+func (pt *pollingTrackerPatch) updateHeaders() error {
+	// by default we can use the original URL for polling and final GET
+	if pt.URI == "" {
+		pt.URI = pt.resp.Request.URL.String()
+	}
+	if pt.FinalGetURI == "" {
+		pt.FinalGetURI = pt.resp.Request.URL.String()
+	}
+	if pt.Pm == PollingUnknown {
+		pt.Pm = PollingRequestURI
+	}
+	// for 201 it's permissible for no headers to be returned
+	if pt.resp.StatusCode == http.StatusCreated {
+		if ao, err := getURLFromAsyncOpHeader(pt.resp); err != nil {
+			return err
+		} else if ao != "" {
+			pt.URI = ao
+			pt.Pm = PollingAsyncOperation
+		}
+	}
+	// for 202 prefer the Azure-AsyncOperation header but fall back to Location if necessary
+	// note the absense of the "final GET" mechanism for PATCH
+	if pt.resp.StatusCode == http.StatusAccepted {
+		ao, err := getURLFromAsyncOpHeader(pt.resp)
+		if err != nil {
+			return err
+		} else if ao != "" {
+			pt.URI = ao
+			pt.Pm = PollingAsyncOperation
+		}
+		if ao == "" {
+			if lh, err := getURLFromLocationHeader(pt.resp); err != nil {
+				return err
+			} else if lh == "" {
+				return autorest.NewError("pollingTrackerPatch", "updateHeaders", "didn't get any suitable polling URLs in 202 response")
+			} else {
+				pt.URI = lh
+				pt.Pm = PollingLocation
+			}
+		}
+	}
+	return nil
+}
+
+func (pt pollingTrackerPatch) checkForErrors() error {
+	return pt.baseCheckForErrors()
+}
+
+func (pt pollingTrackerPatch) provisioningStateApplicable() bool {
+	return pt.resp.StatusCode == http.StatusOK || pt.resp.StatusCode == http.StatusCreated
+}
+
+// POST
+
+type pollingTrackerPost struct {
+	pollingTrackerBase
+}
+
+func (pt *pollingTrackerPost) updateHeaders() error {
+	// 201 requires Location header
+	if pt.resp.StatusCode == http.StatusCreated {
+		if lh, err := getURLFromLocationHeader(pt.resp); err != nil {
+			return err
+		} else if lh == "" {
+			return autorest.NewError("pollingTrackerPost", "updateHeaders", "missing Location header in 201 response")
+		} else {
+			pt.URI = lh
+			pt.FinalGetURI = lh
+			pt.Pm = PollingLocation
+		}
+	}
+	// for 202 prefer the Azure-AsyncOperation header but fall back to Location if necessary
+	if pt.resp.StatusCode == http.StatusAccepted {
+		ao, err := getURLFromAsyncOpHeader(pt.resp)
+		if err != nil {
+			return err
+		} else if ao != "" {
+			pt.URI = ao
+			pt.Pm = PollingAsyncOperation
+		}
+		// if the Location header is invalid and we already have a polling URL
+		// then we don't care if the Location header URL is malformed.
+		if lh, err := getURLFromLocationHeader(pt.resp); err != nil && pt.URI == "" {
+			return err
+		} else if lh != "" {
+			if ao == "" {
+				pt.URI = lh
+				pt.Pm = PollingLocation
+			}
+			// when both headers are returned we use the value in the Location header for the final GET
+			pt.FinalGetURI = lh
+		}
+		// make sure a polling URL was found
+		if pt.URI == "" {
+			return autorest.NewError("pollingTrackerPost", "updateHeaders", "didn't get any suitable polling URLs in 202 response")
+		}
+	}
+	return nil
+}
+
+func (pt pollingTrackerPost) checkForErrors() error {
+	return pt.baseCheckForErrors()
+}
+
+func (pt pollingTrackerPost) provisioningStateApplicable() bool {
+	return pt.resp.StatusCode == http.StatusOK || pt.resp.StatusCode == http.StatusNoContent
+}
+
+// PUT
+
+type pollingTrackerPut struct {
+	pollingTrackerBase
+}
+
+func (pt *pollingTrackerPut) updateHeaders() error {
+	// by default we can use the original URL for polling and final GET
+	if pt.URI == "" {
+		pt.URI = pt.resp.Request.URL.String()
+	}
+	if pt.FinalGetURI == "" {
+		pt.FinalGetURI = pt.resp.Request.URL.String()
+	}
+	if pt.Pm == PollingUnknown {
+		pt.Pm = PollingRequestURI
+	}
+	// for 201 it's permissible for no headers to be returned
+	if pt.resp.StatusCode == http.StatusCreated {
+		if ao, err := getURLFromAsyncOpHeader(pt.resp); err != nil {
+			return err
+		} else if ao != "" {
+			pt.URI = ao
+			pt.Pm = PollingAsyncOperation
+		}
+	}
+	// for 202 prefer the Azure-AsyncOperation header but fall back to Location if necessary
+	if pt.resp.StatusCode == http.StatusAccepted {
+		ao, err := getURLFromAsyncOpHeader(pt.resp)
+		if err != nil {
+			return err
+		} else if ao != "" {
+			pt.URI = ao
+			pt.Pm = PollingAsyncOperation
+		}
+		// if the Location header is invalid and we already have a polling URL
+		// then we don't care if the Location header URL is malformed.
+		if lh, err := getURLFromLocationHeader(pt.resp); err != nil && pt.URI == "" {
+			return err
+		} else if lh != "" {
+			if ao == "" {
+				pt.URI = lh
+				pt.Pm = PollingLocation
+			}
+			// when both headers are returned we use the value in the Location header for the final GET
+			pt.FinalGetURI = lh
+		}
+		// make sure a polling URL was found
+		if pt.URI == "" {
+			return autorest.NewError("pollingTrackerPut", "updateHeaders", "didn't get any suitable polling URLs in 202 response")
+		}
+	}
+	return nil
+}
+
+func (pt pollingTrackerPut) checkForErrors() error {
+	err := pt.baseCheckForErrors()
+	if err != nil {
+		return err
+	}
+	// if there are no LRO headers then the body cannot be empty
+	ao, err := getURLFromAsyncOpHeader(pt.resp)
+	if err != nil {
+		return err
+	}
+	lh, err := getURLFromLocationHeader(pt.resp)
+	if err != nil {
+		return err
+	}
+	if ao == "" && lh == "" && len(pt.rawBody) == 0 {
+		return autorest.NewError("pollingTrackerPut", "checkForErrors", "the response did not contain a body")
+	}
+	return nil
+}
+
+func (pt pollingTrackerPut) provisioningStateApplicable() bool {
+	return pt.resp.StatusCode == http.StatusOK || pt.resp.StatusCode == http.StatusCreated
+}
+
+// creates a polling tracker based on the verb of the original request
+func createPollingTracker(resp *http.Response) (pollingTracker, error) {
+	var pt pollingTracker
+	switch strings.ToUpper(resp.Request.Method) {
+	case http.MethodDelete:
+		pt = &pollingTrackerDelete{pollingTrackerBase: pollingTrackerBase{resp: resp}}
+	case http.MethodPatch:
+		pt = &pollingTrackerPatch{pollingTrackerBase: pollingTrackerBase{resp: resp}}
+	case http.MethodPost:
+		pt = &pollingTrackerPost{pollingTrackerBase: pollingTrackerBase{resp: resp}}
+	case http.MethodPut:
+		pt = &pollingTrackerPut{pollingTrackerBase: pollingTrackerBase{resp: resp}}
+	default:
+		return nil, autorest.NewError("azure", "createPollingTracker", "unsupported HTTP method %s", resp.Request.Method)
+	}
+	if err := pt.initializeState(); err != nil {
+		return pt, err
+	}
+	// this initializes the polling header values, we do this during creation in case the
+	// initial response send us invalid values; this way the API call will return a non-nil
+	// error (not doing this means the error shows up in Future.Done)
+	return pt, pt.updateHeaders()
+}
+
+// gets the polling URL from the Azure-AsyncOperation header.
+// ensures the URL is well-formed and absolute.
+func getURLFromAsyncOpHeader(resp *http.Response) (string, error) {
+	s := resp.Header.Get(http.CanonicalHeaderKey(headerAsyncOperation))
+	if s == "" {
+		return "", nil
+	}
+	if !isValidURL(s) {
+		return "", autorest.NewError("azure", "getURLFromAsyncOpHeader", "invalid polling URL '%s'", s)
+	}
+	return s, nil
+}
+
+// gets the polling URL from the Location header.
+// ensures the URL is well-formed and absolute.
+func getURLFromLocationHeader(resp *http.Response) (string, error) {
+	s := resp.Header.Get(http.CanonicalHeaderKey(autorest.HeaderLocation))
+	if s == "" {
+		return "", nil
+	}
+	if !isValidURL(s) {
+		return "", autorest.NewError("azure", "getURLFromLocationHeader", "invalid polling URL '%s'", s)
+	}
+	return s, nil
+}
+
+// verify that the URL is valid and absolute
+func isValidURL(s string) bool {
+	u, err := url.Parse(s)
+	return err == nil && u.IsAbs()
 }
 
 // DoPollForAsynchronous returns a SendDecorator that polls if the http.Response is for an Azure
 // long-running operation. It will delay between requests for the duration specified in the
-// RetryAfter header or, if the header is absent, the passed delay. Polling may be canceled by
-// closing the optional channel on the http.Request.
+// RetryAfter header or, if the header is absent, the passed delay. Polling may be canceled via
+// the context associated with the http.Request.
+// Deprecated: Prefer using Futures to allow for non-blocking async operations.
 func DoPollForAsynchronous(delay time.Duration) autorest.SendDecorator {
 	return func(s autorest.Sender) autorest.Sender {
-		return autorest.SenderFunc(func(r *http.Request) (resp *http.Response, err error) {
-			resp, err = s.Do(r)
+		return autorest.SenderFunc(func(r *http.Request) (*http.Response, error) {
+			resp, err := s.Do(r)
 			if err != nil {
 				return resp, err
 			}
 			if !autorest.ResponseHasStatusCode(resp, pollingCodes[:]...) {
 				return resp, nil
 			}
-
-			ps := pollingState{}
-			for err == nil {
-				err = updatePollingState(resp, &ps)
-				if err != nil {
-					break
-				}
-				if ps.hasTerminated() {
-					if !ps.hasSucceeded() {
-						err = ps
-					}
-					break
-				}
-
-				r, err = newPollingRequest(ps)
-				if err != nil {
-					return resp, err
-				}
-				r = r.WithContext(resp.Request.Context())
-
-				delay = autorest.GetRetryAfter(resp, delay)
-				resp, err = autorest.SendWithSender(s, r,
-					autorest.AfterDelay(delay))
+			future, err := NewFutureFromResponse(resp)
+			if err != nil {
+				return resp, err
 			}
-
-			return resp, err
+			// retry until either the LRO completes or we receive an error
+			var done bool
+			for done, err = future.Done(s); !done && err == nil; done, err = future.Done(s) {
+				// check for Retry-After delay, if not present use the specified polling delay
+				if pd, ok := future.GetPollingDelay(); ok {
+					delay = pd
+				}
+				// wait until the delay elapses or the context is cancelled
+				if delayElapsed := autorest.DelayForBackoff(delay, 0, r.Context().Done()); !delayElapsed {
+					return future.Response(),
+						autorest.NewErrorWithError(r.Context().Err(), "azure", "DoPollForAsynchronous", future.Response(), "context has been cancelled")
+				}
+			}
+			return future.Response(), err
 		})
 	}
-}
-
-func getAsyncOperation(resp *http.Response) string {
-	return resp.Header.Get(http.CanonicalHeaderKey(headerAsyncOperation))
-}
-
-func hasSucceeded(state string) bool {
-	return strings.EqualFold(state, operationSucceeded)
-}
-
-func hasTerminated(state string) bool {
-	return strings.EqualFold(state, operationCanceled) || strings.EqualFold(state, operationFailed) || strings.EqualFold(state, operationSucceeded)
-}
-
-func hasFailed(state string) bool {
-	return strings.EqualFold(state, operationFailed)
-}
-
-type provisioningTracker interface {
-	state() string
-	hasSucceeded() bool
-	hasTerminated() bool
-}
-
-type operationResource struct {
-	// Note:
-	// 	The specification states services should return the "id" field. However some return it as
-	// 	"operationId".
-	ID              string                 `json:"id"`
-	OperationID     string                 `json:"operationId"`
-	Name            string                 `json:"name"`
-	Status          string                 `json:"status"`
-	Properties      map[string]interface{} `json:"properties"`
-	OperationError  ServiceError           `json:"error"`
-	StartTime       date.Time              `json:"startTime"`
-	EndTime         date.Time              `json:"endTime"`
-	PercentComplete float64                `json:"percentComplete"`
-}
-
-func (or operationResource) state() string {
-	return or.Status
-}
-
-func (or operationResource) hasSucceeded() bool {
-	return hasSucceeded(or.state())
-}
-
-func (or operationResource) hasTerminated() bool {
-	return hasTerminated(or.state())
-}
-
-type provisioningProperties struct {
-	ProvisioningState string `json:"provisioningState"`
-}
-
-type provisioningStatus struct {
-	Properties        provisioningProperties `json:"properties,omitempty"`
-	ProvisioningError ServiceError           `json:"error,omitempty"`
-}
-
-func (ps provisioningStatus) state() string {
-	return ps.Properties.ProvisioningState
-}
-
-func (ps provisioningStatus) hasSucceeded() bool {
-	return hasSucceeded(ps.state())
-}
-
-func (ps provisioningStatus) hasTerminated() bool {
-	return hasTerminated(ps.state())
-}
-
-func (ps provisioningStatus) hasProvisioningError() bool {
-	// code and message are required fields so only check them
-	return len(ps.ProvisioningError.Code) > 0 ||
-		len(ps.ProvisioningError.Message) > 0
 }
 
 // PollingMethodType defines a type used for enumerating polling mechanisms.
@@ -347,150 +875,12 @@ const (
 	// PollingLocation indicates the polling method uses the Location header.
 	PollingLocation PollingMethodType = "Location"
 
+	// PollingRequestURI indicates the polling method uses the original request URI.
+	PollingRequestURI PollingMethodType = "RequestURI"
+
 	// PollingUnknown indicates an unknown polling method and is the default value.
 	PollingUnknown PollingMethodType = ""
 )
-
-type pollingState struct {
-	PollingMethod PollingMethodType `json:"pollingMethod"`
-	URI           string            `json:"uri"`
-	State         string            `json:"state"`
-	ServiceError  *ServiceError     `json:"error,omitempty"`
-}
-
-func (ps pollingState) hasSucceeded() bool {
-	return hasSucceeded(ps.State)
-}
-
-func (ps pollingState) hasTerminated() bool {
-	return hasTerminated(ps.State)
-}
-
-func (ps pollingState) hasFailed() bool {
-	return hasFailed(ps.State)
-}
-
-func (ps pollingState) Error() string {
-	s := fmt.Sprintf("Long running operation terminated with status '%s'", ps.State)
-	if ps.ServiceError != nil {
-		s = fmt.Sprintf("%s: %+v", s, *ps.ServiceError)
-	}
-	return s
-}
-
-//	updatePollingState maps the operation status -- retrieved from either a provisioningState
-// 	field, the status field of an OperationResource, or inferred from the HTTP status code --
-// 	into a well-known states. Since the process begins from the initial request, the state
-//	always comes from either a the provisioningState returned or is inferred from the HTTP
-//	status code. Subsequent requests will read an Azure OperationResource object if the
-//	service initially returned the Azure-AsyncOperation header. The responseFormat field notes
-//	the expected response format.
-func updatePollingState(resp *http.Response, ps *pollingState) error {
-	// Determine the response shape
-	// -- The first response will always be a provisioningStatus response; only the polling requests,
-	//    depending on the header returned, may be something otherwise.
-	var pt provisioningTracker
-	if ps.PollingMethod == PollingAsyncOperation {
-		pt = &operationResource{}
-	} else {
-		pt = &provisioningStatus{}
-	}
-
-	// If this is the first request (that is, the polling response shape is unknown), determine how
-	// to poll and what to expect
-	if ps.PollingMethod == PollingUnknown {
-		req := resp.Request
-		if req == nil {
-			return autorest.NewError("azure", "updatePollingState", "Azure Polling Error - Original HTTP request is missing")
-		}
-
-		// Prefer the Azure-AsyncOperation header
-		ps.URI = getAsyncOperation(resp)
-		if ps.URI != "" {
-			ps.PollingMethod = PollingAsyncOperation
-		} else {
-			ps.PollingMethod = PollingLocation
-		}
-
-		// Else, use the Location header
-		if ps.URI == "" {
-			ps.URI = autorest.GetLocation(resp)
-		}
-
-		// Lastly, requests against an existing resource, use the last request URI
-		if ps.URI == "" {
-			m := strings.ToUpper(req.Method)
-			if m == http.MethodPatch || m == http.MethodPut || m == http.MethodGet {
-				ps.URI = req.URL.String()
-			}
-		}
-	}
-
-	// Read and interpret the response (saving the Body in case no polling is necessary)
-	b := &bytes.Buffer{}
-	err := autorest.Respond(resp,
-		autorest.ByCopying(b),
-		autorest.ByUnmarshallingJSON(pt),
-		autorest.ByClosing())
-	resp.Body = ioutil.NopCloser(b)
-	if err != nil {
-		return err
-	}
-
-	// Interpret the results
-	// -- Terminal states apply regardless
-	// -- Unknown states are per-service inprogress states
-	// -- Otherwise, infer state from HTTP status code
-	if pt.hasTerminated() {
-		ps.State = pt.state()
-	} else if pt.state() != "" {
-		ps.State = operationInProgress
-	} else {
-		switch resp.StatusCode {
-		case http.StatusAccepted:
-			ps.State = operationInProgress
-
-		case http.StatusNoContent, http.StatusCreated, http.StatusOK:
-			ps.State = operationSucceeded
-
-		default:
-			ps.State = operationFailed
-		}
-	}
-
-	if strings.EqualFold(ps.State, operationInProgress) && ps.URI == "" {
-		return autorest.NewError("azure", "updatePollingState", "Azure Polling Error - Unable to obtain polling URI for %s %s", resp.Request.Method, resp.Request.URL)
-	}
-
-	// For failed operation, check for error code and message in
-	// -- Operation resource
-	// -- Response
-	// -- Otherwise, Unknown
-	if ps.hasFailed() {
-		if or, ok := pt.(*operationResource); ok {
-			ps.ServiceError = &or.OperationError
-		} else if p, ok := pt.(*provisioningStatus); ok && p.hasProvisioningError() {
-			ps.ServiceError = &p.ProvisioningError
-		} else {
-			ps.ServiceError = &ServiceError{
-				Code:    "Unknown",
-				Message: "None",
-			}
-		}
-	}
-	return nil
-}
-
-func newPollingRequest(ps pollingState) (*http.Request, error) {
-	reqPoll, err := autorest.Prepare(&http.Request{},
-		autorest.AsGet(),
-		autorest.WithBaseURL(ps.URI))
-	if err != nil {
-		return nil, autorest.NewErrorWithError(err, "azure", "newPollingRequest", nil, "Failure creating poll request to %s", ps.URI)
-	}
-
-	return reqPoll, nil
-}
 
 // AsyncOpIncompleteError is the type that's returned from a future that has not completed.
 type AsyncOpIncompleteError struct {

--- a/autorest/azure/async_test.go
+++ b/autorest/azure/async_test.go
@@ -19,10 +19,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"reflect"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -31,449 +29,630 @@ import (
 	"github.com/Azure/go-autorest/autorest/mocks"
 )
 
-func TestGetAsyncOperation_ReturnsAzureAsyncOperationHeader(t *testing.T) {
-	r := newAsynchronousResponse()
-
-	if getAsyncOperation(r) != mocks.TestAzureAsyncURL {
-		t.Fatalf("azure: getAsyncOperation failed to extract the Azure-AsyncOperation header -- expected %v, received %v", mocks.TestURL, getAsyncOperation(r))
-	}
-}
-
-func TestGetAsyncOperation_ReturnsEmptyStringIfHeaderIsAbsent(t *testing.T) {
-	r := mocks.NewResponse()
-
-	if len(getAsyncOperation(r)) != 0 {
-		t.Fatalf("azure: getAsyncOperation failed to return empty string when the Azure-AsyncOperation header is absent -- received %v", getAsyncOperation(r))
-	}
-}
-
-func TestHasSucceeded_ReturnsTrueForSuccess(t *testing.T) {
-	if !hasSucceeded(operationSucceeded) {
-		t.Fatal("azure: hasSucceeded failed to return true for success")
-	}
-}
-
-func TestHasSucceeded_ReturnsFalseOtherwise(t *testing.T) {
-	if hasSucceeded("not a success string") {
-		t.Fatal("azure: hasSucceeded returned true for a non-success")
-	}
-}
-
-func TestHasTerminated_ReturnsTrueForValidTerminationStates(t *testing.T) {
-	for _, state := range []string{operationSucceeded, operationCanceled, operationFailed} {
-		if !hasTerminated(state) {
-			t.Fatalf("azure: hasTerminated failed to return true for the '%s' state", state)
-		}
-	}
-}
-
-func TestHasTerminated_ReturnsFalseForUnknownStates(t *testing.T) {
-	if hasTerminated("not a known state") {
-		t.Fatal("azure: hasTerminated returned true for an unknown state")
-	}
-}
-
-func TestOperationError_ErrorReturnsAString(t *testing.T) {
-	s := (ServiceError{Code: "server code", Message: "server error"}).Error()
-	if s == "" {
-		t.Fatalf("azure: operationError#Error failed to return an error")
-	}
-	if !strings.Contains(s, "server code") || !strings.Contains(s, "server error") {
-		t.Fatalf("azure: operationError#Error returned a malformed error -- error='%v'", s)
-	}
-}
-
-func TestOperationResource_StateReturnsState(t *testing.T) {
-	if (operationResource{Status: "state"}).state() != "state" {
-		t.Fatalf("azure: operationResource#state failed to return the correct state")
-	}
-}
-
-func TestOperationResource_HasSucceededReturnsFalseIfNotSuccess(t *testing.T) {
-	if (operationResource{Status: "not a success string"}).hasSucceeded() {
-		t.Fatalf("azure: operationResource#hasSucceeded failed to return false for a canceled operation")
-	}
-}
-
-func TestOperationResource_HasSucceededReturnsTrueIfSuccessful(t *testing.T) {
-	if !(operationResource{Status: operationSucceeded}).hasSucceeded() {
-		t.Fatalf("azure: operationResource#hasSucceeded failed to return true for a successful operation")
-	}
-}
-
-func TestOperationResource_HasTerminatedReturnsTrueForKnownStates(t *testing.T) {
-	for _, state := range []string{operationSucceeded, operationCanceled, operationFailed} {
-		if !(operationResource{Status: state}).hasTerminated() {
-			t.Fatalf("azure: operationResource#hasTerminated failed to return true for the '%s' state", state)
-		}
-	}
-}
-
-func TestOperationResource_HasTerminatedReturnsFalseForUnknownStates(t *testing.T) {
-	if (operationResource{Status: "not a known state"}).hasTerminated() {
-		t.Fatalf("azure: operationResource#hasTerminated returned true for a non-terminal operation")
-	}
-}
-
-func TestProvisioningStatus_StateReturnsState(t *testing.T) {
-	if (provisioningStatus{Properties: provisioningProperties{"state"}}).state() != "state" {
-		t.Fatalf("azure: provisioningStatus#state failed to return the correct state")
-	}
-}
-
-func TestProvisioningStatus_HasSucceededReturnsFalseIfNotSuccess(t *testing.T) {
-	if (provisioningStatus{Properties: provisioningProperties{"not a success string"}}).hasSucceeded() {
-		t.Fatalf("azure: provisioningStatus#hasSucceeded failed to return false for a canceled operation")
-	}
-}
-
-func TestProvisioningStatus_HasSucceededReturnsTrueIfSuccessful(t *testing.T) {
-	if !(provisioningStatus{Properties: provisioningProperties{operationSucceeded}}).hasSucceeded() {
-		t.Fatalf("azure: provisioningStatus#hasSucceeded failed to return true for a successful operation")
-	}
-}
-
-func TestProvisioningStatus_HasTerminatedReturnsTrueForKnownStates(t *testing.T) {
-	for _, state := range []string{operationSucceeded, operationCanceled, operationFailed} {
-		if !(provisioningStatus{Properties: provisioningProperties{state}}).hasTerminated() {
-			t.Fatalf("azure: provisioningStatus#hasTerminated failed to return true for the '%s' state", state)
-		}
-	}
-}
-
-func TestProvisioningStatus_HasTerminatedReturnsFalseForUnknownStates(t *testing.T) {
-	if (provisioningStatus{Properties: provisioningProperties{"not a known state"}}).hasTerminated() {
-		t.Fatalf("azure: provisioningStatus#hasTerminated returned true for a non-terminal operation")
-	}
-}
-
-func TestPollingState_HasSucceededReturnsFalseIfNotSuccess(t *testing.T) {
-	if (pollingState{State: "not a success string"}).hasSucceeded() {
-		t.Fatalf("azure: pollingState#hasSucceeded failed to return false for a canceled operation")
-	}
-}
-
-func TestPollingState_HasSucceededReturnsTrueIfSuccessful(t *testing.T) {
-	if !(pollingState{State: operationSucceeded}).hasSucceeded() {
-		t.Fatalf("azure: pollingState#hasSucceeded failed to return true for a successful operation")
-	}
-}
-
-func TestPollingState_HasTerminatedReturnsTrueForKnownStates(t *testing.T) {
-	for _, state := range []string{operationSucceeded, operationCanceled, operationFailed} {
-		if !(pollingState{State: state}).hasTerminated() {
-			t.Fatalf("azure: pollingState#hasTerminated failed to return true for the '%s' state", state)
-		}
-	}
-}
-
-func TestPollingState_HasTerminatedReturnsFalseForUnknownStates(t *testing.T) {
-	if (pollingState{State: "not a known state"}).hasTerminated() {
-		t.Fatalf("azure: pollingState#hasTerminated returned true for a non-terminal operation")
-	}
-}
-
-func TestUpdatePollingState_ReturnsAnErrorIfOneOccurs(t *testing.T) {
-	resp := mocks.NewResponseWithContent(operationResourceIllegal)
-	err := updatePollingState(resp, &pollingState{})
+func TestCreateFromInvalidRequestVerb(t *testing.T) {
+	resp := mocks.NewResponseWithBodyAndStatus(nil, http.StatusOK, "some status")
+	resp.Request = mocks.NewRequestWithParams(http.MethodGet, mocks.TestURL, nil)
+	_, err := createPollingTracker(resp)
 	if err == nil {
-		t.Fatalf("azure: updatePollingState failed to return an error after a JSON parsing error")
+		t.Fatal("unexpected nil error")
 	}
 }
 
-func TestUpdatePollingState_ReturnsTerminatedForKnownProvisioningStates(t *testing.T) {
-	for _, state := range []string{operationSucceeded, operationCanceled, operationFailed} {
-		resp := mocks.NewResponseWithContent(fmt.Sprintf(pollingStateFormat, state))
-		resp.StatusCode = 42
-		ps := &pollingState{PollingMethod: PollingLocation}
-		updatePollingState(resp, ps)
-		if !ps.hasTerminated() {
-			t.Fatalf("azure: updatePollingState failed to return a terminating pollingState for the '%s' state", state)
-		}
-	}
-}
-
-func TestUpdatePollingState_ReturnsSuccessForSuccessfulProvisioningState(t *testing.T) {
-	resp := mocks.NewResponseWithContent(fmt.Sprintf(pollingStateFormat, operationSucceeded))
-	resp.StatusCode = 42
-	ps := &pollingState{PollingMethod: PollingLocation}
-	updatePollingState(resp, ps)
-	if !ps.hasSucceeded() {
-		t.Fatalf("azure: updatePollingState failed to return a successful pollingState for the '%s' state", operationSucceeded)
-	}
-}
-
-func TestUpdatePollingState_ReturnsInProgressForAllOtherProvisioningStates(t *testing.T) {
-	s := "not a recognized state"
-	resp := mocks.NewResponseWithContent(fmt.Sprintf(pollingStateFormat, s))
-	resp.StatusCode = 42
-	ps := &pollingState{PollingMethod: PollingLocation}
-	updatePollingState(resp, ps)
-	if ps.hasTerminated() {
-		t.Fatalf("azure: updatePollingState returned terminated for unknown state '%s'", s)
-	}
-}
-
-func TestUpdatePollingState_ReturnsSuccessWhenProvisioningStateFieldIsAbsentForSuccessStatusCodes(t *testing.T) {
-	for _, sc := range []int{http.StatusOK, http.StatusCreated, http.StatusNoContent} {
-		resp := mocks.NewResponseWithContent(pollingStateEmpty)
-		resp.StatusCode = sc
-		ps := &pollingState{PollingMethod: PollingLocation}
-		updatePollingState(resp, ps)
-		if !ps.hasSucceeded() {
-			t.Fatalf("azure: updatePollingState failed to return success when the provisionState field is absent for Status Code %d", sc)
-		}
-	}
-}
-
-func TestUpdatePollingState_ReturnsInProgressWhenProvisioningStateFieldIsAbsentForAccepted(t *testing.T) {
-	resp := mocks.NewResponseWithContent(pollingStateEmpty)
-	resp.StatusCode = http.StatusAccepted
-	ps := &pollingState{PollingMethod: PollingLocation}
-	updatePollingState(resp, ps)
-	if ps.hasTerminated() {
-		t.Fatalf("azure: updatePollingState returned terminated when the provisionState field is absent for Status Code Accepted")
-	}
-}
-
-func TestUpdatePollingState_ReturnsFailedWhenProvisioningStateFieldIsAbsentForUnknownStatusCodes(t *testing.T) {
-	resp := mocks.NewResponseWithContent(pollingStateEmpty)
-	resp.StatusCode = 42
-	ps := &pollingState{PollingMethod: PollingLocation}
-	updatePollingState(resp, ps)
-	if !ps.hasTerminated() || ps.hasSucceeded() {
-		t.Fatalf("azure: updatePollingState did not return failed when the provisionState field is absent for an unknown Status Code")
-	}
-}
-
-func TestUpdatePollingState_ReturnsTerminatedForKnownOperationResourceStates(t *testing.T) {
-	for _, state := range []string{operationSucceeded, operationCanceled, operationFailed} {
-		resp := mocks.NewResponseWithContent(fmt.Sprintf(operationResourceFormat, state))
-		resp.StatusCode = 42
-		ps := &pollingState{PollingMethod: PollingAsyncOperation}
-		updatePollingState(resp, ps)
-		if !ps.hasTerminated() {
-			t.Fatalf("azure: updatePollingState failed to return a terminating pollingState for the '%s' state", state)
-		}
-	}
-}
-
-func TestUpdatePollingState_ReturnsSuccessForSuccessfulOperationResourceState(t *testing.T) {
-	resp := mocks.NewResponseWithContent(fmt.Sprintf(operationResourceFormat, operationSucceeded))
-	resp.StatusCode = 42
-	ps := &pollingState{PollingMethod: PollingAsyncOperation}
-	updatePollingState(resp, ps)
-	if !ps.hasSucceeded() {
-		t.Fatalf("azure: updatePollingState failed to return a successful pollingState for the '%s' state", operationSucceeded)
-	}
-}
-
-func TestUpdatePollingState_ReturnsInProgressForAllOtherOperationResourceStates(t *testing.T) {
-	s := "not a recognized state"
-	resp := mocks.NewResponseWithContent(fmt.Sprintf(operationResourceFormat, s))
-	resp.StatusCode = 42
-	ps := &pollingState{PollingMethod: PollingAsyncOperation}
-	updatePollingState(resp, ps)
-	if ps.hasTerminated() {
-		t.Fatalf("azure: updatePollingState returned terminated for unknown state '%s'", s)
-	}
-}
-
-func TestUpdatePollingState_CopiesTheResponseBody(t *testing.T) {
-	s := fmt.Sprintf(pollingStateFormat, operationSucceeded)
-	resp := mocks.NewResponseWithContent(s)
-	resp.StatusCode = 42
-	ps := &pollingState{PollingMethod: PollingAsyncOperation}
-	updatePollingState(resp, ps)
-	b, err := ioutil.ReadAll(resp.Body)
+// DELETE
+func TestCreateDeleteTracker201Success(t *testing.T) {
+	resp := newAsyncResp(newAsyncReq(http.MethodDelete, nil), http.StatusCreated, nil)
+	mocks.SetLocationHeader(resp, mocks.TestLocationURL)
+	pt, err := createPollingTracker(resp)
 	if err != nil {
-		t.Fatalf("azure: updatePollingState failed to replace the http.Response Body -- Error='%v'", err)
+		t.Fatalf("failed to create tracker: %v", err)
 	}
-	if string(b) != s {
-		t.Fatalf("azure: updatePollingState failed to copy the http.Response Body -- Expected='%s' Received='%s'", s, string(b))
+	if pt.pollingMethod() != PollingLocation {
+		t.Fatalf("wrong polling method: %s", pt.pollingMethod())
 	}
-}
-
-func TestUpdatePollingState_ClosesTheOriginalResponseBody(t *testing.T) {
-	resp := mocks.NewResponse()
-	b := resp.Body.(*mocks.Body)
-	ps := &pollingState{PollingMethod: PollingLocation}
-	updatePollingState(resp, ps)
-	if b.IsOpen() {
-		t.Fatal("azure: updatePollingState failed to close the original http.Response Body")
+	if pt.finalGetURL() != mocks.TestLocationURL {
+		t.Fatalf("wrong final GET URL: %s", pt.finalGetURL())
 	}
 }
 
-func TestUpdatePollingState_FailsWhenResponseLacksRequest(t *testing.T) {
-	resp := newAsynchronousResponse()
-	resp.Request = nil
-
-	ps := pollingState{}
-	err := updatePollingState(resp, &ps)
+func TestCreateDeleteTracker201FailNoLocation(t *testing.T) {
+	resp := newAsyncResp(newAsyncReq(http.MethodDelete, nil), http.StatusCreated, nil)
+	_, err := createPollingTracker(resp)
 	if err == nil {
-		t.Fatal("azure: updatePollingState failed to return an error when the http.Response lacked the original http.Request")
+		t.Fatal("unexpected nil error")
 	}
 }
 
-func TestUpdatePollingState_SetsThePollingMethodWhenUsingTheAzureAsyncOperationHeader(t *testing.T) {
-	ps := pollingState{}
-	updatePollingState(newAsynchronousResponse(), &ps)
-
-	if ps.PollingMethod != PollingAsyncOperation {
-		t.Fatal("azure: updatePollingState failed to set the correct response format when using the Azure-AsyncOperation header")
-	}
-}
-
-func TestUpdatePollingState_SetsThePollingMethodWhenUsingTheAzureAsyncOperationHeaderIsMissing(t *testing.T) {
-	resp := newAsynchronousResponse()
-	resp.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
-
-	ps := pollingState{}
-	updatePollingState(resp, &ps)
-
-	if ps.PollingMethod != PollingLocation {
-		t.Fatal("azure: updatePollingState failed to set the correct response format when the Azure-AsyncOperation header is absent")
-	}
-}
-
-func TestUpdatePollingState_DoesNotChangeAnExistingReponseFormat(t *testing.T) {
-	resp := newAsynchronousResponse()
-	resp.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
-
-	ps := pollingState{PollingMethod: PollingAsyncOperation}
-	updatePollingState(resp, &ps)
-
-	if ps.PollingMethod != PollingAsyncOperation {
-		t.Fatal("azure: updatePollingState failed to leave an existing response format setting")
-	}
-}
-
-func TestUpdatePollingState_PrefersTheAzureAsyncOperationHeader(t *testing.T) {
-	resp := newAsynchronousResponse()
-
-	ps := pollingState{}
-	updatePollingState(resp, &ps)
-
-	if ps.URI != mocks.TestAzureAsyncURL {
-		t.Fatal("azure: updatePollingState failed to prefer the Azure-AsyncOperation header")
-	}
-}
-
-func TestUpdatePollingState_PrefersLocationWhenTheAzureAsyncOperationHeaderMissing(t *testing.T) {
-	resp := newAsynchronousResponse()
-	resp.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
-
-	ps := pollingState{}
-	updatePollingState(resp, &ps)
-
-	if ps.URI != mocks.TestLocationURL {
-		t.Fatal("azure: updatePollingState failed to prefer the Location header when the Azure-AsyncOperation header is missing")
-	}
-}
-
-func TestUpdatePollingState_UsesTheObjectLocationIfAsyncHeadersAreMissing(t *testing.T) {
-	resp := newAsynchronousResponse()
-	resp.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
-	resp.Header.Del(http.CanonicalHeaderKey(autorest.HeaderLocation))
-	resp.Request.Method = http.MethodPatch
-
-	ps := pollingState{}
-	updatePollingState(resp, &ps)
-
-	if ps.URI != mocks.TestURL {
-		t.Fatal("azure: updatePollingState failed to use the Object URL when the asynchronous headers are missing")
-	}
-}
-
-func TestUpdatePollingState_RecognizesLowerCaseHTTPVerbs(t *testing.T) {
-	for _, m := range []string{strings.ToLower(http.MethodPatch), strings.ToLower(http.MethodPut), strings.ToLower(http.MethodGet)} {
-		resp := newAsynchronousResponse()
-		resp.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
-		resp.Header.Del(http.CanonicalHeaderKey(autorest.HeaderLocation))
-		resp.Request.Method = m
-
-		ps := pollingState{}
-		updatePollingState(resp, &ps)
-
-		if ps.URI != mocks.TestURL {
-			t.Fatalf("azure: updatePollingState failed to recognize the lower-case HTTP verb '%s'", m)
-		}
-	}
-}
-
-func TestUpdatePollingState_ReturnsAnErrorIfAsyncHeadersAreMissingForANewOrDeletedObject(t *testing.T) {
-	resp := newAsynchronousResponse()
-	resp.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
-	resp.Header.Del(http.CanonicalHeaderKey(autorest.HeaderLocation))
-
-	for _, m := range []string{http.MethodDelete, http.MethodPost} {
-		resp.Request.Method = m
-		err := updatePollingState(resp, &pollingState{})
-		if err == nil {
-			t.Fatalf("azure: updatePollingState failed to return an error even though it could not determine the polling URL for Method '%s'", m)
-		}
-	}
-}
-
-func TestNewPollingRequest_ReturnsAnErrorWhenPrepareFails(t *testing.T) {
-	_, err := newPollingRequest(pollingState{PollingMethod: PollingAsyncOperation, URI: mocks.TestBadURL})
+func TestCreateDeleteTracker201FailBadLocation(t *testing.T) {
+	resp := newAsyncResp(newAsyncReq(http.MethodDelete, nil), http.StatusCreated, nil)
+	mocks.SetLocationHeader(resp, mocks.TestBadURL)
+	_, err := createPollingTracker(resp)
 	if err == nil {
-		t.Fatal("azure: newPollingRequest failed to return an error when Prepare fails")
+		t.Fatal("unexpected nil error")
 	}
 }
 
-func TestNewPollingRequest_DoesNotReturnARequestWhenPrepareFails(t *testing.T) {
-	req, _ := newPollingRequest(pollingState{PollingMethod: PollingAsyncOperation, URI: mocks.TestBadURL})
-	if req != nil {
-		t.Fatal("azure: newPollingRequest returned an http.Request when Prepare failed")
+func TestCreateDeleteTracker202SuccessAsyncOp(t *testing.T) {
+	resp := newAsyncResp(newAsyncReq(http.MethodDelete, nil), http.StatusAccepted, nil)
+	setAsyncOpHeader(resp, mocks.TestAzureAsyncURL)
+	pt, err := createPollingTracker(resp)
+	if err != nil {
+		t.Fatalf("failed to create tracker: %v", err)
+	}
+	if pt.pollingMethod() != PollingAsyncOperation {
+		t.Fatalf("wrong polling method: %s", pt.pollingMethod())
+	}
+	if pt.finalGetURL() != "" {
+		t.Fatal("expected empty GET URL")
 	}
 }
 
-func TestNewPollingRequest_ReturnsAGetRequest(t *testing.T) {
-	req, _ := newPollingRequest(pollingState{PollingMethod: PollingAsyncOperation, URI: mocks.TestAzureAsyncURL})
-	if req.Method != "GET" {
-		t.Fatalf("azure: newPollingRequest did not create an HTTP GET request -- actual method %v", req.Method)
+func TestCreateDeleteTracker202SuccessLocation(t *testing.T) {
+	resp := newAsyncResp(newAsyncReq(http.MethodDelete, nil), http.StatusAccepted, nil)
+	mocks.SetLocationHeader(resp, mocks.TestLocationURL)
+	pt, err := createPollingTracker(resp)
+	if err != nil {
+		t.Fatalf("failed to create tracker: %v", err)
+	}
+	if pt.pollingMethod() != PollingLocation {
+		t.Fatalf("wrong polling method: %s", pt.pollingMethod())
+	}
+	if pt.finalGetURL() != mocks.TestLocationURL {
+		t.Fatalf("wrong final GET URL: %s", pt.finalGetURL())
 	}
 }
 
-func TestDoPollForAsynchronous_IgnoresUnspecifiedStatusCodes(t *testing.T) {
-	client := mocks.NewSender()
-
-	r, _ := autorest.SendWithSender(client, mocks.NewRequest(),
-		DoPollForAsynchronous(time.Duration(0)))
-
-	if client.Attempts() != 1 {
-		t.Fatalf("azure: DoPollForAsynchronous polled for unspecified status code")
+func TestCreateDeleteTracker202SuccessBoth(t *testing.T) {
+	resp := newAsyncResp(newAsyncReq(http.MethodDelete, nil), http.StatusAccepted, nil)
+	setAsyncOpHeader(resp, mocks.TestAzureAsyncURL)
+	mocks.SetLocationHeader(resp, mocks.TestLocationURL)
+	pt, err := createPollingTracker(resp)
+	if err != nil {
+		t.Fatalf("failed to create tracker: %v", err)
 	}
-
-	autorest.Respond(r,
-		autorest.ByClosing())
+	if pt.pollingMethod() != PollingAsyncOperation {
+		t.Fatalf("wrong polling method: %s", pt.pollingMethod())
+	}
+	if pt.finalGetURL() != mocks.TestLocationURL {
+		t.Fatalf("wrong final GET URL: %s", pt.finalGetURL())
+	}
 }
 
-func TestDoPollForAsynchronous_PollsForSpecifiedStatusCodes(t *testing.T) {
-	client := mocks.NewSender()
-	client.AppendResponse(newAsynchronousResponse())
+func TestCreateDeleteTracker202SuccessBadLocation(t *testing.T) {
+	resp := newAsyncResp(newAsyncReq(http.MethodDelete, nil), http.StatusAccepted, nil)
+	setAsyncOpHeader(resp, mocks.TestAzureAsyncURL)
+	mocks.SetLocationHeader(resp, mocks.TestBadURL)
+	pt, err := createPollingTracker(resp)
+	if err != nil {
+		t.Fatalf("failed to create tracker: %v", err)
+	}
+	if pt.pollingMethod() != PollingAsyncOperation {
+		t.Fatalf("wrong polling method: %s", pt.pollingMethod())
+	}
+	if pt.finalGetURL() != "" {
+		t.Fatal("expected empty GET URL")
+	}
+}
 
-	r, _ := autorest.SendWithSender(client, mocks.NewRequest(),
-		DoPollForAsynchronous(time.Millisecond))
+func TestCreateDeleteTracker202FailBadAsyncOp(t *testing.T) {
+	resp := newAsyncResp(newAsyncReq(http.MethodDelete, nil), http.StatusAccepted, nil)
+	setAsyncOpHeader(resp, mocks.TestBadURL)
+	_, err := createPollingTracker(resp)
+	if err == nil {
+		t.Fatal("unexpected nil error")
+	}
+}
 
-	if client.Attempts() != 2 {
-		t.Fatalf("azure: DoPollForAsynchronous failed to poll for specified status code")
+func TestCreateDeleteTracker202FailBadLocation(t *testing.T) {
+	resp := newAsyncResp(newAsyncReq(http.MethodDelete, nil), http.StatusAccepted, nil)
+	mocks.SetLocationHeader(resp, mocks.TestBadURL)
+	_, err := createPollingTracker(resp)
+	if err == nil {
+		t.Fatal("unexpected nil error")
+	}
+}
+
+// PATCH
+
+func TestCreatePatchTracker201Success(t *testing.T) {
+	resp := newAsyncResp(newAsyncReq(http.MethodPatch, nil), http.StatusCreated, nil)
+	setAsyncOpHeader(resp, mocks.TestAzureAsyncURL)
+	pt, err := createPollingTracker(resp)
+	if err != nil {
+		t.Fatalf("failed to create tracker: %v", err)
+	}
+	if pt.pollingMethod() != PollingAsyncOperation {
+		t.Fatalf("wrong polling method: %s", pt.pollingMethod())
+	}
+	if pt.finalGetURL() != mocks.TestURL {
+		t.Fatalf("wrong final GET URL: %s", pt.finalGetURL())
+	}
+}
+
+func TestCreatePatchTracker201SuccessNoHeaders(t *testing.T) {
+	resp := newAsyncResp(newAsyncReq(http.MethodPatch, nil), http.StatusCreated, nil)
+	pt, err := createPollingTracker(resp)
+	if err != nil {
+		t.Fatalf("failed to create tracker: %v", err)
+	}
+	if pt.pollingMethod() != PollingRequestURI {
+		t.Fatalf("wrong polling method: %s", pt.pollingMethod())
+	}
+	if pt.finalGetURL() != mocks.TestURL {
+		t.Fatalf("wrong final GET URL: %s", pt.finalGetURL())
+	}
+}
+
+func TestCreatePatchTracker201FailBadAsyncOp(t *testing.T) {
+	resp := newAsyncResp(newAsyncReq(http.MethodPatch, nil), http.StatusCreated, nil)
+	setAsyncOpHeader(resp, mocks.TestBadURL)
+	_, err := createPollingTracker(resp)
+	if err == nil {
+		t.Fatal("unexpected nil error")
+	}
+}
+
+func TestCreatePatchTracker202SuccessAsyncOp(t *testing.T) {
+	resp := newAsyncResp(newAsyncReq(http.MethodPatch, nil), http.StatusAccepted, nil)
+	setAsyncOpHeader(resp, mocks.TestAzureAsyncURL)
+	pt, err := createPollingTracker(resp)
+	if err != nil {
+		t.Fatalf("failed to create tracker: %v", err)
+	}
+	if pt.pollingMethod() != PollingAsyncOperation {
+		t.Fatalf("wrong polling method: %s", pt.pollingMethod())
+	}
+	if pt.finalGetURL() != mocks.TestURL {
+		t.Fatalf("wrong final GET URL: %s", pt.finalGetURL())
+	}
+}
+
+func TestCreatePatchTracker202SuccessLocation(t *testing.T) {
+	resp := newAsyncResp(newAsyncReq(http.MethodPatch, nil), http.StatusAccepted, nil)
+	mocks.SetLocationHeader(resp, mocks.TestLocationURL)
+	pt, err := createPollingTracker(resp)
+	if err != nil {
+		t.Fatalf("failed to create tracker: %v", err)
+	}
+	if pt.pollingMethod() != PollingLocation {
+		t.Fatalf("wrong polling method: %s", pt.pollingMethod())
+	}
+	if pt.finalGetURL() != mocks.TestURL {
+		t.Fatalf("wrong final GET URL: %s", pt.finalGetURL())
+	}
+}
+
+func TestCreatePatchTracker202SuccessBoth(t *testing.T) {
+	resp := newAsyncResp(newAsyncReq(http.MethodPatch, nil), http.StatusAccepted, nil)
+	setAsyncOpHeader(resp, mocks.TestAzureAsyncURL)
+	mocks.SetLocationHeader(resp, mocks.TestLocationURL)
+	pt, err := createPollingTracker(resp)
+	if err != nil {
+		t.Fatalf("failed to create tracker: %v", err)
+	}
+	if pt.pollingMethod() != PollingAsyncOperation {
+		t.Fatalf("wrong polling method: %s", pt.pollingMethod())
+	}
+	if pt.finalGetURL() != mocks.TestURL {
+		t.Fatalf("wrong final GET URL: %s", pt.finalGetURL())
+	}
+}
+
+func TestCreatePatchTracker202FailBadAsyncOp(t *testing.T) {
+	resp := newAsyncResp(newAsyncReq(http.MethodPatch, nil), http.StatusAccepted, nil)
+	setAsyncOpHeader(resp, mocks.TestBadURL)
+	_, err := createPollingTracker(resp)
+	if err == nil {
+		t.Fatal("unexpected nil error")
+	}
+}
+
+func TestCreatePatchTracker202FailBadLocation(t *testing.T) {
+	resp := newAsyncResp(newAsyncReq(http.MethodPatch, nil), http.StatusAccepted, nil)
+	mocks.SetLocationHeader(resp, mocks.TestBadURL)
+	_, err := createPollingTracker(resp)
+	if err == nil {
+		t.Fatal("unexpected nil error")
+	}
+}
+
+// POST
+
+func TestCreatePostTracker201Success(t *testing.T) {
+	resp := newAsyncResp(newAsyncReq(http.MethodPost, nil), http.StatusCreated, nil)
+	mocks.SetLocationHeader(resp, mocks.TestLocationURL)
+	pt, err := createPollingTracker(resp)
+	if err != nil {
+		t.Fatalf("failed to create tracker: %v", err)
+	}
+	if pt.pollingMethod() != PollingLocation {
+		t.Fatalf("wrong polling method: %s", pt.pollingMethod())
+	}
+	if pt.finalGetURL() != mocks.TestLocationURL {
+		t.Fatalf("wrong final GET URL: %s", pt.finalGetURL())
+	}
+}
+
+func TestCreatePostTracker201FailNoHeader(t *testing.T) {
+	resp := newAsyncResp(newAsyncReq(http.MethodPost, nil), http.StatusCreated, nil)
+	_, err := createPollingTracker(resp)
+	if err == nil {
+		t.Fatal("unexpected nil err")
+	}
+}
+
+func TestCreatePostTracker201FailBadHeader(t *testing.T) {
+	resp := newAsyncResp(newAsyncReq(http.MethodPost, nil), http.StatusCreated, nil)
+	mocks.SetLocationHeader(resp, mocks.TestBadURL)
+	_, err := createPollingTracker(resp)
+	if err == nil {
+		t.Fatal("unexpected nil err")
+	}
+}
+
+func TestCreatePostTracker202SuccessAsyncOp(t *testing.T) {
+	resp := newAsyncResp(newAsyncReq(http.MethodPost, nil), http.StatusAccepted, nil)
+	setAsyncOpHeader(resp, mocks.TestAzureAsyncURL)
+	pt, err := createPollingTracker(resp)
+	if err != nil {
+		t.Fatalf("failed to create tracker: %v", err)
+	}
+	if pt.pollingMethod() != PollingAsyncOperation {
+		t.Fatalf("wrong polling method: %s", pt.pollingMethod())
+	}
+	if pt.finalGetURL() != "" {
+		t.Fatal("expected empty final GET URL")
+	}
+}
+
+func TestCreatePostTracker202SuccessLocation(t *testing.T) {
+	resp := newAsyncResp(newAsyncReq(http.MethodPost, nil), http.StatusAccepted, nil)
+	mocks.SetLocationHeader(resp, mocks.TestLocationURL)
+	pt, err := createPollingTracker(resp)
+	if err != nil {
+		t.Fatalf("failed to create tracker: %v", err)
+	}
+	if pt.pollingMethod() != PollingLocation {
+		t.Fatalf("wrong polling method: %s", pt.pollingMethod())
+	}
+	if pt.finalGetURL() != mocks.TestLocationURL {
+		t.Fatalf("wrong final GET URI: %s", pt.finalGetURL())
+	}
+}
+
+func TestCreatePostTracker202SuccessBoth(t *testing.T) {
+	resp := newAsyncResp(newAsyncReq(http.MethodPost, nil), http.StatusAccepted, nil)
+	setAsyncOpHeader(resp, mocks.TestAzureAsyncURL)
+	mocks.SetLocationHeader(resp, mocks.TestLocationURL)
+	pt, err := createPollingTracker(resp)
+	if err != nil {
+		t.Fatalf("failed to create tracker: %v", err)
+	}
+	if pt.pollingMethod() != PollingAsyncOperation {
+		t.Fatalf("wrong polling method: %s", pt.pollingMethod())
+	}
+	if pt.finalGetURL() != mocks.TestLocationURL {
+		t.Fatalf("wrong final GET URL: %s", pt.finalGetURL())
+	}
+}
+
+func TestCreatePostTracker202SuccessBadLocation(t *testing.T) {
+	resp := newAsyncResp(newAsyncReq(http.MethodPost, nil), http.StatusAccepted, nil)
+	setAsyncOpHeader(resp, mocks.TestAzureAsyncURL)
+	mocks.SetLocationHeader(resp, mocks.TestBadURL)
+	pt, err := createPollingTracker(resp)
+	if err != nil {
+		t.Fatalf("failed to create tracker: %v", err)
+	}
+	if pt.pollingMethod() != PollingAsyncOperation {
+		t.Fatalf("wrong polling method: %s", pt.pollingMethod())
+	}
+	if pt.finalGetURL() != "" {
+		t.Fatal("expected empty final GET URL")
+	}
+}
+
+func TestCreatePostTracker202FailBadAsyncOp(t *testing.T) {
+	resp := newAsyncResp(newAsyncReq(http.MethodPost, nil), http.StatusAccepted, nil)
+	setAsyncOpHeader(resp, mocks.TestBadURL)
+	_, err := createPollingTracker(resp)
+	if err == nil {
+		t.Fatal("unexpected nil error")
+	}
+}
+
+func TestCreatePostTracker202FailBadLocation(t *testing.T) {
+	resp := newAsyncResp(newAsyncReq(http.MethodPost, nil), http.StatusAccepted, nil)
+	_, err := createPollingTracker(resp)
+	mocks.SetLocationHeader(resp, mocks.TestBadURL)
+	if err == nil {
+		t.Fatal("unexpected nil error")
+	}
+}
+
+// PUT
+
+func TestCreatePutTracker201SuccessAsyncOp(t *testing.T) {
+	resp := newAsyncResp(newAsyncReq(http.MethodPut, nil), http.StatusCreated, nil)
+	setAsyncOpHeader(resp, mocks.TestAzureAsyncURL)
+	pt, err := createPollingTracker(resp)
+	if err != nil {
+		t.Fatalf("failed to create tracker: %v", err)
+	}
+	if pt.pollingMethod() != PollingAsyncOperation {
+		t.Fatalf("wrong polling method: %s", pt.pollingMethod())
+	}
+	if pt.finalGetURL() != mocks.TestURL {
+		t.Fatalf("wrong final GET URL: %s", pt.finalGetURL())
+	}
+}
+
+func TestCreatePutTracker201SuccessNoHeaders(t *testing.T) {
+	resp := newAsyncResp(newAsyncReq(http.MethodPut, nil), http.StatusCreated, nil)
+	pt, err := createPollingTracker(resp)
+	if err != nil {
+		t.Fatalf("failed to create tracker: %v", err)
+	}
+	if pt.pollingMethod() != PollingRequestURI {
+		t.Fatalf("wrong polling method: %s", pt.pollingMethod())
+	}
+	if pt.finalGetURL() != mocks.TestURL {
+		t.Fatalf("wrong final GET URL: %s", pt.finalGetURL())
+	}
+}
+
+func TestCreatePutTracker201FailBadAsyncOp(t *testing.T) {
+	resp := newAsyncResp(newAsyncReq(http.MethodPut, nil), http.StatusCreated, nil)
+	setAsyncOpHeader(resp, mocks.TestBadURL)
+	_, err := createPollingTracker(resp)
+	if err == nil {
+		t.Fatal("unexpected nil error")
+	}
+}
+
+func TestCreatePutTracker202SuccessAsyncOp(t *testing.T) {
+	resp := newAsyncResp(newAsyncReq(http.MethodPut, nil), http.StatusAccepted, nil)
+	setAsyncOpHeader(resp, mocks.TestAzureAsyncURL)
+	pt, err := createPollingTracker(resp)
+	if err != nil {
+		t.Fatalf("failed to create tracker: %v", err)
+	}
+	if pt.pollingMethod() != PollingAsyncOperation {
+		t.Fatalf("wrong polling method: %s", pt.pollingMethod())
+	}
+	if pt.finalGetURL() != mocks.TestURL {
+		t.Fatalf("wrong final GET URL: %s", pt.finalGetURL())
+	}
+}
+
+func TestCreatePutTracker202SuccessLocation(t *testing.T) {
+	resp := newAsyncResp(newAsyncReq(http.MethodPut, nil), http.StatusAccepted, nil)
+	mocks.SetLocationHeader(resp, mocks.TestLocationURL)
+	pt, err := createPollingTracker(resp)
+	if err != nil {
+		t.Fatalf("failed to create tracker: %v", err)
+	}
+	if pt.pollingMethod() != PollingLocation {
+		t.Fatalf("wrong polling method: %s", pt.pollingMethod())
+	}
+	if pt.finalGetURL() != mocks.TestLocationURL {
+		t.Fatalf("wrong final GET URL: %s", pt.finalGetURL())
+	}
+}
+
+func TestCreatePutTracker202SuccessBoth(t *testing.T) {
+	resp := newAsyncResp(newAsyncReq(http.MethodPut, nil), http.StatusAccepted, nil)
+	setAsyncOpHeader(resp, mocks.TestAzureAsyncURL)
+	mocks.SetLocationHeader(resp, mocks.TestLocationURL)
+	pt, err := createPollingTracker(resp)
+	if err != nil {
+		t.Fatalf("failed to create tracker: %v", err)
+	}
+	if pt.pollingMethod() != PollingAsyncOperation {
+		t.Fatalf("wrong polling method: %s", pt.pollingMethod())
+	}
+	if pt.finalGetURL() != mocks.TestLocationURL {
+		t.Fatalf("wrong final GET URL: %s", pt.finalGetURL())
+	}
+}
+
+func TestCreatePutTracker202SuccessBadLocation(t *testing.T) {
+	resp := newAsyncResp(newAsyncReq(http.MethodPut, nil), http.StatusAccepted, nil)
+	setAsyncOpHeader(resp, mocks.TestAzureAsyncURL)
+	mocks.SetLocationHeader(resp, mocks.TestBadURL)
+	pt, err := createPollingTracker(resp)
+	if err != nil {
+		t.Fatalf("failed to create tracker: %v", err)
+	}
+	if pt.pollingMethod() != PollingAsyncOperation {
+		t.Fatalf("wrong polling method: %s", pt.pollingMethod())
+	}
+	if pt.finalGetURL() != mocks.TestURL {
+		t.Fatalf("wrong final GET URL: %s", pt.finalGetURL())
+	}
+}
+
+func TestCreatePutTracker202FailBadAsyncOp(t *testing.T) {
+	resp := newAsyncResp(newAsyncReq(http.MethodPut, nil), http.StatusAccepted, nil)
+	setAsyncOpHeader(resp, mocks.TestBadURL)
+	_, err := createPollingTracker(resp)
+	if err == nil {
+		t.Fatal("unexpected nil error")
+	}
+}
+
+func TestPollPutTrackerSuccessNoHeaders(t *testing.T) {
+	resp := newAsyncResp(newAsyncReq(http.MethodPut, nil), http.StatusAccepted, nil)
+	pt, err := createPollingTracker(resp)
+	if err != nil {
+		t.Fatalf("failed to create tracker: %v", err)
+	}
+	sender := mocks.NewSender()
+	sender.AppendResponse(newProvisioningStatusResponse("InProgress"))
+	err = pt.pollForStatus(sender)
+	if err != nil {
+		t.Fatalf("failed to poll for status: %v", err)
+	}
+	err = pt.checkForErrors()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPollPutTrackerFailNoHeadersEmptyBody(t *testing.T) {
+	resp := newAsyncResp(newAsyncReq(http.MethodPut, nil), http.StatusAccepted, nil)
+	pt, err := createPollingTracker(resp)
+	if err != nil {
+		t.Fatalf("failed to create tracker: %v", err)
+	}
+	sender := mocks.NewSender()
+	sender.AppendResponse(mocks.NewResponseWithBodyAndStatus(&mocks.Body{}, http.StatusOK, "status ok"))
+	err = pt.pollForStatus(sender)
+	if err != nil {
+		t.Fatalf("failed to poll for status: %v", err)
+	}
+	err = pt.checkForErrors()
+	if err == nil {
+		t.Fatalf("unexpected nil error")
+	}
+}
+
+// errors
+
+func TestAsyncPollingReturnsWrappedError(t *testing.T) {
+	resp := newSimpleAsyncResp()
+	pt, err := createPollingTracker(resp)
+	if err != nil {
+		t.Fatalf("failed to create tracker: %v", err)
+	}
+	sender := mocks.NewSender()
+	sender.AppendResponse(newOperationResourceErrorResponse("Failed"))
+	err = pt.pollForStatus(sender)
+	if err != nil {
+		t.Fatalf("failed to poll for status: %v", err)
+	}
+	err = pt.pollingError()
+	if err == nil {
+		t.Fatal("unexpected nil polling error")
+	}
+	if se, ok := err.(*ServiceError); !ok {
+		t.Fatal("incorrect error type")
+	} else if se.Code == "" {
+		t.Fatal("empty service error code")
+	} else if se.Message == "" {
+		t.Fatal("empty service error message")
+	}
+}
+
+func TestLocationPollingReturnsWrappedError(t *testing.T) {
+	resp := newSimpleLocationResp()
+	pt, err := createPollingTracker(resp)
+	if err != nil {
+		t.Fatalf("failed to create tracker: %v", err)
+	}
+	sender := mocks.NewSender()
+	sender.AppendResponse(newProvisioningStatusErrorResponse("Failed"))
+	err = pt.pollForStatus(sender)
+	if err != nil {
+		t.Fatalf("failed to poll for status: %v", err)
+	}
+	err = pt.pollingError()
+	if err == nil {
+		t.Fatal("unexpected nil polling error")
+	}
+	if se, ok := err.(*ServiceError); !ok {
+		t.Fatal("incorrect error type")
+	} else if se.Code == "" {
+		t.Fatal("empty service error code")
+	} else if se.Message == "" {
+		t.Fatal("empty service error message")
+	}
+}
+
+func TestLocationPollingReturnsUnwrappedError(t *testing.T) {
+	resp := newSimpleLocationResp()
+	pt, err := createPollingTracker(resp)
+	if err != nil {
+		t.Fatalf("failed to create tracker: %v", err)
+	}
+	sender := mocks.NewSender()
+	sender.AppendResponse(newProvisioningStatusUnwrappedErrorResponse("Failed"))
+	err = pt.pollForStatus(sender)
+	if err != nil {
+		t.Fatalf("failed to poll for status: %v", err)
+	}
+	err = pt.pollingError()
+	if err == nil {
+		t.Fatal("unexpected nil polling error")
+	}
+	if se, ok := err.(*ServiceError); !ok {
+		t.Fatal("incorrect error type")
+	} else if se.Code == "" {
+		t.Fatal("empty service error code")
+	} else if se.Message == "" {
+		t.Fatal("empty service error message")
+	}
+}
+
+// DoPollForAsynchronous (legacy so not many tests plus it builds on Future which has more tests)
+
+func TestDoPollForAsynchronous_Success(t *testing.T) {
+	r1 := newSimpleAsyncResp()
+	r2 := newOperationResourceResponse("busy")
+	r3 := newOperationResourceResponse(operationSucceeded)
+
+	sender := mocks.NewSender()
+	sender.AppendResponse(r1)
+	sender.AppendAndRepeatResponse(r2, 2)
+	sender.AppendAndRepeatResponse(r3, 1)
+
+	r, err := autorest.SendWithSender(sender, newAsyncReq(http.MethodPut, nil), DoPollForAsynchronous(time.Millisecond))
+	if err != nil {
+		t.Fatalf("failed to poll for status: %v", err)
 	}
 
-	autorest.Respond(r,
-		autorest.ByClosing())
+	if sender.Attempts() < sender.NumResponses() {
+		t.Fatal("DoPollForAsynchronous stopped polling before receiving a terminated OperationResource")
+	}
+	autorest.Respond(r, autorest.ByClosing())
+}
+
+func TestDoPollForAsynchronous_Failed(t *testing.T) {
+	r1 := newSimpleAsyncResp()
+	r2 := newOperationResourceResponse("busy")
+	r3 := newOperationResourceErrorResponse(operationFailed)
+
+	sender := mocks.NewSender()
+	sender.AppendResponse(r1)
+	sender.AppendAndRepeatResponse(r2, 2)
+	sender.AppendAndRepeatResponse(r3, 1)
+
+	r, err := autorest.SendWithSender(sender, newAsyncReq(http.MethodPut, nil), DoPollForAsynchronous(time.Millisecond))
+	if err == nil {
+		t.Fatal("unexpected nil error when polling")
+	}
+	if se, ok := err.(*ServiceError); !ok {
+		t.Fatal("incorrect error type")
+	} else if se.Code == "" {
+		t.Fatal("empty service error code")
+	} else if se.Message == "" {
+		t.Fatal("empty service error message")
+	}
+
+	if sender.Attempts() < sender.NumResponses() {
+		t.Fatalf("DoPollForAsynchronous stopped polling before receiving a terminated OperationResource")
+	}
+	autorest.Respond(r, autorest.ByClosing())
 }
 
 func TestDoPollForAsynchronous_CanBeCanceled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	delay := 5 * time.Second
 
-	r1 := newAsynchronousResponse()
+	r1 := newSimpleAsyncResp()
 
-	client := mocks.NewSender()
-	client.AppendResponse(r1)
-	client.AppendAndRepeatResponse(newOperationResourceResponse("Busy"), -1)
+	sender := mocks.NewSender()
+	sender.AppendResponse(r1)
+	sender.AppendAndRepeatResponse(newOperationResourceResponse("Busy"), -1)
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -481,14 +660,11 @@ func TestDoPollForAsynchronous_CanBeCanceled(t *testing.T) {
 	end := time.Now()
 	var err error
 	go func() {
-		req := mocks.NewRequest()
+		req := newAsyncReq(http.MethodPut, nil)
 		req = req.WithContext(ctx)
-
 		var r *http.Response
-		r, err = autorest.SendWithSender(client, req,
-			DoPollForAsynchronous(delay))
-		autorest.Respond(r,
-			autorest.ByClosing())
+		r, err = autorest.SendWithSender(sender, req, DoPollForAsynchronous(delay))
+		autorest.Respond(r, autorest.ByClosing())
 		end = time.Now()
 		wg.Done()
 	}()
@@ -496,554 +672,32 @@ func TestDoPollForAsynchronous_CanBeCanceled(t *testing.T) {
 	wg.Wait()
 	time.Sleep(5 * time.Millisecond)
 	if err == nil {
-		t.Fatalf("azure: DoPollForAsynchronous didn't cancel")
+		t.Fatalf("DoPollForAsynchronous didn't cancel")
 	}
 	if end.Sub(start) >= delay {
-		t.Fatalf("azure: DoPollForAsynchronous failed to cancel")
+		t.Fatalf("DoPollForAsynchronous failed to cancel")
 	}
-}
-
-func TestDoPollForAsynchronous_ClosesAllNonreturnedResponseBodiesWhenPolling(t *testing.T) {
-	r1 := newAsynchronousResponse()
-	b1 := r1.Body.(*mocks.Body)
-	r2 := newOperationResourceResponse("busy")
-	b2 := r2.Body.(*mocks.Body)
-	r3 := newOperationResourceResponse(operationSucceeded)
-	b3 := r3.Body.(*mocks.Body)
-
-	client := mocks.NewSender()
-	client.AppendResponse(r1)
-	client.AppendAndRepeatResponse(r2, 2)
-	client.AppendResponse(r3)
-
-	r, _ := autorest.SendWithSender(client, mocks.NewRequest(),
-		DoPollForAsynchronous(time.Millisecond))
-
-	if b1.IsOpen() || b2.IsOpen() || b3.IsOpen() {
-		t.Fatalf("azure: DoPollForAsynchronous did not close unreturned response bodies")
-	}
-
-	autorest.Respond(r,
-		autorest.ByClosing())
-}
-
-func TestDoPollForAsynchronous_LeavesLastResponseBodyOpen(t *testing.T) {
-	r1 := newAsynchronousResponse()
-	r2 := newOperationResourceResponse("busy")
-	r3 := newOperationResourceResponse(operationSucceeded)
-
-	client := mocks.NewSender()
-	client.AppendResponse(r1)
-	client.AppendAndRepeatResponse(r2, 2)
-	client.AppendResponse(r3)
-
-	r, _ := autorest.SendWithSender(client, mocks.NewRequest(),
-		DoPollForAsynchronous(time.Millisecond))
-
-	b, err := ioutil.ReadAll(r.Body)
-	if len(b) <= 0 || err != nil {
-		t.Fatalf("azure: DoPollForAsynchronous did not leave open the body of the last response - Error='%v'", err)
-	}
-
-	autorest.Respond(r,
-		autorest.ByClosing())
-}
-
-func TestDoPollForAsynchronous_DoesNotPollIfOriginalRequestReturnedAnError(t *testing.T) {
-	r1 := newAsynchronousResponse()
-	r2 := newOperationResourceResponse("busy")
-
-	client := mocks.NewSender()
-	client.AppendResponse(r1)
-	client.AppendResponse(r2)
-	client.SetError(fmt.Errorf("Faux Error"))
-
-	r, _ := autorest.SendWithSender(client, mocks.NewRequest(),
-		DoPollForAsynchronous(time.Millisecond))
-
-	if client.Attempts() != 1 {
-		t.Fatalf("azure: DoPollForAsynchronous tried to poll after receiving an error")
-	}
-
-	autorest.Respond(r,
-		autorest.ByClosing())
-}
-
-func TestDoPollForAsynchronous_DoesNotPollIfCreatingOperationRequestFails(t *testing.T) {
-	r1 := newAsynchronousResponse()
-	mocks.SetResponseHeader(r1, http.CanonicalHeaderKey(headerAsyncOperation), mocks.TestBadURL)
-	r2 := newOperationResourceResponse("busy")
-
-	client := mocks.NewSender()
-	client.AppendResponse(r1)
-	client.AppendAndRepeatResponse(r2, 2)
-
-	r, _ := autorest.SendWithSender(client, mocks.NewRequest(),
-		DoPollForAsynchronous(time.Millisecond))
-
-	if client.Attempts() > 1 {
-		t.Fatalf("azure: DoPollForAsynchronous polled with an invalidly formed operation request")
-	}
-
-	autorest.Respond(r,
-		autorest.ByClosing())
-}
-
-func TestDoPollForAsynchronous_StopsPollingAfterAnError(t *testing.T) {
-	r1 := newAsynchronousResponse()
-	r2 := newOperationResourceResponse("busy")
-
-	client := mocks.NewSender()
-	client.AppendResponse(r1)
-	client.AppendAndRepeatResponse(r2, 2)
-	client.SetError(fmt.Errorf("Faux Error"))
-	client.SetEmitErrorAfter(2)
-
-	r, _ := autorest.SendWithSender(client, mocks.NewRequest(),
-		DoPollForAsynchronous(time.Millisecond))
-
-	if client.Attempts() > 3 {
-		t.Fatalf("azure: DoPollForAsynchronous failed to stop polling after receiving an error")
-	}
-
-	autorest.Respond(r,
-		autorest.ByClosing())
-}
-
-func TestDoPollForAsynchronous_ReturnsPollingError(t *testing.T) {
-	client := mocks.NewSender()
-	client.AppendAndRepeatResponse(newAsynchronousResponse(), 5)
-	client.SetError(fmt.Errorf("Faux Error"))
-	client.SetEmitErrorAfter(1)
-
-	r, err := autorest.SendWithSender(client, mocks.NewRequest(),
-		DoPollForAsynchronous(time.Millisecond))
-
-	if err == nil {
-		t.Fatalf("azure: DoPollForAsynchronous failed to return error from polling")
-	}
-
-	autorest.Respond(r,
-		autorest.ByClosing())
-}
-
-func TestDoPollForAsynchronous_PollsForStatusAccepted(t *testing.T) {
-	r1 := newAsynchronousResponse()
-	r1.Status = "202 Accepted"
-	r1.StatusCode = http.StatusAccepted
-	r2 := newOperationResourceResponse("busy")
-	r3 := newOperationResourceResponse(operationCanceled)
-
-	client := mocks.NewSender()
-	client.AppendResponse(r1)
-	client.AppendAndRepeatResponse(r2, 2)
-	client.AppendAndRepeatResponse(r3, 1)
-
-	r, _ := autorest.SendWithSender(client, mocks.NewRequest(),
-		DoPollForAsynchronous(time.Millisecond))
-
-	if client.Attempts() < client.NumResponses() {
-		t.Fatalf("azure: DoPollForAsynchronous stopped polling before receiving a terminated OperationResource")
-	}
-
-	autorest.Respond(r,
-		autorest.ByClosing())
-}
-
-func TestDoPollForAsynchronous_PollsForStatusCreated(t *testing.T) {
-	r1 := newAsynchronousResponse()
-	r1.Status = "201 Created"
-	r1.StatusCode = http.StatusCreated
-	r2 := newOperationResourceResponse("busy")
-	r3 := newOperationResourceResponse(operationCanceled)
-
-	client := mocks.NewSender()
-	client.AppendResponse(r1)
-	client.AppendAndRepeatResponse(r2, 2)
-	client.AppendAndRepeatResponse(r3, 1)
-
-	r, _ := autorest.SendWithSender(client, mocks.NewRequest(),
-		DoPollForAsynchronous(time.Millisecond))
-
-	if client.Attempts() < client.NumResponses() {
-		t.Fatalf("azure: DoPollForAsynchronous stopped polling before receiving a terminated OperationResource")
-	}
-
-	autorest.Respond(r,
-		autorest.ByClosing())
-}
-
-func TestDoPollForAsynchronous_PollsUntilProvisioningStatusTerminates(t *testing.T) {
-	r1 := newAsynchronousResponse()
-	r1.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
-	r2 := newProvisioningStatusResponse("busy")
-	r2.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
-	r3 := newProvisioningStatusResponse(operationCanceled)
-	r3.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
-
-	client := mocks.NewSender()
-	client.AppendResponse(r1)
-	client.AppendAndRepeatResponse(r2, 2)
-	client.AppendAndRepeatResponse(r3, 1)
-
-	r, _ := autorest.SendWithSender(client, mocks.NewRequest(),
-		DoPollForAsynchronous(time.Millisecond))
-
-	if client.Attempts() < client.NumResponses() {
-		t.Fatalf("azure: DoPollForAsynchronous stopped polling before receiving a terminated OperationResource")
-	}
-
-	autorest.Respond(r,
-		autorest.ByClosing())
-}
-
-func TestDoPollForAsynchronous_PollsUntilProvisioningStatusSucceeds(t *testing.T) {
-	r1 := newAsynchronousResponse()
-	r1.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
-	r2 := newProvisioningStatusResponse("busy")
-	r2.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
-	r3 := newProvisioningStatusResponse(operationSucceeded)
-	r3.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
-
-	client := mocks.NewSender()
-	client.AppendResponse(r1)
-	client.AppendAndRepeatResponse(r2, 2)
-	client.AppendAndRepeatResponse(r3, 1)
-
-	r, _ := autorest.SendWithSender(client, mocks.NewRequest(),
-		DoPollForAsynchronous(time.Millisecond))
-
-	if client.Attempts() < client.NumResponses() {
-		t.Fatalf("azure: DoPollForAsynchronous stopped polling before receiving a terminated OperationResource")
-	}
-
-	autorest.Respond(r,
-		autorest.ByClosing())
-}
-
-func TestDoPollForAsynchronous_PollsUntilOperationResourceHasTerminated(t *testing.T) {
-	r1 := newAsynchronousResponse()
-	r2 := newOperationResourceResponse("busy")
-	r3 := newOperationResourceResponse(operationCanceled)
-
-	client := mocks.NewSender()
-	client.AppendResponse(r1)
-	client.AppendAndRepeatResponse(r2, 2)
-	client.AppendAndRepeatResponse(r3, 1)
-
-	r, _ := autorest.SendWithSender(client, mocks.NewRequest(),
-		DoPollForAsynchronous(time.Millisecond))
-
-	if client.Attempts() < client.NumResponses() {
-		t.Fatalf("azure: DoPollForAsynchronous stopped polling before receiving a terminated OperationResource")
-	}
-
-	autorest.Respond(r,
-		autorest.ByClosing())
-}
-
-func TestDoPollForAsynchronous_PollsUntilOperationResourceHasSucceeded(t *testing.T) {
-	r1 := newAsynchronousResponse()
-	r2 := newOperationResourceResponse("busy")
-	r3 := newOperationResourceResponse(operationSucceeded)
-
-	client := mocks.NewSender()
-	client.AppendResponse(r1)
-	client.AppendAndRepeatResponse(r2, 2)
-	client.AppendAndRepeatResponse(r3, 1)
-
-	r, _ := autorest.SendWithSender(client, mocks.NewRequest(),
-		DoPollForAsynchronous(time.Millisecond))
-
-	if client.Attempts() < client.NumResponses() {
-		t.Fatalf("azure: DoPollForAsynchronous stopped polling before receiving a terminated OperationResource")
-	}
-
-	autorest.Respond(r,
-		autorest.ByClosing())
-}
-
-func TestDoPollForAsynchronous_StopsPollingWhenOperationResourceHasTerminated(t *testing.T) {
-	r1 := newAsynchronousResponse()
-	r2 := newOperationResourceResponse("busy")
-	r3 := newOperationResourceResponse(operationCanceled)
-
-	client := mocks.NewSender()
-	client.AppendResponse(r1)
-	client.AppendAndRepeatResponse(r2, 2)
-	client.AppendAndRepeatResponse(r3, 2)
-
-	r, _ := autorest.SendWithSender(client, mocks.NewRequest(),
-		DoPollForAsynchronous(time.Millisecond))
-
-	if client.Attempts() > 4 {
-		t.Fatalf("azure: DoPollForAsynchronous failed to stop after receiving a terminated OperationResource")
-	}
-
-	autorest.Respond(r,
-		autorest.ByClosing())
-}
-
-func TestDoPollForAsynchronous_ReturnsAnErrorForCanceledOperations(t *testing.T) {
-	r1 := newAsynchronousResponse()
-	r2 := newOperationResourceResponse("busy")
-	r3 := newOperationResourceErrorResponse(operationCanceled)
-
-	client := mocks.NewSender()
-	client.AppendResponse(r1)
-	client.AppendAndRepeatResponse(r2, 2)
-	client.AppendAndRepeatResponse(r3, 1)
-
-	r, err := autorest.SendWithSender(client, mocks.NewRequest(),
-		DoPollForAsynchronous(time.Millisecond))
-
-	if err == nil || !strings.Contains(fmt.Sprintf("%v", err), "Canceled") {
-		t.Fatalf("azure: DoPollForAsynchronous failed to return an appropriate error for a canceled OperationResource")
-	}
-
-	autorest.Respond(r,
-		autorest.ByClosing())
-}
-
-func TestDoPollForAsynchronous_ReturnsAnErrorForFailedOperations(t *testing.T) {
-	r1 := newAsynchronousResponse()
-	r2 := newOperationResourceResponse("busy")
-	r3 := newOperationResourceErrorResponse(operationFailed)
-
-	client := mocks.NewSender()
-	client.AppendResponse(r1)
-	client.AppendAndRepeatResponse(r2, 2)
-	client.AppendAndRepeatResponse(r3, 1)
-
-	r, err := autorest.SendWithSender(client, mocks.NewRequest(),
-		DoPollForAsynchronous(time.Millisecond))
-
-	if err == nil || !strings.Contains(fmt.Sprintf("%v", err), "Failed") {
-		t.Fatalf("azure: DoPollForAsynchronous failed to return an appropriate error for a canceled OperationResource")
-	}
-
-	autorest.Respond(r,
-		autorest.ByClosing())
-}
-
-func TestDoPollForAsynchronous_WithNilURI(t *testing.T) {
-	r1 := newAsynchronousResponse()
-	r1.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
-	r1.Header.Del(http.CanonicalHeaderKey(autorest.HeaderLocation))
-
-	r2 := newOperationResourceResponse("busy")
-	r2.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
-	r2.Header.Del(http.CanonicalHeaderKey(autorest.HeaderLocation))
-
-	client := mocks.NewSender()
-	client.AppendResponse(r1)
-	client.AppendResponse(r2)
-
-	req, _ := http.NewRequest("POST", "https://microsoft.com/a/b/c/", mocks.NewBody(""))
-	r, err := autorest.SendWithSender(client, req,
-		DoPollForAsynchronous(time.Millisecond))
-
-	if err == nil {
-		t.Fatalf("azure: DoPollForAsynchronous failed to return error for nil URI. got: nil; want: Azure Polling Error - Unable to obtain polling URI for POST")
-	}
-
-	autorest.Respond(r,
-		autorest.ByClosing())
-}
-
-func TestDoPollForAsynchronous_ReturnsAnUnknownErrorForFailedOperations(t *testing.T) {
-	// Return unknown error if error not present in last response
-	r1 := newAsynchronousResponse()
-	r1.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
-	r2 := newProvisioningStatusResponse("busy")
-	r2.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
-	r3 := newProvisioningStatusResponse(operationFailed)
-	r3.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
-
-	client := mocks.NewSender()
-	client.AppendResponse(r1)
-	client.AppendAndRepeatResponse(r2, 2)
-	client.AppendAndRepeatResponse(r3, 1)
-
-	r, err := autorest.SendWithSender(client, mocks.NewRequest(),
-		DoPollForAsynchronous(time.Millisecond))
-
-	expected := makeLongRunningOperationErrorString("Unknown", "None")
-	if err.Error() != expected {
-		t.Fatalf("azure: DoPollForAsynchronous failed to return an appropriate error message for an unknown error. \n expected=%q \n got=%q",
-			expected, err.Error())
-	}
-
-	autorest.Respond(r,
-		autorest.ByClosing())
-}
-
-func TestDoPollForAsynchronous_ReturnsErrorForLastErrorResponse(t *testing.T) {
-	// Return error code and message if error present in last response
-	r1 := newAsynchronousResponse()
-	r1.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
-	r2 := newProvisioningStatusResponse("busy")
-	r2.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
-	r3 := newAsynchronousResponseWithError("400 Bad Request", http.StatusBadRequest)
-	r3.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
-
-	client := mocks.NewSender()
-	client.AppendResponse(r1)
-	client.AppendAndRepeatResponse(r2, 2)
-	client.AppendAndRepeatResponse(r3, 1)
-
-	r, err := autorest.SendWithSender(client, mocks.NewRequest(),
-		DoPollForAsynchronous(time.Millisecond))
-
-	expected := makeLongRunningOperationErrorString("InvalidParameter", "tom-service-DISCOVERY-server-base-v1.core.local' is not a valid captured VHD blob name prefix.")
-	if err.Error() != expected {
-		t.Fatalf("azure: DoPollForAsynchronous failed to return an appropriate error message for an unknown error. \n expected=%q \n got=%q",
-			expected, err.Error())
-	}
-
-	autorest.Respond(r,
-		autorest.ByClosing())
-}
-
-func TestDoPollForAsynchronous_ReturnsOperationResourceErrorForFailedOperations(t *testing.T) {
-	// Return Operation resource response with error code and message in last operation resource response
-	r1 := newAsynchronousResponse()
-	r2 := newOperationResourceResponse("busy")
-	r3 := newOperationResourceErrorResponse(operationFailed)
-
-	client := mocks.NewSender()
-	client.AppendResponse(r1)
-	client.AppendAndRepeatResponse(r2, 2)
-	client.AppendAndRepeatResponse(r3, 1)
-
-	r, err := autorest.SendWithSender(client, mocks.NewRequest(),
-		DoPollForAsynchronous(time.Millisecond))
-
-	expected := makeLongRunningOperationErrorString("BadArgument", "The provided database 'foo' has an invalid username.")
-	if err.Error() != expected {
-		t.Fatalf("azure: DoPollForAsynchronous failed to return an appropriate error message for a failed Operations. \n expected=%q \n got=%q",
-			expected, err.Error())
-	}
-
-	autorest.Respond(r,
-		autorest.ByClosing())
-}
-
-func TestDoPollForAsynchronous_ReturnsErrorForFirstPutRequest(t *testing.T) {
-	// Return 400 bad response with error code and message in first put
-	r1 := newAsynchronousResponseWithError("400 Bad Request", http.StatusBadRequest)
-	client := mocks.NewSender()
-	client.AppendResponse(r1)
-
-	res, err := autorest.SendWithSender(client, mocks.NewRequest(),
-		DoPollForAsynchronous(time.Millisecond))
-	if err != nil {
-		t.Fatalf("azure: DoPollForAsynchronous failed to return an appropriate error message for a failed Operations. \n expected=%q \n got=%q",
-			errorResponse, err.Error())
-	}
-
-	err = autorest.Respond(res,
-		WithErrorUnlessStatusCode(http.StatusAccepted, http.StatusCreated, http.StatusOK),
-		autorest.ByClosing())
-
-	reqError, ok := err.(*RequestError)
-	if !ok {
-		t.Fatalf("azure: returned error is not azure.RequestError: %T", err)
-	}
-
-	expected := &RequestError{
-		ServiceError: &ServiceError{
-			Code:    "InvalidParameter",
-			Message: "tom-service-DISCOVERY-server-base-v1.core.local' is not a valid captured VHD blob name prefix.",
-		},
-		DetailedError: autorest.DetailedError{
-			StatusCode: 400,
-		},
-	}
-	if !reflect.DeepEqual(reqError, expected) {
-		t.Fatalf("azure: wrong error. expected=%q\ngot=%q", expected, reqError)
-	}
-
-	defer res.Body.Close()
-	b, err := ioutil.ReadAll(res.Body)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(b) != errorResponse {
-		t.Fatalf("azure: Response body is wrong. got=%q expected=%q", string(b), errorResponse)
-	}
-
-}
-
-func TestDoPollForAsynchronous_ReturnsNoErrorForSuccessfulOperations(t *testing.T) {
-	r1 := newAsynchronousResponse()
-	r2 := newOperationResourceResponse("busy")
-	r3 := newOperationResourceErrorResponse(operationSucceeded)
-
-	client := mocks.NewSender()
-	client.AppendResponse(r1)
-	client.AppendAndRepeatResponse(r2, 2)
-	client.AppendAndRepeatResponse(r3, 1)
-
-	r, err := autorest.SendWithSender(client, mocks.NewRequest(),
-		DoPollForAsynchronous(time.Millisecond))
-
-	if err != nil {
-		t.Fatalf("azure: DoPollForAsynchronous returned an error for a successful OperationResource")
-	}
-
-	autorest.Respond(r,
-		autorest.ByClosing())
-}
-
-func TestDoPollForAsynchronous_StopsPollingIfItReceivesAnInvalidOperationResource(t *testing.T) {
-	r1 := newAsynchronousResponse()
-	r2 := newOperationResourceResponse("busy")
-	r3 := newOperationResourceResponse("busy")
-	r3.Body = mocks.NewBody(operationResourceIllegal)
-	r4 := newOperationResourceResponse(operationSucceeded)
-
-	client := mocks.NewSender()
-	client.AppendResponse(r1)
-	client.AppendAndRepeatResponse(r2, 2)
-	client.AppendAndRepeatResponse(r3, 1)
-	client.AppendAndRepeatResponse(r4, 1)
-
-	r, err := autorest.SendWithSender(client, mocks.NewRequest(),
-		DoPollForAsynchronous(time.Millisecond))
-
-	if client.Attempts() > 4 {
-		t.Fatalf("azure: DoPollForAsynchronous failed to stop polling after receiving an invalid OperationResource")
-	}
-	if err == nil {
-		t.Fatalf("azure: DoPollForAsynchronous failed to return an error after receving an invalid OperationResource")
-	}
-
-	autorest.Respond(r,
-		autorest.ByClosing())
 }
 
 func TestFuture_PollsUntilProvisioningStatusSucceeds(t *testing.T) {
-	r1 := newAsynchronousResponse()
-	r1.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
-	r2 := newProvisioningStatusResponse("busy")
-	r2.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
-	r3 := newProvisioningStatusResponse(operationSucceeded)
-	r3.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
+	r2 := newOperationResourceResponse("busy")
+	r3 := newOperationResourceResponse(operationSucceeded)
 
-	client := mocks.NewSender()
-	client.AppendResponse(r1)
-	client.AppendAndRepeatResponse(r2, 2)
-	client.AppendResponse(r3)
+	sender := mocks.NewSender()
+	sender.AppendAndRepeatResponse(r2, 2)
+	sender.AppendResponse(r3)
 
-	future := NewFuture(mocks.NewRequest())
+	future, err := NewFutureFromResponse(newSimpleAsyncResp())
+	if err != nil {
+		t.Fatalf("failed to create future: %v", err)
+	}
 
-	for done, err := future.Done(client); !done; done, err = future.Done(client) {
-		if future.PollingMethod() != PollingLocation {
-			t.Fatalf("azure: wrong future polling method")
+	for done, err := future.Done(sender); !done; done, err = future.Done(sender) {
+		if future.PollingMethod() != PollingAsyncOperation {
+			t.Fatalf("wrong future polling method: %s", future.PollingMethod())
 		}
 		if err != nil {
-			t.Fatalf("azure: TestFuture polling Done failed")
+			t.Fatalf("polling Done failed: %v", err)
 		}
 		delay, ok := future.GetPollingDelay()
 		if !ok {
@@ -1052,92 +706,93 @@ func TestFuture_PollsUntilProvisioningStatusSucceeds(t *testing.T) {
 		time.Sleep(delay)
 	}
 
-	if client.Attempts() < client.NumResponses() {
-		t.Fatalf("azure: TestFuture stopped polling before receiving a terminated OperationResource")
+	if sender.Attempts() < sender.NumResponses() {
+		t.Fatalf("stopped polling before receiving a terminated OperationResource")
 	}
 
 	autorest.Respond(future.Response(),
 		autorest.ByClosing())
 }
 
-func TestFuture_Marshalling(t *testing.T) {
-	client := mocks.NewSender()
-	client.AppendResponse(newAsynchronousResponse())
-
-	future := NewFuture(mocks.NewRequest())
-	done, err := future.Done(client)
+func TestFuture_MarshallingSuccess(t *testing.T) {
+	future, err := NewFutureFromResponse(newSimpleAsyncResp())
 	if err != nil {
-		t.Fatalf("azure: TestFuture marshalling Done failed")
-	}
-	if done {
-		t.Fatalf("azure: TestFuture marshalling shouldn't be done")
-	}
-	if future.PollingMethod() != PollingAsyncOperation {
-		t.Fatalf("azure: wrong future polling method")
+		t.Fatalf("failed to create future: %v", err)
 	}
 
 	data, err := json.Marshal(future)
 	if err != nil {
-		t.Fatalf("azure: TestFuture failed to marshal")
+		t.Fatalf("failed to marshal: %v", err)
 	}
 
 	var future2 Future
 	err = json.Unmarshal(data, &future2)
 	if err != nil {
-		t.Fatalf("azure: TestFuture failed to unmarshal")
+		t.Fatalf("failed to unmarshal: %v", err)
 	}
 
-	if future.ps.ServiceError != future2.ps.ServiceError {
-		t.Fatalf("azure: TestFuture marshalling ServiceError don't match")
+	if reflect.DeepEqual(future.pt, future2.pt) {
+		t.Fatalf("marshalling unexpected match")
 	}
-	if future.ps.PollingMethod != future2.ps.PollingMethod {
-		t.Fatalf("azure: TestFuture marshalling response formats don't match")
-	}
-	if future.ps.State != future2.ps.State {
-		t.Fatalf("azure: TestFuture marshalling states don't match")
-	}
-	if future.ps.URI != future2.ps.URI {
-		t.Fatalf("azure: TestFuture marshalling URIs don't match")
+
+	// these fields don't get marshalled so nil them before deep comparison
+	future.pt.(*pollingTrackerPut).resp = nil
+	future.pt.(*pollingTrackerPut).rawBody = nil
+	if !reflect.DeepEqual(future.pt, future2.pt) {
+		t.Fatalf("marshalling futures don't match")
 	}
 }
 
-func TestFuture_MarshallingWithServiceError(t *testing.T) {
-	client := mocks.NewSender()
-	client.AppendResponse(newAsynchronousResponseWithError("400 Bad Request", http.StatusBadRequest))
+func TestFuture_MarshallingWithError(t *testing.T) {
+	future, err := NewFutureFromResponse(newAsyncResponseWithError(http.MethodPut))
+	if err != nil {
+		t.Fatalf("failed to create future: %v", err)
+	}
 
-	future := NewFuture(mocks.NewRequest())
-	done, err := future.Done(client)
+	data, err := json.Marshal(future)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	var future2 Future
+	err = json.Unmarshal(data, &future2)
+	if err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if reflect.DeepEqual(future.pt, future2.pt) {
+		t.Fatalf("marshalling unexpected match")
+	}
+
+	// these fields don't get marshalled so nil them before deep comparison
+	future.pt.(*pollingTrackerPut).resp = nil
+	future.pt.(*pollingTrackerPut).rawBody = nil
+	if !reflect.DeepEqual(future.pt, future2.pt) {
+		t.Fatalf("marshalling futures don't match")
+	}
+}
+
+func TestFuture_CreateFromFailedOperation(t *testing.T) {
+	future, err := NewFutureFromResponse(newAsyncResponseWithError(http.MethodPut))
+	if err != nil {
+		t.Fatalf("failed to create future: %v", err)
+	}
+	done, err := future.Done(mocks.NewSender())
 	if err == nil {
-		t.Fatalf("azure: TestFuture marshalling didn't fail")
+		t.Fatalf("Done should have returned an error")
 	}
-	if done {
-		t.Fatalf("azure: TestFuture marshalling shouldn't be done")
-	}
-	if future.PollingMethod() != "" {
-		t.Fatalf("azure: future shouldn't have polling method")
+	if !done {
+		t.Fatalf("should be done")
 	}
 }
 
 func TestFuture_WaitForCompletion(t *testing.T) {
-	r1 := newAsynchronousResponse()
-	r1.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
-	r2 := newProvisioningStatusResponse("busy")
-	r2.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
-	r3 := newAsynchronousResponseWithError("Internal server error", http.StatusInternalServerError)
-	r3.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
-	r3.Header.Del(http.CanonicalHeaderKey("Retry-After"))
-	r4 := newProvisioningStatusResponse(operationSucceeded)
-	r4.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
+	r2 := newOperationResourceResponse("busy")
+	r3 := newOperationResourceResponse(operationSucceeded)
 
 	sender := mocks.NewSender()
-	sender.AppendResponse(r1)
-	sender.AppendError(errors.New("transient network failure"))
 	sender.AppendAndRepeatResponse(r2, 2)
 	sender.AppendResponse(r3)
-	sender.AppendResponse(r4)
-
-	future := NewFuture(mocks.NewRequest())
-
 	client := autorest.Client{
 		PollingDelay:    1 * time.Second,
 		PollingDuration: autorest.DefaultPollingDuration,
@@ -1146,13 +801,18 @@ func TestFuture_WaitForCompletion(t *testing.T) {
 		Sender:          sender,
 	}
 
-	err := future.WaitForCompletion(context.Background(), client)
+	future, err := NewFutureFromResponse(newSimpleAsyncResp())
 	if err != nil {
-		t.Fatalf("azure: WaitForCompletion returned non-nil error")
+		t.Fatalf("failed to create future: %v", err)
+	}
+
+	err = future.WaitForCompletion(context.Background(), client)
+	if err != nil {
+		t.Fatalf("WaitForCompletion returned non-nil error")
 	}
 
 	if sender.Attempts() < sender.NumResponses() {
-		t.Fatalf("azure: TestFuture stopped polling before receiving a terminated OperationResource")
+		t.Fatalf("stopped polling before receiving a terminated OperationResource")
 	}
 
 	autorest.Respond(future.Response(),
@@ -1160,16 +820,15 @@ func TestFuture_WaitForCompletion(t *testing.T) {
 }
 
 func TestFuture_WaitForCompletionTimedOut(t *testing.T) {
-	r1 := newAsynchronousResponse()
-	r1.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
 	r2 := newProvisioningStatusResponse("busy")
-	r2.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
 
 	sender := mocks.NewSender()
-	sender.AppendResponse(r1)
 	sender.AppendAndRepeatResponseWithDelay(r2, 1*time.Second, 5)
 
-	future := NewFuture(mocks.NewRequest())
+	future, err := NewFutureFromResponse(newSimpleAsyncResp())
+	if err != nil {
+		t.Fatalf("failed to create future: %v", err)
+	}
 
 	client := autorest.Client{
 		PollingDelay:    autorest.DefaultPollingDelay,
@@ -1179,21 +838,23 @@ func TestFuture_WaitForCompletionTimedOut(t *testing.T) {
 		Sender:          sender,
 	}
 
-	err := future.WaitForCompletion(context.Background(), client)
+	err = future.WaitForCompletion(context.Background(), client)
 	if err == nil {
-		t.Fatalf("azure: WaitForCompletion returned nil error, should have timed out")
+		t.Fatalf("WaitForCompletion returned nil error, should have timed out")
 	}
 }
 
 func TestFuture_WaitForCompletionRetriesExceeded(t *testing.T) {
-	r1 := newAsynchronousResponse()
-	r1.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
+	r1 := newProvisioningStatusResponse("InProgress")
 
 	sender := mocks.NewSender()
 	sender.AppendResponse(r1)
 	sender.AppendAndRepeatError(errors.New("transient network failure"), autorest.DefaultRetryAttempts+1)
 
-	future := NewFuture(mocks.NewRequest())
+	future, err := NewFutureFromResponse(newSimpleAsyncResp())
+	if err != nil {
+		t.Fatalf("failed to create future: %v", err)
+	}
 
 	client := autorest.Client{
 		PollingDelay:    autorest.DefaultPollingDelay,
@@ -1203,23 +864,22 @@ func TestFuture_WaitForCompletionRetriesExceeded(t *testing.T) {
 		Sender:          sender,
 	}
 
-	err := future.WaitForCompletion(context.Background(), client)
+	err = future.WaitForCompletion(context.Background(), client)
 	if err == nil {
-		t.Fatalf("azure: WaitForCompletion returned nil error, should have errored out")
+		t.Fatalf("WaitForCompletion returned nil error, should have errored out")
 	}
 }
 
 func TestFuture_WaitForCompletionCancelled(t *testing.T) {
-	r1 := newAsynchronousResponse()
-	r1.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
-	r2 := newProvisioningStatusResponse("busy")
-	r2.Header.Del(http.CanonicalHeaderKey(headerAsyncOperation))
+	r1 := newProvisioningStatusResponse("InProgress")
 
 	sender := mocks.NewSender()
-	sender.AppendResponse(r1)
-	sender.AppendAndRepeatResponseWithDelay(r2, 1*time.Second, 5)
+	sender.AppendAndRepeatResponseWithDelay(r1, 1*time.Second, 5)
 
-	future := NewFuture(mocks.NewRequest())
+	future, err := NewFutureFromResponse(newSimpleAsyncResp())
+	if err != nil {
+		t.Fatalf("failed to create future: %v", err)
+	}
 
 	client := autorest.Client{
 		PollingDelay:    autorest.DefaultPollingDelay,
@@ -1235,9 +895,9 @@ func TestFuture_WaitForCompletionCancelled(t *testing.T) {
 		cancel()
 	}()
 
-	err := future.WaitForCompletion(ctx, client)
+	err = future.WaitForCompletion(ctx, client)
 	if err == nil {
-		t.Fatalf("azure: WaitForCompletion returned nil error, should have been cancelled")
+		t.Fatalf("WaitForCompletion returned nil error, should have been cancelled")
 	}
 }
 
@@ -1245,6 +905,8 @@ const (
 	operationResourceIllegal = `
 	This is not JSON and should fail...badly.
 	`
+
+	// returned from LROs that use Location header
 	pollingStateFormat = `
 	{
 		"unused" : {
@@ -1256,6 +918,7 @@ const (
 	}
 	`
 
+	// returned from LROs that use Location header
 	errorResponse = `
 	{
 		"error" : {
@@ -1265,6 +928,15 @@ const (
 	}
 	`
 
+	// returned from LROs that use Location header
+	unwrappedErrorResponse = `
+	{
+		"code" : "InvalidParameter",
+		"message" : "tom-service-DISCOVERY-server-base-v1.core.local' is not a valid captured VHD blob name prefix."
+	}
+	`
+
+	// returned from LROs that use Location header
 	pollingStateEmpty = `
 	{
 		"unused" : {
@@ -1275,6 +947,7 @@ const (
 	}
 	`
 
+	// returned from LROs that use Azure-AsyncOperation header
 	operationResourceFormat = `
 	{
 		"id": "/subscriptions/id/locations/westus/operationsStatus/sameguid",
@@ -1283,11 +956,13 @@ const (
 		"startTime" : "2006-01-02T15:04:05Z",
 		"endTime" : "2006-01-02T16:04:05Z",
 		"percentComplete" : 50.00,
-
-		"properties" : {}
+		"properties" : {
+			"foo": "bar"
+		}
 	}
 	`
 
+	// returned from LROs that use Azure-AsyncOperation header
 	operationResourceErrorFormat = `
 	{
 		"id": "/subscriptions/id/locations/westus/operationsStatus/sameguid",
@@ -1296,7 +971,6 @@ const (
 		"startTime" : "2006-01-02T15:04:05Z",
 		"endTime" : "2006-01-02T16:04:05Z",
 		"percentComplete" : 50.00,
-
 		"properties" : {},
 		"error" : {
 			"code" : "BadArgument",
@@ -1306,42 +980,79 @@ const (
 	`
 )
 
-func newAsynchronousResponse() *http.Response {
-	r := mocks.NewResponseWithStatus("201 Created", http.StatusCreated)
-	r.Body = mocks.NewBody(fmt.Sprintf(pollingStateFormat, operationInProgress))
-	mocks.SetResponseHeader(r, http.CanonicalHeaderKey(headerAsyncOperation), mocks.TestAzureAsyncURL)
-	mocks.SetResponseHeader(r, http.CanonicalHeaderKey(autorest.HeaderLocation), mocks.TestLocationURL)
-	mocks.SetRetryHeader(r, retryDelay)
-	r.Request = mocks.NewRequestForURL(mocks.TestURL)
+// creates an async request with the specified body.
+func newAsyncReq(reqMethod string, body *mocks.Body) *http.Request {
+	return mocks.NewRequestWithParams(reqMethod, mocks.TestURL, body)
+}
+
+// creates an async response with the specified body.
+// the req param is the originating LRO request.
+func newAsyncResp(req *http.Request, statusCode int, body *mocks.Body) *http.Response {
+	status := "Unknown"
+	switch statusCode {
+	case http.StatusOK, http.StatusNoContent:
+		status = "Completed"
+	case http.StatusCreated:
+		status = "Creating"
+	case http.StatusAccepted:
+		status = "In progress"
+	case http.StatusBadRequest:
+		status = "Bad request"
+	}
+	r := mocks.NewResponseWithBodyAndStatus(body, statusCode, status)
+	r.Request = req
 	return r
 }
 
-func newAsynchronousResponseWithError(response string, status int) *http.Response {
-	r := mocks.NewResponseWithStatus(response, status)
-	mocks.SetRetryHeader(r, retryDelay)
-	r.Request = mocks.NewRequestForURL(mocks.TestURL)
-	r.Body = mocks.NewBody(errorResponse)
+// creates a simple LRO response, PUT/201 with Azure-AsyncOperation header
+func newSimpleAsyncResp() *http.Response {
+	r := newAsyncResp(newAsyncReq(http.MethodPut, nil), http.StatusCreated, mocks.NewBody(fmt.Sprintf(operationResourceFormat, operationInProgress)))
+	mocks.SetResponseHeader(r, headerAsyncOperation, mocks.TestAzureAsyncURL)
 	return r
 }
 
+// creates a simple LRO response, POST/201 with Location header
+func newSimpleLocationResp() *http.Response {
+	r := newAsyncResp(newAsyncReq(http.MethodPost, nil), http.StatusCreated, mocks.NewBody(fmt.Sprintf(pollingStateFormat, operationInProgress)))
+	mocks.SetResponseHeader(r, autorest.HeaderLocation, mocks.TestLocationURL)
+	return r
+}
+
+// creates an async response that contains an error (HTTP 400 + error response body)
+func newAsyncResponseWithError(reqMethod string) *http.Response {
+	return newAsyncResp(newAsyncReq(reqMethod, nil), http.StatusBadRequest, mocks.NewBody(errorResponse))
+}
+
+// creates a LRO polling response using the operation resource format (Azure-AsyncOperation LROs)
 func newOperationResourceResponse(status string) *http.Response {
-	r := newAsynchronousResponse()
-	r.Body = mocks.NewBody(fmt.Sprintf(operationResourceFormat, status))
+	r := mocks.NewResponseWithBodyAndStatus(mocks.NewBody(fmt.Sprintf(operationResourceFormat, status)), http.StatusOK, status)
+	mocks.SetRetryHeader(r, retryDelay)
 	return r
 }
 
+// creates a LRO polling error response using the operation resource format (Azure-AsyncOperation LROs)
 func newOperationResourceErrorResponse(status string) *http.Response {
-	r := newAsynchronousResponse()
-	r.Body = mocks.NewBody(fmt.Sprintf(operationResourceErrorFormat, status))
-	return r
+	return mocks.NewResponseWithBodyAndStatus(mocks.NewBody(fmt.Sprintf(operationResourceErrorFormat, status)), http.StatusBadRequest, status)
 }
 
+// creates a LRO polling response using the provisioning state format (Location LROs)
 func newProvisioningStatusResponse(status string) *http.Response {
-	r := newAsynchronousResponse()
-	r.Body = mocks.NewBody(fmt.Sprintf(pollingStateFormat, status))
+	r := mocks.NewResponseWithBodyAndStatus(mocks.NewBody(fmt.Sprintf(pollingStateFormat, status)), http.StatusOK, status)
+	mocks.SetRetryHeader(r, retryDelay)
 	return r
 }
 
-func makeLongRunningOperationErrorString(code string, message string) string {
-	return fmt.Sprintf("Long running operation terminated with status 'Failed': Code=%q Message=%q", code, message)
+// creates a LRO polling error response using the provisioning state format (Location LROs)
+func newProvisioningStatusErrorResponse(status string) *http.Response {
+	return mocks.NewResponseWithBodyAndStatus(mocks.NewBody(errorResponse), http.StatusBadRequest, status)
+}
+
+// creates a LRO polling unwrapped error response using the provisioning state format (Location LROs)
+func newProvisioningStatusUnwrappedErrorResponse(status string) *http.Response {
+	return mocks.NewResponseWithBodyAndStatus(mocks.NewBody(unwrappedErrorResponse), http.StatusBadRequest, status)
+}
+
+// adds the Azure-AsyncOperation header with the specified location to the response
+func setAsyncOpHeader(resp *http.Response, location string) {
+	mocks.SetResponseHeader(resp, http.CanonicalHeaderKey(headerAsyncOperation), location)
 }

--- a/autorest/mocks/helpers.go
+++ b/autorest/mocks/helpers.go
@@ -16,6 +16,7 @@ package mocks
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"time"
 )
@@ -72,7 +73,12 @@ func NewRequestWithCloseBodyContent(c string) *http.Request {
 
 // NewRequestForURL instantiates a new request using the passed URL.
 func NewRequestForURL(u string) *http.Request {
-	r, err := http.NewRequest("GET", u, NewBody(""))
+	return NewRequestWithParams("GET", u, NewBody(""))
+}
+
+// NewRequestWithParams instantiates a new request using the provided parameters.
+func NewRequestWithParams(method, u string, body io.Reader) *http.Request {
+	r, err := http.NewRequest(method, u, body)
 	if err != nil {
 		panic(fmt.Sprintf("mocks: ERROR (%v) parsing testing URL %s", err, u))
 	}
@@ -111,6 +117,7 @@ func NewResponseWithStatus(s string, c int) *http.Response {
 func NewResponseWithBodyAndStatus(body *Body, c int, s string) *http.Response {
 	resp := NewResponse()
 	resp.Body = body
+	resp.ContentLength = body.Length()
 	resp.Status = s
 	resp.StatusCode = c
 	return resp

--- a/autorest/mocks/mocks.go
+++ b/autorest/mocks/mocks.go
@@ -80,6 +80,14 @@ func (body *Body) reset() *Body {
 	return body
 }
 
+// Length returns the number of bytes in the body.
+func (body *Body) Length() int64 {
+	if body == nil {
+		return 0
+	}
+	return int64(len(body.b))
+}
+
 type response struct {
 	r *http.Response
 	e error

--- a/autorest/version.go
+++ b/autorest/version.go
@@ -16,5 +16,5 @@ package autorest
 
 // Version returns the semantic version (see http://semver.org).
 func Version() string {
-	return "v10.8.1"
+	return "v10.9.0"
 }


### PR DESCRIPTION
The polling mechanism for async operations is determined by the verb of
the originating request along with the HTTP status code of the initial
response; the original implementation didn't take this into account
which caused some Future types to incorrectly poll or obtain the wrong
URL for retrieving the result.
This change introduces the pollingTracker interface as an abstraction
over verb-specific polling trackers; this allows the logic to be
separated per tracker.  All shared state and methods are in the
pollingTrackerBase type.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.