### PR TITLE
Add support for marshalling/unmarshalling ServicePrincipalTokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## v10.10.0
+
+### New Features
+
+- Most ServicePrincipalTokens can now be marshalled/unmarshall to/from JSON (ServicePrincipalCertificateSecret and ServicePrincipalMSISecret are not supported).
+- Added method ServicePrincipalToken.SetRefreshCallbacks().
+
 ## v10.9.2
 
 ### Bug Fixes

--- a/autorest/adal/config.go
+++ b/autorest/adal/config.go
@@ -26,10 +26,10 @@ const (
 // OAuthConfig represents the endpoints needed
 // in OAuth operations
 type OAuthConfig struct {
-	AuthorityEndpoint  url.URL
-	AuthorizeEndpoint  url.URL
-	TokenEndpoint      url.URL
-	DeviceCodeEndpoint url.URL
+	AuthorityEndpoint  url.URL `json:"authorityEndpoint"`
+	AuthorizeEndpoint  url.URL `json:"authorizeEndpoint"`
+	TokenEndpoint      url.URL `json:"tokenEndpoint"`
+	DeviceCodeEndpoint url.URL `json:"deviceCodeEndpoint"`
 }
 
 // IsZero returns true if the OAuthConfig object is zero-initialized.

--- a/autorest/adal/token.go
+++ b/autorest/adal/token.go
@@ -22,6 +22,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"math"
@@ -154,9 +155,19 @@ func (noSecret *ServicePrincipalNoSecret) SetAuthenticationValues(spt *ServicePr
 	return fmt.Errorf("Manually created ServicePrincipalToken does not contain secret material to retrieve a new access token")
 }
 
+// MarshalJSON implements the json.Marshaler interface.
+func (noSecret ServicePrincipalNoSecret) MarshalJSON() ([]byte, error) {
+	type tokenType struct {
+		Type string `json:"type"`
+	}
+	return json.Marshal(tokenType{
+		Type: "ServicePrincipalNoSecret",
+	})
+}
+
 // ServicePrincipalTokenSecret implements ServicePrincipalSecret for client_secret type authorization.
 type ServicePrincipalTokenSecret struct {
-	ClientSecret string
+	ClientSecret string `json:"value"`
 }
 
 // SetAuthenticationValues is a method of the interface ServicePrincipalSecret.
@@ -164,6 +175,18 @@ type ServicePrincipalTokenSecret struct {
 func (tokenSecret *ServicePrincipalTokenSecret) SetAuthenticationValues(spt *ServicePrincipalToken, v *url.Values) error {
 	v.Set("client_secret", tokenSecret.ClientSecret)
 	return nil
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (tokenSecret ServicePrincipalTokenSecret) MarshalJSON() ([]byte, error) {
+	type tokenType struct {
+		Type  string `json:"type"`
+		Value string `json:"value"`
+	}
+	return json.Marshal(tokenType{
+		Type:  "ServicePrincipalTokenSecret",
+		Value: tokenSecret.ClientSecret,
+	})
 }
 
 // ServicePrincipalCertificateSecret implements ServicePrincipalSecret for generic RSA cert auth with signed JWTs.
@@ -192,9 +215,9 @@ func (secret *ServicePrincipalCertificateSecret) SignJwt(spt *ServicePrincipalTo
 	token := jwt.New(jwt.SigningMethodRS256)
 	token.Header["x5t"] = thumbprint
 	token.Claims = jwt.MapClaims{
-		"aud": spt.oauthConfig.TokenEndpoint.String(),
-		"iss": spt.clientID,
-		"sub": spt.clientID,
+		"aud": spt.inner.OauthConfig.TokenEndpoint.String(),
+		"iss": spt.inner.ClientID,
+		"sub": spt.inner.ClientID,
 		"jti": base64.URLEncoding.EncodeToString(jti),
 		"nbf": time.Now().Unix(),
 		"exp": time.Now().Add(time.Hour * 24).Unix(),
@@ -217,6 +240,11 @@ func (secret *ServicePrincipalCertificateSecret) SetAuthenticationValues(spt *Se
 	return nil
 }
 
+// MarshalJSON implements the json.Marshaler interface.
+func (secret ServicePrincipalCertificateSecret) MarshalJSON() ([]byte, error) {
+	return nil, errors.New("marshalling ServicePrincipalCertificateSecret is not supported")
+}
+
 // ServicePrincipalMSISecret implements ServicePrincipalSecret for machines running the MSI Extension.
 type ServicePrincipalMSISecret struct {
 }
@@ -226,10 +254,15 @@ func (msiSecret *ServicePrincipalMSISecret) SetAuthenticationValues(spt *Service
 	return nil
 }
 
+// MarshalJSON implements the json.Marshaler interface.
+func (msiSecret ServicePrincipalMSISecret) MarshalJSON() ([]byte, error) {
+	return nil, errors.New("marshalling ServicePrincipalMSISecret is not supported")
+}
+
 // ServicePrincipalUsernamePasswordSecret implements ServicePrincipalSecret for username and password auth.
 type ServicePrincipalUsernamePasswordSecret struct {
-	Username string
-	Password string
+	Username string `json:"username"`
+	Password string `json:"password"`
 }
 
 // SetAuthenticationValues is a method of the interface ServicePrincipalSecret.
@@ -239,11 +272,25 @@ func (secret *ServicePrincipalUsernamePasswordSecret) SetAuthenticationValues(sp
 	return nil
 }
 
+// MarshalJSON implements the json.Marshaler interface.
+func (secret ServicePrincipalUsernamePasswordSecret) MarshalJSON() ([]byte, error) {
+	type tokenType struct {
+		Type     string `json:"type"`
+		Username string `json:"username"`
+		Password string `json:"password"`
+	}
+	return json.Marshal(tokenType{
+		Type:     "ServicePrincipalUsernamePasswordSecret",
+		Username: secret.Username,
+		Password: secret.Password,
+	})
+}
+
 // ServicePrincipalAuthorizationCodeSecret implements ServicePrincipalSecret for authorization code auth.
 type ServicePrincipalAuthorizationCodeSecret struct {
-	ClientSecret      string
-	AuthorizationCode string
-	RedirectURI       string
+	ClientSecret      string `json:"value"`
+	AuthorizationCode string `json:"authCode"`
+	RedirectURI       string `json:"redirect"`
 }
 
 // SetAuthenticationValues is a method of the interface ServicePrincipalSecret.
@@ -254,19 +301,83 @@ func (secret *ServicePrincipalAuthorizationCodeSecret) SetAuthenticationValues(s
 	return nil
 }
 
+// MarshalJSON implements the json.Marshaler interface.
+func (secret ServicePrincipalAuthorizationCodeSecret) MarshalJSON() ([]byte, error) {
+	type tokenType struct {
+		Type     string `json:"type"`
+		Value    string `json:"value"`
+		AuthCode string `json:"authCode"`
+		Redirect string `json:"redirect"`
+	}
+	return json.Marshal(tokenType{
+		Type:     "ServicePrincipalAuthorizationCodeSecret",
+		Value:    secret.ClientSecret,
+		AuthCode: secret.AuthorizationCode,
+		Redirect: secret.RedirectURI,
+	})
+}
+
 // ServicePrincipalToken encapsulates a Token created for a Service Principal.
 type ServicePrincipalToken struct {
-	token         Token
-	secret        ServicePrincipalSecret
-	oauthConfig   OAuthConfig
-	clientID      string
-	resource      string
-	autoRefresh   bool
-	refreshLock   *sync.RWMutex
-	refreshWithin time.Duration
-	sender        Sender
-
+	inner            servicePrincipalToken
+	refreshLock      *sync.RWMutex
+	sender           Sender
 	refreshCallbacks []TokenRefreshCallback
+}
+
+// SetRefreshCallbacks replaces any existing refresh callbacks with the specified callbacks.
+func (spt *ServicePrincipalToken) SetRefreshCallbacks(callbacks []TokenRefreshCallback) {
+	spt.refreshCallbacks = callbacks
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (spt ServicePrincipalToken) MarshalJSON() ([]byte, error) {
+	return json.Marshal(spt.inner)
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (spt *ServicePrincipalToken) UnmarshalJSON(data []byte) error {
+	// need to determine the token type
+	raw := map[string]interface{}{}
+	err := json.Unmarshal(data, &raw)
+	if err != nil {
+		return err
+	}
+	secret := raw["secret"].(map[string]interface{})
+	switch secret["type"] {
+	case "ServicePrincipalNoSecret":
+		spt.inner.Secret = &ServicePrincipalNoSecret{}
+	case "ServicePrincipalTokenSecret":
+		spt.inner.Secret = &ServicePrincipalTokenSecret{}
+	case "ServicePrincipalCertificateSecret":
+		return errors.New("unmarshalling ServicePrincipalCertificateSecret is not supported")
+	case "ServicePrincipalMSISecret":
+		return errors.New("unmarshalling ServicePrincipalMSISecret is not supported")
+	case "ServicePrincipalUsernamePasswordSecret":
+		spt.inner.Secret = &ServicePrincipalUsernamePasswordSecret{}
+	case "ServicePrincipalAuthorizationCodeSecret":
+		spt.inner.Secret = &ServicePrincipalAuthorizationCodeSecret{}
+	default:
+		return fmt.Errorf("unrecognized token type '%s'", secret["type"])
+	}
+	err = json.Unmarshal(data, &spt.inner)
+	if err != nil {
+		return err
+	}
+	spt.refreshLock = &sync.RWMutex{}
+	spt.sender = &http.Client{}
+	return nil
+}
+
+// internal type used for marshalling/unmarshalling
+type servicePrincipalToken struct {
+	Token         Token                  `json:"token"`
+	Secret        ServicePrincipalSecret `json:"secret"`
+	OauthConfig   OAuthConfig            `json:"oauth"`
+	ClientID      string                 `json:"clientID"`
+	Resource      string                 `json:"resource"`
+	AutoRefresh   bool                   `json:"autoRefresh"`
+	RefreshWithin time.Duration          `json:"refreshWithin"`
 }
 
 func validateOAuthConfig(oac OAuthConfig) error {
@@ -291,13 +402,15 @@ func NewServicePrincipalTokenWithSecret(oauthConfig OAuthConfig, id string, reso
 		return nil, fmt.Errorf("parameter 'secret' cannot be nil")
 	}
 	spt := &ServicePrincipalToken{
-		oauthConfig:      oauthConfig,
-		secret:           secret,
-		clientID:         id,
-		resource:         resource,
-		autoRefresh:      true,
+		inner: servicePrincipalToken{
+			OauthConfig:   oauthConfig,
+			Secret:        secret,
+			ClientID:      id,
+			Resource:      resource,
+			AutoRefresh:   true,
+			RefreshWithin: defaultRefresh,
+		},
 		refreshLock:      &sync.RWMutex{},
-		refreshWithin:    defaultRefresh,
 		sender:           &http.Client{},
 		refreshCallbacks: callbacks,
 	}
@@ -328,7 +441,7 @@ func NewServicePrincipalTokenFromManualToken(oauthConfig OAuthConfig, clientID s
 		return nil, err
 	}
 
-	spt.token = token
+	spt.inner.Token = token
 
 	return spt, nil
 }
@@ -496,20 +609,22 @@ func newServicePrincipalTokenFromMSI(msiEndpoint, resource string, userAssignedI
 	msiEndpointURL.RawQuery = v.Encode()
 
 	spt := &ServicePrincipalToken{
-		oauthConfig: OAuthConfig{
-			TokenEndpoint: *msiEndpointURL,
+		inner: servicePrincipalToken{
+			OauthConfig: OAuthConfig{
+				TokenEndpoint: *msiEndpointURL,
+			},
+			Secret:        &ServicePrincipalMSISecret{},
+			Resource:      resource,
+			AutoRefresh:   true,
+			RefreshWithin: defaultRefresh,
 		},
-		secret:           &ServicePrincipalMSISecret{},
-		resource:         resource,
-		autoRefresh:      true,
 		refreshLock:      &sync.RWMutex{},
-		refreshWithin:    defaultRefresh,
 		sender:           &http.Client{},
 		refreshCallbacks: callbacks,
 	}
 
 	if userAssignedID != nil {
-		spt.clientID = *userAssignedID
+		spt.inner.ClientID = *userAssignedID
 	}
 
 	return spt, nil
@@ -544,12 +659,12 @@ func (spt *ServicePrincipalToken) EnsureFresh() error {
 // EnsureFreshWithContext will refresh the token if it will expire within the refresh window (as set by
 // RefreshWithin) and autoRefresh flag is on.  This method is safe for concurrent use.
 func (spt *ServicePrincipalToken) EnsureFreshWithContext(ctx context.Context) error {
-	if spt.autoRefresh && spt.token.WillExpireIn(spt.refreshWithin) {
+	if spt.inner.AutoRefresh && spt.inner.Token.WillExpireIn(spt.inner.RefreshWithin) {
 		// take the write lock then check to see if the token was already refreshed
 		spt.refreshLock.Lock()
 		defer spt.refreshLock.Unlock()
-		if spt.token.WillExpireIn(spt.refreshWithin) {
-			return spt.refreshInternal(ctx, spt.resource)
+		if spt.inner.Token.WillExpireIn(spt.inner.RefreshWithin) {
+			return spt.refreshInternal(ctx, spt.inner.Resource)
 		}
 	}
 	return nil
@@ -559,7 +674,7 @@ func (spt *ServicePrincipalToken) EnsureFreshWithContext(ctx context.Context) er
 func (spt *ServicePrincipalToken) InvokeRefreshCallbacks(token Token) error {
 	if spt.refreshCallbacks != nil {
 		for _, callback := range spt.refreshCallbacks {
-			err := callback(spt.token)
+			err := callback(spt.inner.Token)
 			if err != nil {
 				return fmt.Errorf("adal: TokenRefreshCallback handler failed. Error = '%v'", err)
 			}
@@ -579,7 +694,7 @@ func (spt *ServicePrincipalToken) Refresh() error {
 func (spt *ServicePrincipalToken) RefreshWithContext(ctx context.Context) error {
 	spt.refreshLock.Lock()
 	defer spt.refreshLock.Unlock()
-	return spt.refreshInternal(ctx, spt.resource)
+	return spt.refreshInternal(ctx, spt.inner.Resource)
 }
 
 // RefreshExchange refreshes the token, but for a different resource.
@@ -597,7 +712,7 @@ func (spt *ServicePrincipalToken) RefreshExchangeWithContext(ctx context.Context
 }
 
 func (spt *ServicePrincipalToken) getGrantType() string {
-	switch spt.secret.(type) {
+	switch spt.inner.Secret.(type) {
 	case *ServicePrincipalUsernamePasswordSecret:
 		return OAuthGrantTypeUserPass
 	case *ServicePrincipalAuthorizationCodeSecret:
@@ -616,30 +731,30 @@ func isIMDS(u url.URL) bool {
 }
 
 func (spt *ServicePrincipalToken) refreshInternal(ctx context.Context, resource string) error {
-	req, err := http.NewRequest(http.MethodPost, spt.oauthConfig.TokenEndpoint.String(), nil)
+	req, err := http.NewRequest(http.MethodPost, spt.inner.OauthConfig.TokenEndpoint.String(), nil)
 	if err != nil {
 		return fmt.Errorf("adal: Failed to build the refresh request. Error = '%v'", err)
 	}
 	req = req.WithContext(ctx)
-	if !isIMDS(spt.oauthConfig.TokenEndpoint) {
+	if !isIMDS(spt.inner.OauthConfig.TokenEndpoint) {
 		v := url.Values{}
-		v.Set("client_id", spt.clientID)
+		v.Set("client_id", spt.inner.ClientID)
 		v.Set("resource", resource)
 
-		if spt.token.RefreshToken != "" {
+		if spt.inner.Token.RefreshToken != "" {
 			v.Set("grant_type", OAuthGrantTypeRefreshToken)
-			v.Set("refresh_token", spt.token.RefreshToken)
+			v.Set("refresh_token", spt.inner.Token.RefreshToken)
 			// web apps must specify client_secret when refreshing tokens
 			// see https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-protocols-oauth-code#refreshing-the-access-tokens
 			if spt.getGrantType() == OAuthGrantTypeAuthorizationCode {
-				err := spt.secret.SetAuthenticationValues(spt, &v)
+				err := spt.inner.Secret.SetAuthenticationValues(spt, &v)
 				if err != nil {
 					return err
 				}
 			}
 		} else {
 			v.Set("grant_type", spt.getGrantType())
-			err := spt.secret.SetAuthenticationValues(spt, &v)
+			err := spt.inner.Secret.SetAuthenticationValues(spt, &v)
 			if err != nil {
 				return err
 			}
@@ -652,13 +767,13 @@ func (spt *ServicePrincipalToken) refreshInternal(ctx context.Context, resource 
 		req.Body = body
 	}
 
-	if _, ok := spt.secret.(*ServicePrincipalMSISecret); ok {
+	if _, ok := spt.inner.Secret.(*ServicePrincipalMSISecret); ok {
 		req.Method = http.MethodGet
 		req.Header.Set(metadataHeader, "true")
 	}
 
 	var resp *http.Response
-	if isIMDS(spt.oauthConfig.TokenEndpoint) {
+	if isIMDS(spt.inner.OauthConfig.TokenEndpoint) {
 		resp, err = retry(spt.sender, req)
 	} else {
 		resp, err = spt.sender.Do(req)
@@ -693,7 +808,7 @@ func (spt *ServicePrincipalToken) refreshInternal(ctx context.Context, resource 
 		return fmt.Errorf("adal: Failed to unmarshal the service principal token during refresh. Error = '%v' JSON = '%s'", err, string(rb))
 	}
 
-	spt.token = token
+	spt.inner.Token = token
 
 	return spt.InvokeRefreshCallbacks(token)
 }
@@ -777,13 +892,13 @@ func containsInt(ints []int, n int) bool {
 
 // SetAutoRefresh enables or disables automatic refreshing of stale tokens.
 func (spt *ServicePrincipalToken) SetAutoRefresh(autoRefresh bool) {
-	spt.autoRefresh = autoRefresh
+	spt.inner.AutoRefresh = autoRefresh
 }
 
 // SetRefreshWithin sets the interval within which if the token will expire, EnsureFresh will
 // refresh the token.
 func (spt *ServicePrincipalToken) SetRefreshWithin(d time.Duration) {
-	spt.refreshWithin = d
+	spt.inner.RefreshWithin = d
 	return
 }
 
@@ -795,12 +910,12 @@ func (spt *ServicePrincipalToken) SetSender(s Sender) { spt.sender = s }
 func (spt *ServicePrincipalToken) OAuthToken() string {
 	spt.refreshLock.RLock()
 	defer spt.refreshLock.RUnlock()
-	return spt.token.OAuthToken()
+	return spt.inner.Token.OAuthToken()
 }
 
 // Token returns a copy of the current token.
 func (spt *ServicePrincipalToken) Token() Token {
 	spt.refreshLock.RLock()
 	defer spt.refreshLock.RUnlock()
-	return spt.token
+	return spt.inner.Token
 }

--- a/autorest/version.go
+++ b/autorest/version.go
@@ -16,5 +16,5 @@ package autorest
 
 // Version returns the semantic version (see http://semver.org).
 func Version() string {
-	return "v10.9.2"
+	return "v10.10.0"
 }


### PR DESCRIPTION
Most ServicePrincipalToken types can now be marshalled and unmarshalled
to/from JSON, allowing them to be persisted etc.
Added method ServicePrincipalToken.SetRefreshCallbacks() so that refresh
callbacks can be added to unmarshalled SPTs (or updated in general).
Moved methods to be next to their types (no functional changes).

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.