### PR TITLE
Make refreshing MSI tokens have configurable cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New Features
 
-- Added field ServicePrincipalToken.MaxMSIRefreshAttempts to configure the maximun number of attempts to refresh an MSI token (default is five).
+- Added field ServicePrincipalToken.MaxMSIRefreshAttempts to configure the maximun number of attempts to refresh an MSI token.
 
 ## v10.11.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v10.12.0
+
+### New Features
+
+- Added field ServicePrincipalToken.MaxMSIRefreshAttempts to configure the maximun number of attempts to refresh an MSI token (default is five).
+
 ## v10.11.4
 
 ### Bug Fixes

--- a/autorest/adal/token.go
+++ b/autorest/adal/token.go
@@ -61,6 +61,9 @@ const (
 
 	// msiEndpoint is the well known endpoint for getting MSI authentications tokens
 	msiEndpoint = "http://169.254.169.254/metadata/identity/oauth2/token"
+
+	// the default number of attempts to refresh an MSI authentication token
+	defaultMaxMSIRefreshAttempts = 5
 )
 
 // OAuthTokenProvider is an interface which should be implemented by an access token retriever
@@ -323,7 +326,7 @@ type ServicePrincipalToken struct {
 	refreshLock      *sync.RWMutex
 	sender           Sender
 	refreshCallbacks []TokenRefreshCallback
-	// MaxMSIRefreshAttempts is the maximum number of attempts to refresh an MSI token.  The default is five.
+	// MaxMSIRefreshAttempts is the maximum number of attempts to refresh an MSI token.
 	MaxMSIRefreshAttempts int
 }
 
@@ -660,7 +663,7 @@ func newServicePrincipalTokenFromMSI(msiEndpoint, resource string, userAssignedI
 		refreshLock:           &sync.RWMutex{},
 		sender:                &http.Client{},
 		refreshCallbacks:      callbacks,
-		MaxMSIRefreshAttempts: 5,
+		MaxMSIRefreshAttempts: defaultMaxMSIRefreshAttempts,
 	}
 
 	if userAssignedID != nil {

--- a/autorest/version.go
+++ b/autorest/version.go
@@ -16,5 +16,5 @@ package autorest
 
 // Version returns the semantic version (see http://semver.org).
 func Version() string {
-	return "v10.11.4"
+	return "v10.12.0"
 }


### PR DESCRIPTION
Added field MaxMSIRefreshAttempts to ServicePrincipalToken with a
default value of five.  Removed hard-coded cap of five attempts.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.