### PR TITLE
IMDS retry logic should use exponential backoff.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## v10.9.1
+
+### Bug Fixes
+
+- The retry logic for MSI token requests now uses exponential backoff per the guidelines.
+- IsTemporaryNetworkError() will return true for errors that don't implement the net.Error interface.
+
 ## v10.9.0
 
 ### Deprecated Methods

--- a/autorest/adal/token.go
+++ b/autorest/adal/token.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"math"
 	"net"
 	"net/http"
 	"net/url"
@@ -690,6 +691,7 @@ func (spt *ServicePrincipalToken) refreshInternal(ctx context.Context, resource 
 }
 
 func retry(sender Sender, req *http.Request) (resp *http.Response, err error) {
+	// copied from client.go due to circular dependency
 	retries := []int{
 		http.StatusRequestTimeout,      // 408
 		http.StatusTooManyRequests,     // 429
@@ -698,8 +700,10 @@ func retry(sender Sender, req *http.Request) (resp *http.Response, err error) {
 		http.StatusServiceUnavailable,  // 503
 		http.StatusGatewayTimeout,      // 504
 	}
-	// Extra retry status codes requered
-	retries = append(retries, http.StatusNotFound,
+	// extra retry status codes specific to IMDS
+	retries = append(retries,
+		http.StatusNotFound,
+		http.StatusGone,
 		// all remaining 5xx
 		http.StatusNotImplemented,
 		http.StatusHTTPVersionNotSupported,
@@ -709,56 +713,55 @@ func retry(sender Sender, req *http.Request) (resp *http.Response, err error) {
 		http.StatusNotExtended,
 		http.StatusNetworkAuthenticationRequired)
 
+	// see https://docs.microsoft.com/en-us/azure/active-directory/managed-service-identity/how-to-use-vm-token#retry-guidance
+
+	const maxAttempts int = 5
+	const deltaDelay int = 2          // seconds
+	const maxDelay time.Duration = 60 // seconds
+
 	attempt := 0
-	maxAttempts := 5
+	delay := time.Duration(0)
 
 	for attempt < maxAttempts {
 		resp, err = sender.Do(req)
 		// retry on temporary network errors, e.g. transient network failures.
-		if (err != nil && !isTemporaryNetworkError(err)) || (err != nil && resp == nil) || resp.StatusCode == http.StatusOK || !containsInt(retries, resp.StatusCode) {
+		if (err != nil && !isTemporaryNetworkError(err)) || resp.StatusCode == http.StatusOK || !containsInt(retries, resp.StatusCode) {
 			return
 		}
 
-		if !delay(resp, req.Context().Done()) {
-			select {
-			case <-time.After(time.Second):
-				attempt++
-			case <-req.Context().Done():
-				err = req.Context().Err()
-				return
-			}
+		// perform exponential backoff with a cap.
+		// must increment attempt before calculating delay.
+		attempt++
+		delay += time.Duration(math.Pow(float64(deltaDelay), float64(attempt)))
+		if delay > maxDelay {
+			delay = maxDelay
+		}
+
+		select {
+		case <-time.After(delay * time.Second):
+			// intentionally left blank
+		case <-req.Context().Done():
+			err = req.Context().Err()
+			return
 		}
 	}
 	return
 }
 
+// returns true if the specified error is a temporary network error or false if it's not.
+// if the error doesn't implement the net.Error interface the return value is true.
 func isTemporaryNetworkError(err error) bool {
-	if netErr, ok := err.(net.Error); ok && netErr.Temporary() {
+	if netErr, ok := err.(net.Error); !ok || (ok && netErr.Temporary()) {
 		return true
 	}
 	return false
 }
 
+// returns true if slice ints contains the value n
 func containsInt(ints []int, n int) bool {
 	for _, i := range ints {
 		if i == n {
 			return true
-		}
-	}
-	return false
-}
-
-func delay(resp *http.Response, cancel <-chan struct{}) bool {
-	if resp == nil {
-		return false
-	}
-	retryAfter, _ := strconv.Atoi(resp.Header.Get("Retry-After"))
-	if resp.StatusCode == http.StatusTooManyRequests && retryAfter > 0 {
-		select {
-		case <-time.After(time.Duration(retryAfter) * time.Second):
-			return true
-		case <-cancel:
-			return false
 		}
 	}
 	return false

--- a/autorest/utility.go
+++ b/autorest/utility.go
@@ -218,9 +218,10 @@ func IsTokenRefreshError(err error) bool {
 	return false
 }
 
-// IsTemporaryNetworkError returns true if the specified error is a temporary network error.
+// IsTemporaryNetworkError returns true if the specified error is a temporary network error or false
+// if it's not.  If the error doesn't implement the net.Error interface the return value is true.
 func IsTemporaryNetworkError(err error) bool {
-	if netErr, ok := err.(net.Error); ok && netErr.Temporary() {
+	if netErr, ok := err.(net.Error); !ok || (ok && netErr.Temporary()) {
 		return true
 	}
 	return false

--- a/autorest/version.go
+++ b/autorest/version.go
@@ -16,5 +16,5 @@ package autorest
 
 // Version returns the semantic version (see http://semver.org).
 func Version() string {
-	return "v10.9.0"
+	return "v10.9.1"
 }


### PR DESCRIPTION
Fixed retry logic to use exponential backoff per retry guidelines.
Added StatusGone to the list of IMDS-specific retry status codes.
Changed IsTemporaryNetworkError to be conservative, so errors that don't
implement the net.Error interface are now considered temporary.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.