### PR TITLE
Validation code handles int and int64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v10.11.2
+
+### Bug Fixes
+
+- Validation for integers handles int and int64 types.
+
 ## v10.11.1
 
 ### Bug Fixes

--- a/autorest/validation/validation.go
+++ b/autorest/validation/validation.go
@@ -136,29 +136,29 @@ func validatePtr(x reflect.Value, v Constraint) error {
 
 func validateInt(x reflect.Value, v Constraint) error {
 	i := x.Int()
-	r, ok := v.Rule.(int)
+	r, ok := toInt64(v.Rule)
 	if !ok {
 		return createError(x, v, fmt.Sprintf("rule must be integer value for %v constraint; got: %v", v.Name, v.Rule))
 	}
 	switch v.Name {
 	case MultipleOf:
-		if i%int64(r) != 0 {
+		if i%r != 0 {
 			return createError(x, v, fmt.Sprintf("value must be a multiple of %v", r))
 		}
 	case ExclusiveMinimum:
-		if i <= int64(r) {
+		if i <= r {
 			return createError(x, v, fmt.Sprintf("value must be greater than %v", r))
 		}
 	case ExclusiveMaximum:
-		if i >= int64(r) {
+		if i >= r {
 			return createError(x, v, fmt.Sprintf("value must be less than %v", r))
 		}
 	case InclusiveMinimum:
-		if i < int64(r) {
+		if i < r {
 			return createError(x, v, fmt.Sprintf("value must be greater than or equal to %v", r))
 		}
 	case InclusiveMaximum:
-		if i > int64(r) {
+		if i > r {
 			return createError(x, v, fmt.Sprintf("value must be less than or equal to %v", r))
 		}
 	default:
@@ -386,6 +386,17 @@ func isZero(x interface{}) bool {
 func createError(x reflect.Value, v Constraint, err string) error {
 	return fmt.Errorf("autorest/validation: validation failed: parameter=%s constraint=%s value=%#v details: %s",
 		v.Target, v.Name, getInterfaceValue(x), err)
+}
+
+func toInt64(v interface{}) (int64, bool) {
+	if i64, ok := v.(int64); ok {
+		return i64, true
+	}
+	// older generators emit max constants as int, so if int64 fails fall back to int
+	if i32, ok := v.(int); ok {
+		return int64(i32), true
+	}
+	return 0, false
 }
 
 // NewErrorWithValidationError appends package type and method name in

--- a/autorest/validation/validation_test.go
+++ b/autorest/validation/validation_test.go
@@ -1090,7 +1090,7 @@ func TestValidateInt_inclusiveMaximumConstraintValid(t *testing.T) {
 	c := Constraint{
 		Target: "str",
 		Name:   InclusiveMaximum,
-		Rule:   2,
+		Rule:   int64(2),
 		Chain:  nil,
 	}
 	require.Nil(t, validateInt(reflect.ValueOf(1), c))
@@ -1101,7 +1101,7 @@ func TestValidateInt_inclusiveMaximumConstraintInvalid(t *testing.T) {
 	c := Constraint{
 		Target: "str",
 		Name:   InclusiveMaximum,
-		Rule:   1,
+		Rule:   int64(1),
 		Chain:  nil,
 	}
 	require.Equal(t, validateInt(reflect.ValueOf(x), c).Error(),
@@ -1112,7 +1112,7 @@ func TestValidateInt_inclusiveMaximumConstraintBoundary(t *testing.T) {
 	c := Constraint{
 		Target: "str",
 		Name:   InclusiveMaximum,
-		Rule:   1,
+		Rule:   int64(1),
 		Chain:  nil,
 	}
 	require.Nil(t, validateInt(reflect.ValueOf(1), c))

--- a/autorest/version.go
+++ b/autorest/version.go
@@ -16,5 +16,5 @@ package autorest
 
 // Version returns the semantic version (see http://semver.org).
 func Version() string {
-	return "v10.11.1"
+	return "v10.11.2"
 }


### PR DESCRIPTION
Ensure that integer validation can handle int and int64.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.