### PR TITLE
Fix panic in LRO implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## v10.11.4
+
+### Bug Fixes
+
+- If an LRO returns http.StatusOK on the initial response with no async headers return the response body from Future.GetResult().
+- If there is no "final GET URL" return an error from Future.GetResult().
+
 ## v10.11.3
 
 ### Bug Fixes

--- a/autorest/azure/async.go
+++ b/autorest/azure/async.go
@@ -247,8 +247,8 @@ func (f Future) GetResult(sender autorest.Sender) (*http.Response, error) {
 	if f.pt.finalGetURL() == "" {
 		// we can end up in this situation if the async operation returns a 200
 		// with no polling URLs.  in that case return the response which should
-		// contain the JSON payload.
-		if lr := f.pt.latestResponse(); lr != nil {
+		// contain the JSON payload (only do this for successful terminal cases).
+		if lr := f.pt.latestResponse(); lr != nil && f.pt.hasSucceeded() {
 			return lr, nil
 		}
 		return nil, autorest.NewError("Future", "GetResult", "missing URL for retrieving result")

--- a/autorest/azure/async_test.go
+++ b/autorest/azure/async_test.go
@@ -959,6 +959,22 @@ func TestFuture_GetResultFromNonAsyncOperation(t *testing.T) {
 	}
 }
 
+func TestFuture_GetResultNonTerminal(t *testing.T) {
+	resp := newAsyncResp(newAsyncReq(http.MethodDelete, nil), http.StatusAccepted, mocks.NewBody(fmt.Sprintf(operationResourceFormat, operationInProgress)))
+	mocks.SetResponseHeader(resp, headerAsyncOperation, mocks.TestAzureAsyncURL)
+	future, err := NewFutureFromResponse(resp)
+	if err != nil {
+		t.Fatalf("failed to create future: %v", err)
+	}
+	res, err := future.GetResult(nil)
+	if err == nil {
+		t.Fatal("expected non-nil error")
+	}
+	if res != nil {
+		t.Fatal("expected nil result")
+	}
+}
+
 const (
 	operationResourceIllegal = `
 	This is not JSON and should fail...badly.

--- a/autorest/azure/async_test.go
+++ b/autorest/azure/async_test.go
@@ -934,6 +934,31 @@ func TestFuture_WaitForCompletionCancelled(t *testing.T) {
 	}
 }
 
+func TestFuture_GetResultFromNonAsyncOperation(t *testing.T) {
+	resp := newAsyncResp(newAsyncReq(http.MethodPost, nil), http.StatusOK, mocks.NewBody(someResource))
+	future, err := NewFutureFromResponse(resp)
+	if err != nil {
+		t.Fatalf("failed to create tracker: %v", err)
+	}
+	if pm := future.PollingMethod(); pm != PollingUnknown {
+		t.Fatalf("wrong polling method: %s", pm)
+	}
+	done, err := future.Done(nil)
+	if err != nil {
+		t.Fatalf("failed to check status: %v", err)
+	}
+	if !done {
+		t.Fatal("operation should be done")
+	}
+	res, err := future.GetResult(nil)
+	if err != nil {
+		t.Fatalf("failed to get result: %v", err)
+	}
+	if res != resp {
+		t.Fatal("result and response don't match")
+	}
+}
+
 const (
 	operationResourceIllegal = `
 	This is not JSON and should fail...badly.
@@ -1009,6 +1034,17 @@ const (
 			"code" : "BadArgument",
 			"message" : "The provided database 'foo' has an invalid username."
 		}
+	}
+	`
+
+	// returned from an operation marked as LRO but really isn't
+	someResource = `
+	{
+		"id": "/subscriptions/guid/resourceGroups/rg/providers/something/else/thing",
+		"name": "thing",
+		"type": "Imaginary.type",
+		"location": "Central US",
+		"properties": {}
 	}
 	`
 )

--- a/autorest/version.go
+++ b/autorest/version.go
@@ -16,5 +16,5 @@ package autorest
 
 // Version returns the semantic version (see http://semver.org).
 func Version() string {
-	return "v10.11.3"
+	return "v10.11.4"
 }


### PR DESCRIPTION
If an LRO returns http.StatusOK on the initial response with no async
headers return the response body from Future.GetResult().
If there is no "final GET URL" return an error.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.