### PR TITLE
Various bug fixes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## v10.11.3
+
+### Bug Fixes
+
+- In IMDS retry logic, if we don't receive a response don't retry.
+  - Renamed the retry function so it's clear it's meant for IMDS only.
+- For error response bodies that aren't OData-v4 compliant stick the raw JSON in the ServiceError.Details field so the information isn't lost.
+  - Also add the raw HTTP response to the DetailedResponse.
+- Removed superfluous wrapping of response error in azure.DoRetryWithRegistration().
+
 ## v10.11.2
 
 ### Bug Fixes

--- a/autorest/azure/azure.go
+++ b/autorest/azure/azure.go
@@ -279,16 +279,29 @@ func WithErrorUnlessStatusCode(codes ...int) autorest.RespondDecorator {
 				resp.Body = ioutil.NopCloser(&b)
 				if decodeErr != nil {
 					return fmt.Errorf("autorest/azure: error response cannot be parsed: %q error: %v", b.String(), decodeErr)
-				} else if e.ServiceError == nil {
+				}
+				if e.ServiceError == nil {
 					// Check if error is unwrapped ServiceError
-					if err := json.Unmarshal(b.Bytes(), &e.ServiceError); err != nil || e.ServiceError.Message == "" {
-						e.ServiceError = &ServiceError{
-							Code:    "Unknown",
-							Message: "Unknown service error",
-						}
+					if err := json.Unmarshal(b.Bytes(), &e.ServiceError); err != nil {
+						return err
 					}
 				}
-
+				if e.ServiceError.Message == "" {
+					// if we're here it means the returned error wasn't OData v4 compliant.
+					// try to unmarshal the body as raw JSON in hopes of getting something.
+					rawBody := map[string]interface{}{}
+					if err := json.Unmarshal(b.Bytes(), &rawBody); err != nil {
+						return err
+					}
+					e.ServiceError = &ServiceError{
+						Code:    "Unknown",
+						Message: "Unknown service error",
+					}
+					if len(rawBody) > 0 {
+						e.ServiceError.Details = []map[string]interface{}{rawBody}
+					}
+				}
+				e.Response = resp
 				e.RequestID = ExtractRequestID(resp)
 				if e.StatusCode == nil {
 					e.StatusCode = resp.StatusCode

--- a/autorest/azure/azure_test.go
+++ b/autorest/azure/azure_test.go
@@ -333,6 +333,9 @@ func TestWithErrorUnlessStatusCode_NoAzureError(t *testing.T) {
 	expected := &ServiceError{
 		Code:    "Unknown",
 		Message: "Unknown service error",
+		Details: []map[string]interface{}{
+			{"Status": "NotFound"},
+		},
 	}
 
 	if !reflect.DeepEqual(expected, azErr.ServiceError) {

--- a/autorest/azure/rp.go
+++ b/autorest/azure/rp.go
@@ -64,7 +64,7 @@ func DoRetryWithRegistration(client autorest.Client) autorest.SendDecorator {
 					}
 				}
 			}
-			return resp, fmt.Errorf("failed request: %s", err)
+			return resp, err
 		})
 	}
 }

--- a/autorest/version.go
+++ b/autorest/version.go
@@ -16,5 +16,5 @@ package autorest
 
 // Version returns the semantic version (see http://semver.org).
 func Version() string {
-	return "v10.11.2"
+	return "v10.11.3"
 }


### PR DESCRIPTION
In IMDS retry logic, if we don't receive a response don't retry.
For error response bodies that aren't OData-v4 compliant stick the raw
JSON in the ServiceError.Details field so the information isn't lost.
Removed superfluous wrapping of response error in
azure.DoRetryWithRegistration.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.