### PR TITLE
Add additionalInfo to CloudError

### DIFF
--- a/autorest/azure/azure.go
+++ b/autorest/azure/azure.go
@@ -44,11 +44,12 @@ const (
 // ServiceError encapsulates the error response from an Azure service.
 // It adhears to the OData v4 specification for error responses.
 type ServiceError struct {
-	Code       string                   `json:"code"`
-	Message    string                   `json:"message"`
-	Target     *string                  `json:"target"`
-	Details    []map[string]interface{} `json:"details"`
-	InnerError map[string]interface{}   `json:"innererror"`
+	Code           string                   `json:"code"`
+	Message        string                   `json:"message"`
+	Target         *string                  `json:"target"`
+	Details        []map[string]interface{} `json:"details"`
+	InnerError     map[string]interface{}   `json:"innererror"`
+	AdditionalInfo []map[string]interface{} `json:"additionalInfo"`
 }
 
 func (se ServiceError) Error() string {
@@ -74,6 +75,14 @@ func (se ServiceError) Error() string {
 		result += fmt.Sprintf(" InnerError=%v", string(d))
 	}
 
+	if se.AdditionalInfo != nil {
+		d, err := json.Marshal(se.AdditionalInfo)
+		if err != nil {
+			result += fmt.Sprintf(" AdditionalInfo=%v", se.AdditionalInfo)
+		}
+		result += fmt.Sprintf(" AdditionalInfo=%v", string(d))
+	}
+
 	return result
 }
 
@@ -86,44 +95,47 @@ func (se *ServiceError) UnmarshalJSON(b []byte) error {
 	// http://docs.oasis-open.org/odata/odata-json-format/v4.0/os/odata-json-format-v4.0-os.html#_Toc372793091
 
 	type serviceError1 struct {
-		Code       string                   `json:"code"`
-		Message    string                   `json:"message"`
-		Target     *string                  `json:"target"`
-		Details    []map[string]interface{} `json:"details"`
-		InnerError map[string]interface{}   `json:"innererror"`
+		Code           string                   `json:"code"`
+		Message        string                   `json:"message"`
+		Target         *string                  `json:"target"`
+		Details        []map[string]interface{} `json:"details"`
+		InnerError     map[string]interface{}   `json:"innererror"`
+		AdditionalInfo []map[string]interface{} `json:"additionalInfo"`
 	}
 
 	type serviceError2 struct {
-		Code       string                 `json:"code"`
-		Message    string                 `json:"message"`
-		Target     *string                `json:"target"`
-		Details    map[string]interface{} `json:"details"`
-		InnerError map[string]interface{} `json:"innererror"`
+		Code           string                   `json:"code"`
+		Message        string                   `json:"message"`
+		Target         *string                  `json:"target"`
+		Details        map[string]interface{}   `json:"details"`
+		InnerError     map[string]interface{}   `json:"innererror"`
+		AdditionalInfo []map[string]interface{} `json:"additionalInfo"`
 	}
 
 	se1 := serviceError1{}
 	err := json.Unmarshal(b, &se1)
 	if err == nil {
-		se.populate(se1.Code, se1.Message, se1.Target, se1.Details, se1.InnerError)
+		se.populate(se1.Code, se1.Message, se1.Target, se1.Details, se1.InnerError, se1.AdditionalInfo)
 		return nil
 	}
 
 	se2 := serviceError2{}
 	err = json.Unmarshal(b, &se2)
 	if err == nil {
-		se.populate(se2.Code, se2.Message, se2.Target, nil, se2.InnerError)
+		se.populate(se2.Code, se2.Message, se2.Target, nil, se2.InnerError, se2.AdditionalInfo)
 		se.Details = append(se.Details, se2.Details)
 		return nil
 	}
 	return err
 }
 
-func (se *ServiceError) populate(code, message string, target *string, details []map[string]interface{}, inner map[string]interface{}) {
+func (se *ServiceError) populate(code, message string, target *string, details []map[string]interface{}, inner map[string]interface{}, additional []map[string]interface{}) {
 	se.Code = code
 	se.Message = message
 	se.Target = target
 	se.Details = details
 	se.InnerError = inner
+	se.AdditionalInfo = additional
 }
 
 // RequestError describes an error response returned by Azure service.

--- a/autorest/azure/azure_test.go
+++ b/autorest/azure/azure_test.go
@@ -241,9 +241,10 @@ func TestWithErrorUnlessStatusCode_FoundAzureFullError(t *testing.T) {
 			"code": "InternalError",
 			"message": "Azure is having trouble right now.",
 			"target": "target1",
-			"details": [{"code": "conflict1", "message":"error message1"},
+			"details": [{"code": "conflict1", "message":"error message1"}, 
 						{"code": "conflict2", "message":"error message2"}],
-			"innererror": { "customKey": "customValue" }
+			"innererror": { "customKey": "customValue" },
+			"additionalInfo": [{"type": "someErrorType", "info": {"someProperty": "someValue"}}]
 		}
 	}`
 	uuid := "71FDB9F4-5E49-4C12-B266-DE7B4FD999A6"
@@ -285,6 +286,11 @@ func TestWithErrorUnlessStatusCode_FoundAzureFullError(t *testing.T) {
 	i, _ := json.Marshal(azErr.ServiceError.InnerError)
 	if string(i) != `{"customKey":"customValue"}` {
 		t.Fatalf("azure: inner error is not unmarshaled properly")
+	}
+
+	a, _ := json.Marshal(azErr.ServiceError.AdditionalInfo)
+	if string(a) != `[{"info":{"someProperty":"someValue"},"type":"someErrorType"}]` {
+		t.Fatalf("azure: error additional info is not unmarshaled properly")
 	}
 
 	if expected := http.StatusInternalServerError; azErr.StatusCode != expected {
@@ -367,7 +373,8 @@ func TestWithErrorUnlessStatusCode_UnwrappedError(t *testing.T) {
 		"target": "target1",
 		"details": [{"code": "conflict1", "message":"error message1"},
 					{"code": "conflict2", "message":"error message2"}],
-		"innererror": { "customKey": "customValue" }
+		"innererror": { "customKey": "customValue" },
+		"additionalInfo": [{"type": "someErrorType", "info": {"someProperty": "someValue"}}]
     }`
 	uuid := "71FDB9F4-5E49-4C12-B266-DE7B4FD999A6"
 	r := mocks.NewResponseWithContent(j)
@@ -432,6 +439,15 @@ func TestWithErrorUnlessStatusCode_UnwrappedError(t *testing.T) {
 		t.Fail()
 	}
 
+	expectedServiceErrorAdditionalInfo := `[{"info":{"someProperty":"someValue"},"type":"someErrorType"}]`
+	if azErr.ServiceError.AdditionalInfo == nil {
+		t.Logf("`ServiceError.AdditionalInfo` was nil when it should have been %q", expectedServiceErrorAdditionalInfo)
+		t.Fail()
+	} else if additionalInfo, _ := json.Marshal(azErr.ServiceError.AdditionalInfo); expectedServiceErrorAdditionalInfo != string(additionalInfo) {
+		t.Logf("Additional info was not unmarshaled properly.\n\tgot:  %q\n\twant: %q", string(additionalInfo), expectedServiceErrorAdditionalInfo)
+		t.Fail()
+	}
+
 	// the error body should still be there
 	defer r.Body.Close()
 	b, err := ioutil.ReadAll(r.Body)
@@ -451,7 +467,8 @@ func TestRequestErrorString_WithError(t *testing.T) {
 			"message": "Conflict",
 			"target": "target1",
 			"details": [{"code": "conflict1", "message":"error message1"}],
-			"innererror": { "customKey": "customValue" }
+			"innererror": { "customKey": "customValue" },
+			"additionalInfo": [{"type": "someErrorType", "info": {"someProperty": "someValue"}}]
 		}
 	}`
 	uuid := "71FDB9F4-5E49-4C12-B266-DE7B4FD999A6"
@@ -469,7 +486,7 @@ func TestRequestErrorString_WithError(t *testing.T) {
 		t.Fatalf("azure: returned nil error for proper error response")
 	}
 	azErr, _ := err.(*RequestError)
-	expected := "autorest/azure: Service returned an error. Status=500 Code=\"InternalError\" Message=\"Conflict\" Target=\"target1\" Details=[{\"code\":\"conflict1\",\"message\":\"error message1\"}] InnerError={\"customKey\":\"customValue\"}"
+	expected := "autorest/azure: Service returned an error. Status=500 Code=\"InternalError\" Message=\"Conflict\" Target=\"target1\" Details=[{\"code\":\"conflict1\",\"message\":\"error message1\"}] InnerError={\"customKey\":\"customValue\"} AdditionalInfo=[{\"info\":{\"someProperty\":\"someValue\"},\"type\":\"someErrorType\"}]"
 	if expected != azErr.Error() {
 		t.Fatalf("azure: send wrong RequestError.\nexpected=%v\ngot=%v", expected, azErr.Error())
 	}


### PR DESCRIPTION
'additionalInfo', a new property added to ARM error contract, contains additional error information. For example, it will contain detailed policy violation error information when the request to ARM failed due to violation of Azure policies.

The changes are to allow deserializing additionalInfo in ARM error.


 - [x] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [x] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.