### PR TITLE
Include user-agent info in token requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## v10.14.0
+
+### New Features
+
+- Added package version that contains version constants and user-agent data.
+
+### Bug Fixes
+
+- Add the user-agent to token requests.
+
 ## v10.13.0
 
 - Added support for additionalInfo in ServiceError type.

--- a/autorest/adal/token.go
+++ b/autorest/adal/token.go
@@ -779,7 +779,7 @@ func (spt *ServicePrincipalToken) refreshInternal(ctx context.Context, resource 
 	if err != nil {
 		return fmt.Errorf("adal: Failed to build the refresh request. Error = '%v'", err)
 	}
-	req.Header.Add("User-Agent", version.UserAgent)
+	req.Header.Add("User-Agent", version.UserAgent())
 	req = req.WithContext(ctx)
 	if !isIMDS(spt.inner.OauthConfig.TokenEndpoint) {
 		v := url.Values{}

--- a/autorest/adal/token.go
+++ b/autorest/adal/token.go
@@ -35,6 +35,7 @@ import (
 	"time"
 
 	"github.com/Azure/go-autorest/autorest/date"
+	"github.com/Azure/go-autorest/version"
 	"github.com/dgrijalva/jwt-go"
 )
 
@@ -778,6 +779,7 @@ func (spt *ServicePrincipalToken) refreshInternal(ctx context.Context, resource 
 	if err != nil {
 		return fmt.Errorf("adal: Failed to build the refresh request. Error = '%v'", err)
 	}
+	req.Header.Add("User-Agent", version.UserAgent)
 	req = req.WithContext(ctx)
 	if !isIMDS(spt.inner.OauthConfig.TokenEndpoint) {
 		v := url.Values{}

--- a/autorest/client.go
+++ b/autorest/client.go
@@ -22,8 +22,9 @@ import (
 	"log"
 	"net/http"
 	"net/http/cookiejar"
-	"runtime"
 	"time"
+
+	"github.com/Azure/go-autorest/version"
 )
 
 const (
@@ -41,15 +42,6 @@ const (
 )
 
 var (
-	// defaultUserAgent builds a string containing the Go version, system archityecture and OS,
-	// and the go-autorest version.
-	defaultUserAgent = fmt.Sprintf("Go/%s (%s-%s) go-autorest/%s",
-		runtime.Version(),
-		runtime.GOARCH,
-		runtime.GOOS,
-		Version(),
-	)
-
 	// StatusCodesForRetry are a defined group of status code for which the client will retry
 	StatusCodesForRetry = []int{
 		http.StatusRequestTimeout,      // 408
@@ -179,7 +171,7 @@ func NewClientWithUserAgent(ua string) Client {
 		PollingDuration: DefaultPollingDuration,
 		RetryAttempts:   DefaultRetryAttempts,
 		RetryDuration:   DefaultRetryDuration,
-		UserAgent:       defaultUserAgent,
+		UserAgent:       version.UserAgent,
 	}
 	c.Sender = c.sender()
 	c.AddToUserAgent(ua)

--- a/autorest/client.go
+++ b/autorest/client.go
@@ -171,7 +171,7 @@ func NewClientWithUserAgent(ua string) Client {
 		PollingDuration: DefaultPollingDuration,
 		RetryAttempts:   DefaultRetryAttempts,
 		RetryDuration:   DefaultRetryDuration,
-		UserAgent:       version.UserAgent,
+		UserAgent:       version.UserAgent(),
 	}
 	c.Sender = c.sender()
 	c.AddToUserAgent(ua)

--- a/autorest/client_test.go
+++ b/autorest/client_test.go
@@ -127,7 +127,7 @@ func TestLoggingInspectorByInspectingRestoresBody(t *testing.T) {
 func TestNewClientWithUserAgent(t *testing.T) {
 	ua := "UserAgent"
 	c := NewClientWithUserAgent(ua)
-	completeUA := fmt.Sprintf("%s %s", version.UserAgent, ua)
+	completeUA := fmt.Sprintf("%s %s", version.UserAgent(), ua)
 
 	if c.UserAgent != completeUA {
 		t.Fatalf("autorest: NewClientWithUserAgent failed to set the UserAgent -- expected %s, received %s",
@@ -143,7 +143,7 @@ func TestAddToUserAgent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("autorest: AddToUserAgent returned error -- expected nil, received %s", err)
 	}
-	completeUA := fmt.Sprintf("%s %s %s", version.UserAgent, ua, ext)
+	completeUA := fmt.Sprintf("%s %s %s", version.UserAgent(), ua, ext)
 
 	if c.UserAgent != completeUA {
 		t.Fatalf("autorest: AddToUserAgent failed to add an extension to the UserAgent -- expected %s, received %s",

--- a/autorest/client_test.go
+++ b/autorest/client_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/Azure/go-autorest/autorest/mocks"
+	"github.com/Azure/go-autorest/version"
 )
 
 func TestLoggingInspectorWithInspection(t *testing.T) {
@@ -126,7 +127,7 @@ func TestLoggingInspectorByInspectingRestoresBody(t *testing.T) {
 func TestNewClientWithUserAgent(t *testing.T) {
 	ua := "UserAgent"
 	c := NewClientWithUserAgent(ua)
-	completeUA := fmt.Sprintf("%s %s", defaultUserAgent, ua)
+	completeUA := fmt.Sprintf("%s %s", version.UserAgent, ua)
 
 	if c.UserAgent != completeUA {
 		t.Fatalf("autorest: NewClientWithUserAgent failed to set the UserAgent -- expected %s, received %s",
@@ -142,7 +143,7 @@ func TestAddToUserAgent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("autorest: AddToUserAgent returned error -- expected nil, received %s", err)
 	}
-	completeUA := fmt.Sprintf("%s %s %s", defaultUserAgent, ua, ext)
+	completeUA := fmt.Sprintf("%s %s %s", version.UserAgent, ua, ext)
 
 	if c.UserAgent != completeUA {
 		t.Fatalf("autorest: AddToUserAgent failed to add an extension to the UserAgent -- expected %s, received %s",

--- a/version/version.go
+++ b/version/version.go
@@ -23,12 +23,15 @@ import (
 const Number = "v10.14.0"
 
 var (
-	// UserAgent builds a string containing the Go version, system archityecture and OS,
-	// and the go-autorest version.
-	UserAgent = fmt.Sprintf("Go/%s (%s-%s) go-autorest/%s",
+	userAgent = fmt.Sprintf("Go/%s (%s-%s) go-autorest/%s",
 		runtime.Version(),
 		runtime.GOARCH,
 		runtime.GOOS,
 		Number,
 	)
 )
+
+// UserAgent returns a string containing the Go version, system archityecture and OS, and the go-autorest version.
+func UserAgent() string {
+	return userAgent
+}

--- a/version/version.go
+++ b/version/version.go
@@ -1,6 +1,4 @@
-package autorest
-
-import "github.com/Azure/go-autorest/version"
+package version
 
 // Copyright 2017 Microsoft Corporation
 //
@@ -16,7 +14,21 @@ import "github.com/Azure/go-autorest/version"
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-// Version returns the semantic version (see http://semver.org).
-func Version() string {
-	return version.Number
-}
+import (
+	"fmt"
+	"runtime"
+)
+
+// Number contains the semantic version of this SDK.
+const Number = "v10.14.0"
+
+var (
+	// UserAgent builds a string containing the Go version, system archityecture and OS,
+	// and the go-autorest version.
+	UserAgent = fmt.Sprintf("Go/%s (%s-%s) go-autorest/%s",
+		runtime.Version(),
+		runtime.GOARCH,
+		runtime.GOOS,
+		Number,
+	)
+)


### PR DESCRIPTION
Add the standard go-autorest user-agent string to token requests.  This
required moving version info to its own package to avoid a circular
dependency.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.