### PR TITLE
Add basic request/respopnse logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v10.13.0
+
+- Added support for additionalInfo in ServiceError type.
+
 ## v10.12.0
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## v10.14.0
+
+### New Features
+
+- Added package version that contains version constants and user-agent data.
+
+### Bug Fixes
+
+- Add the user-agent to token requests.
+
 ## v10.13.0
 
 - Added support for additionalInfo in ServiceError type.

--- a/autorest/adal/token.go
+++ b/autorest/adal/token.go
@@ -35,6 +35,7 @@ import (
 	"time"
 
 	"github.com/Azure/go-autorest/autorest/date"
+	"github.com/Azure/go-autorest/version"
 	"github.com/dgrijalva/jwt-go"
 )
 
@@ -778,6 +779,7 @@ func (spt *ServicePrincipalToken) refreshInternal(ctx context.Context, resource 
 	if err != nil {
 		return fmt.Errorf("adal: Failed to build the refresh request. Error = '%v'", err)
 	}
+	req.Header.Add("User-Agent", version.UserAgent())
 	req = req.WithContext(ctx)
 	if !isIMDS(spt.inner.OauthConfig.TokenEndpoint) {
 		v := url.Values{}

--- a/autorest/azure/azure.go
+++ b/autorest/azure/azure.go
@@ -44,11 +44,12 @@ const (
 // ServiceError encapsulates the error response from an Azure service.
 // It adhears to the OData v4 specification for error responses.
 type ServiceError struct {
-	Code       string                   `json:"code"`
-	Message    string                   `json:"message"`
-	Target     *string                  `json:"target"`
-	Details    []map[string]interface{} `json:"details"`
-	InnerError map[string]interface{}   `json:"innererror"`
+	Code           string                   `json:"code"`
+	Message        string                   `json:"message"`
+	Target         *string                  `json:"target"`
+	Details        []map[string]interface{} `json:"details"`
+	InnerError     map[string]interface{}   `json:"innererror"`
+	AdditionalInfo []map[string]interface{} `json:"additionalInfo"`
 }
 
 func (se ServiceError) Error() string {
@@ -74,6 +75,14 @@ func (se ServiceError) Error() string {
 		result += fmt.Sprintf(" InnerError=%v", string(d))
 	}
 
+	if se.AdditionalInfo != nil {
+		d, err := json.Marshal(se.AdditionalInfo)
+		if err != nil {
+			result += fmt.Sprintf(" AdditionalInfo=%v", se.AdditionalInfo)
+		}
+		result += fmt.Sprintf(" AdditionalInfo=%v", string(d))
+	}
+
 	return result
 }
 
@@ -86,44 +95,47 @@ func (se *ServiceError) UnmarshalJSON(b []byte) error {
 	// http://docs.oasis-open.org/odata/odata-json-format/v4.0/os/odata-json-format-v4.0-os.html#_Toc372793091
 
 	type serviceError1 struct {
-		Code       string                   `json:"code"`
-		Message    string                   `json:"message"`
-		Target     *string                  `json:"target"`
-		Details    []map[string]interface{} `json:"details"`
-		InnerError map[string]interface{}   `json:"innererror"`
+		Code           string                   `json:"code"`
+		Message        string                   `json:"message"`
+		Target         *string                  `json:"target"`
+		Details        []map[string]interface{} `json:"details"`
+		InnerError     map[string]interface{}   `json:"innererror"`
+		AdditionalInfo []map[string]interface{} `json:"additionalInfo"`
 	}
 
 	type serviceError2 struct {
-		Code       string                 `json:"code"`
-		Message    string                 `json:"message"`
-		Target     *string                `json:"target"`
-		Details    map[string]interface{} `json:"details"`
-		InnerError map[string]interface{} `json:"innererror"`
+		Code           string                   `json:"code"`
+		Message        string                   `json:"message"`
+		Target         *string                  `json:"target"`
+		Details        map[string]interface{}   `json:"details"`
+		InnerError     map[string]interface{}   `json:"innererror"`
+		AdditionalInfo []map[string]interface{} `json:"additionalInfo"`
 	}
 
 	se1 := serviceError1{}
 	err := json.Unmarshal(b, &se1)
 	if err == nil {
-		se.populate(se1.Code, se1.Message, se1.Target, se1.Details, se1.InnerError)
+		se.populate(se1.Code, se1.Message, se1.Target, se1.Details, se1.InnerError, se1.AdditionalInfo)
 		return nil
 	}
 
 	se2 := serviceError2{}
 	err = json.Unmarshal(b, &se2)
 	if err == nil {
-		se.populate(se2.Code, se2.Message, se2.Target, nil, se2.InnerError)
+		se.populate(se2.Code, se2.Message, se2.Target, nil, se2.InnerError, se2.AdditionalInfo)
 		se.Details = append(se.Details, se2.Details)
 		return nil
 	}
 	return err
 }
 
-func (se *ServiceError) populate(code, message string, target *string, details []map[string]interface{}, inner map[string]interface{}) {
+func (se *ServiceError) populate(code, message string, target *string, details []map[string]interface{}, inner map[string]interface{}, additional []map[string]interface{}) {
 	se.Code = code
 	se.Message = message
 	se.Target = target
 	se.Details = details
 	se.InnerError = inner
+	se.AdditionalInfo = additional
 }
 
 // RequestError describes an error response returned by Azure service.

--- a/autorest/client.go
+++ b/autorest/client.go
@@ -22,8 +22,9 @@ import (
 	"log"
 	"net/http"
 	"net/http/cookiejar"
-	"runtime"
 	"time"
+
+	"github.com/Azure/go-autorest/version"
 )
 
 const (
@@ -41,15 +42,6 @@ const (
 )
 
 var (
-	// defaultUserAgent builds a string containing the Go version, system archityecture and OS,
-	// and the go-autorest version.
-	defaultUserAgent = fmt.Sprintf("Go/%s (%s-%s) go-autorest/%s",
-		runtime.Version(),
-		runtime.GOARCH,
-		runtime.GOOS,
-		Version(),
-	)
-
 	// StatusCodesForRetry are a defined group of status code for which the client will retry
 	StatusCodesForRetry = []int{
 		http.StatusRequestTimeout,      // 408
@@ -179,7 +171,7 @@ func NewClientWithUserAgent(ua string) Client {
 		PollingDuration: DefaultPollingDuration,
 		RetryAttempts:   DefaultRetryAttempts,
 		RetryDuration:   DefaultRetryDuration,
-		UserAgent:       defaultUserAgent,
+		UserAgent:       version.UserAgent(),
 	}
 	c.Sender = c.sender()
 	c.AddToUserAgent(ua)

--- a/autorest/client_test.go
+++ b/autorest/client_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/Azure/go-autorest/autorest/mocks"
+	"github.com/Azure/go-autorest/version"
 )
 
 func TestLoggingInspectorWithInspection(t *testing.T) {
@@ -126,7 +127,7 @@ func TestLoggingInspectorByInspectingRestoresBody(t *testing.T) {
 func TestNewClientWithUserAgent(t *testing.T) {
 	ua := "UserAgent"
 	c := NewClientWithUserAgent(ua)
-	completeUA := fmt.Sprintf("%s %s", defaultUserAgent, ua)
+	completeUA := fmt.Sprintf("%s %s", version.UserAgent(), ua)
 
 	if c.UserAgent != completeUA {
 		t.Fatalf("autorest: NewClientWithUserAgent failed to set the UserAgent -- expected %s, received %s",
@@ -142,7 +143,7 @@ func TestAddToUserAgent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("autorest: AddToUserAgent returned error -- expected nil, received %s", err)
 	}
-	completeUA := fmt.Sprintf("%s %s %s", defaultUserAgent, ua, ext)
+	completeUA := fmt.Sprintf("%s %s %s", version.UserAgent(), ua, ext)
 
 	if c.UserAgent != completeUA {
 		t.Fatalf("autorest: AddToUserAgent failed to add an extension to the UserAgent -- expected %s, received %s",

--- a/autorest/logger/logger.go
+++ b/autorest/logger/logger.go
@@ -1,0 +1,213 @@
+package logger
+
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// LevelType tells a logger the minimum level to log. When code reports a log entry,
+// the LogLevel indicates the level of the log entry. The logger only records entries
+// whose level is at least the level it was told to log. See the Log* constants.
+// For example, if a logger is configured with LogError, then LogError, LogPanic,
+// and LogFatal entries will be logged; lower level entries are ignored.
+type LevelType uint32
+
+const (
+	// LogNone tells a logger not to log any entries passed to it.
+	LogNone LevelType = iota
+
+	// LogFatal tells a logger to log all LogFatal entries passed to it.
+	LogFatal
+
+	// LogPanic tells a logger to log all LogPanic and LogFatal entries passed to it.
+	LogPanic
+
+	// LogError tells a logger to log all LogError, LogPanic and LogFatal entries passed to it.
+	LogError
+
+	// LogWarning tells a logger to log all LogWarning, LogError, LogPanic and LogFatal entries passed to it.
+	LogWarning
+
+	// LogInfo tells a logger to log all LogInfo, LogWarning, LogError, LogPanic and LogFatal entries passed to it.
+	LogInfo
+
+	// LogDebug tells a logger to log all LogDebug, LogInfo, LogWarning, LogError, LogPanic and LogFatal entries passed to it.
+	LogDebug
+)
+
+// ParseLevel converts the specified string into the corresponding LevelType.
+func ParseLevel(s string) (lt LevelType, err error) {
+	switch strings.ToLower(s) {
+	case "fatal":
+		lt = LogFatal
+	case "panic":
+		lt = LogPanic
+	case "error":
+		lt = LogError
+	case "warning":
+		lt = LogWarning
+	case "info":
+		lt = LogInfo
+	case "debug":
+		lt = LogDebug
+	default:
+		err = fmt.Errorf("bad log level '%s'", s)
+	}
+	return
+}
+
+// String implements the stringer interface for LevelType.
+func (lt LevelType) String() string {
+	switch lt {
+	case LogNone:
+		return "NONE"
+	case LogFatal:
+		return "FATAL"
+	case LogPanic:
+		return "PANIC"
+	case LogError:
+		return "ERROR"
+	case LogWarning:
+		return "WARNING"
+	case LogInfo:
+		return "INFO"
+	case LogDebug:
+		return "DEBUG"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+const (
+	// this format provides a fixed number of digits so the size of the timestamp is constant
+	logTimestamp = "2006-01-02T15:04:05.0000000Z07:00"
+)
+
+// Writer defines methods for writing to a logging facility.
+type Writer interface {
+	// Writeln writes the specified message with the standard log entry header and new-line character.
+	Writeln(level LevelType, message string)
+
+	// Writef writes the specified format specifier with the standard log entry header and no new-line character.
+	Writef(level LevelType, format string, a ...interface{})
+
+	// WriteRequest writes the specified HTTP request to the logger if the log level is greater than
+	// or equal to LogInfo.  The request body, if set, is logged at level LogDebug or higher.
+	WriteRequest(req *http.Request)
+
+	// WriteResponse writes the specified HTTP response to the logger if the log level is greater than
+	// or equal to LogInfo.  The response body, if set, is logged at level LogDebug or higher.
+	WriteResponse(resp *http.Response)
+}
+
+type fileLogger struct {
+	logLevel LevelType
+	logFile  *os.File
+}
+
+// NewFileLogger creates a file-based logger that logs messages of the specified level.
+// A File is used instead of a Logger so the stream can be flushed after every write.
+func NewFileLogger(level LevelType, dest *os.File) Writer {
+	return fileLogger{
+		logLevel: level,
+		logFile:  dest,
+	}
+}
+
+func (fl fileLogger) Writeln(level LevelType, message string) {
+	fl.Writef(level, "%s\n", message)
+}
+
+func (fl fileLogger) Writef(level LevelType, format string, a ...interface{}) {
+	if fl.logLevel >= level {
+		fmt.Fprintf(fl.logFile, "%s %s", entryHeader(level), fmt.Sprintf(format, a...))
+		fl.logFile.Sync()
+	}
+}
+
+func (fl fileLogger) WriteRequest(req *http.Request) {
+	if fl.logLevel >= LogInfo {
+		b := &bytes.Buffer{}
+		fmt.Fprintf(b, "%s REQUEST: %s %s\n", entryHeader(LogInfo), req.Method, req.URL.String())
+		// dump headers
+		for k, v := range req.Header {
+			if strings.ToLower(k) == "authorization" {
+				v = []string{"**REDACTED**"}
+			}
+			fmt.Fprintf(b, "%s: %s\n", k, strings.Join(v, ","))
+		}
+		if fl.shouldLogBody(req.Header, req.Body) {
+			// dump body
+			body, err := ioutil.ReadAll(req.Body)
+			if err == nil {
+				fmt.Fprintln(b, string(body))
+				if nc, ok := req.Body.(io.Seeker); ok {
+					// rewind to the beginning
+					nc.Seek(0, io.SeekStart)
+				} else {
+					// recreate the body
+					req.Body = ioutil.NopCloser(bytes.NewReader(body))
+				}
+			} else {
+				fmt.Fprintf(b, "failed to read body: %v", err)
+			}
+		}
+		fmt.Fprintln(fl.logFile, b.String())
+		fl.logFile.Sync()
+	}
+}
+
+func (fl fileLogger) WriteResponse(resp *http.Response) {
+	if fl.logLevel > LogInfo {
+		b := &bytes.Buffer{}
+		fmt.Fprintf(b, "%s RESPONSE: %d %s\n", entryHeader(LogInfo), resp.StatusCode, resp.Request.URL.String())
+		// dump headers
+		for k, v := range resp.Header {
+			fmt.Fprintf(b, "%s: %s\n", k, strings.Join(v, ","))
+		}
+		if fl.shouldLogBody(resp.Header, resp.Body) {
+			// dump body
+			defer resp.Body.Close()
+			body, err := ioutil.ReadAll(resp.Body)
+			if err == nil {
+				fmt.Fprintln(b, string(body))
+				resp.Body = ioutil.NopCloser(bytes.NewReader(body))
+			} else {
+				fmt.Fprintf(b, "failed to read body: %v", err)
+			}
+		}
+		fmt.Fprintln(fl.logFile, b.String())
+		fl.logFile.Sync()
+	}
+}
+
+// returns true if the provided body should be included in the log
+func (fl fileLogger) shouldLogBody(header http.Header, body io.ReadCloser) bool {
+	ct := header.Get("Content-Type")
+	return fl.logLevel >= LogDebug && body != nil && strings.Index(ct, "application/octet-stream") == -1
+}
+
+// creates standard header for log entries, it contains a timestamp and the log level
+func entryHeader(level LevelType) string {
+	return fmt.Sprintf("(%s) %s:", time.Now().Format(logTimestamp), level.String())
+}

--- a/autorest/version.go
+++ b/autorest/version.go
@@ -16,5 +16,5 @@ package autorest
 
 // Version returns the semantic version (see http://semver.org).
 func Version() string {
-	return "v10.12.0"
+	return "v10.13.0"
 }

--- a/version/version.go
+++ b/version/version.go
@@ -1,6 +1,4 @@
-package autorest
-
-import "github.com/Azure/go-autorest/version"
+package version
 
 // Copyright 2017 Microsoft Corporation
 //
@@ -16,7 +14,24 @@ import "github.com/Azure/go-autorest/version"
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-// Version returns the semantic version (see http://semver.org).
-func Version() string {
-	return version.Number
+import (
+	"fmt"
+	"runtime"
+)
+
+// Number contains the semantic version of this SDK.
+const Number = "v10.14.0"
+
+var (
+	userAgent = fmt.Sprintf("Go/%s (%s-%s) go-autorest/%s",
+		runtime.Version(),
+		runtime.GOARCH,
+		runtime.GOOS,
+		Number,
+	)
+)
+
+// UserAgent returns a string containing the Go version, system archityecture and OS, and the go-autorest version.
+func UserAgent() string {
+	return userAgent
 }


### PR DESCRIPTION
Added basic logging inspectors that are hooked up to the default client.
They are off by default but can be enabled by setting environment
variable AZURE_GO_AUTOREST_LOG_LEVEL to one of two values.
basic - includes URL and headers
full - everything in basic plus request/response bodies
The value of the Authorization header is redacted to avoid inadvertently
leaking access tokens.
Each request/response includes a timestamp.
Logging spew defaults to stderr but can be written to stdout or a log
file by setting AZURE_GO_AUTOREST_LOG_FILE with the desired destination.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.