### PR TITLE
Fix refreshing a refresh token from authorization code.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v10.9.2
+
+### Bug Fixes
+
+- Refreshing a refresh token obtained from a web app authorization code now works.
+
 ## v10.9.1
 
 ### Bug Fixes

--- a/autorest/adal/token.go
+++ b/autorest/adal/token.go
@@ -629,6 +629,14 @@ func (spt *ServicePrincipalToken) refreshInternal(ctx context.Context, resource 
 		if spt.token.RefreshToken != "" {
 			v.Set("grant_type", OAuthGrantTypeRefreshToken)
 			v.Set("refresh_token", spt.token.RefreshToken)
+			// web apps must specify client_secret when refreshing tokens
+			// see https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-protocols-oauth-code#refreshing-the-access-tokens
+			if spt.getGrantType() == OAuthGrantTypeAuthorizationCode {
+				err := spt.secret.SetAuthenticationValues(spt, &v)
+				if err != nil {
+					return err
+				}
+			}
 		} else {
 			v.Set("grant_type", spt.getGrantType())
 			err := spt.secret.SetAuthenticationValues(spt, &v)

--- a/autorest/adal/token_test.go
+++ b/autorest/adal/token_test.go
@@ -354,6 +354,19 @@ func TestServicePrincipalTokenAuthorizationCodeRefreshSetsBody(t *testing.T) {
 			t.Fatalf("adal: ServicePrincipalTokenAuthorizationCode#Refresh did not correctly set the HTTP Request Body.")
 		}
 	})
+	testServicePrincipalTokenRefreshSetsBody(t, spt, func(t *testing.T, b []byte) {
+		body := string(b)
+
+		values, _ := url.ParseQuery(body)
+		if values["client_id"][0] != "id" ||
+			values["grant_type"][0] != OAuthGrantTypeRefreshToken ||
+			values["code"][0] != "code" ||
+			values["client_secret"][0] != "clientSecret" ||
+			values["redirect_uri"][0] != "http://redirectUri/getToken" ||
+			values["resource"][0] != "resource" {
+			t.Fatalf("adal: ServicePrincipalTokenAuthorizationCode#Refresh did not correctly set the HTTP Request Body.")
+		}
+	})
 }
 
 func TestServicePrincipalTokenSecretRefreshSetsBody(t *testing.T) {
@@ -688,7 +701,8 @@ func newTokenJSON(expiresOn string, resource string) string {
 		"expires_on"   : "%s",
 		"not_before"   : "%s",
 		"resource"     : "%s",
-		"token_type"   : "Bearer"
+		"token_type"   : "Bearer",
+		"refresh_token": "ABC123"
 		}`,
 		expiresOn, expiresOn, resource)
 }

--- a/autorest/version.go
+++ b/autorest/version.go
@@ -16,5 +16,5 @@ package autorest
 
 // Version returns the semantic version (see http://semver.org).
 func Version() string {
-	return "v10.9.1"
+	return "v10.9.2"
 }


### PR DESCRIPTION
When refreshing a token obtained via a web app the client_secret field
must be set in the request body.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.