### PR TITLE
Add function to create new SPT with token and secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## v10.11.0
+
+### New Features
+
+- Added NewServicePrincipalTokenFromManualTokenSecret for creating a new SPT using a manual token and secret
+- Added method ServicePrincipalToken.MarshalTokenJSON() to marshall the inner Token
+
 ## v10.10.0
 
 ### New Features

--- a/autorest/version.go
+++ b/autorest/version.go
@@ -16,5 +16,5 @@ package autorest
 
 // Version returns the semantic version (see http://semver.org).
 func Version() string {
-	return "v10.10.0"
+	return "v10.11.0"
 }


### PR DESCRIPTION
Add a new function so an SPT can be created with a current token and
secret.

I am opening against master as opening this against the dev branch pulls in a lot of other commits. 

FIxes https://github.com/Azure/go-autorest/issues/283

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.