### PR TITLE
Fixes for LROs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## v10.15.1
+
+### Bug Fixes
+
+- If an LRO API returns a ```Failed``` provisioning state in the initial response return an error at that point so the caller doesn't have to poll.
+- For failed LROs without an OData v4 error include the response body in the error's ```AdditionalInfo``` field to aid in diagnosing the failure.
+
 ## v10.15.0
 
 ### New Features

--- a/autorest/azure/async.go
+++ b/autorest/azure/async.go
@@ -348,6 +348,10 @@ func (pt *pollingTrackerBase) initializeState() error {
 	case http.StatusOK:
 		if ps := pt.getProvisioningState(); ps != nil {
 			pt.State = *ps
+			if pt.hasFailed() {
+				pt.updateErrorFromResponse()
+				return pt.pollingError()
+			}
 		} else {
 			pt.State = operationSucceeded
 		}
@@ -364,6 +368,7 @@ func (pt *pollingTrackerBase) initializeState() error {
 	default:
 		pt.State = operationFailed
 		pt.updateErrorFromResponse()
+		return pt.pollingError()
 	}
 	return nil
 }
@@ -422,6 +427,7 @@ func (pt *pollingTrackerBase) pollForStatus(sender autorest.Sender) error {
 
 // attempts to unmarshal a ServiceError type from the response body.
 // if that fails then make a best attempt at creating something meaningful.
+// NOTE: this assumes that the async operation has failed.
 func (pt *pollingTrackerBase) updateErrorFromResponse() {
 	var err error
 	if pt.resp.ContentLength != 0 {
@@ -431,8 +437,7 @@ func (pt *pollingTrackerBase) updateErrorFromResponse() {
 		re := respErr{}
 		defer pt.resp.Body.Close()
 		var b []byte
-		b, err = ioutil.ReadAll(pt.resp.Body)
-		if err != nil {
+		if b, err = ioutil.ReadAll(pt.resp.Body); err != nil {
 			goto Default
 		}
 		if err = json.Unmarshal(b, &re); err != nil {
@@ -445,19 +450,28 @@ func (pt *pollingTrackerBase) updateErrorFromResponse() {
 				goto Default
 			}
 		}
-		if re.ServiceError != nil {
+		// the unmarshaller will ensure re.ServiceError is non-nil
+		// even if there was no content unmarshalled so check the code.
+		if re.ServiceError.Code != "" {
 			pt.Err = re.ServiceError
 			return
 		}
 	}
 Default:
 	se := &ServiceError{
-		Code:    fmt.Sprintf("HTTP status code %v", pt.resp.StatusCode),
-		Message: pt.resp.Status,
+		Code:    pt.pollingStatus(),
+		Message: "The async operation failed.",
 	}
 	if err != nil {
 		se.InnerError = make(map[string]interface{})
 		se.InnerError["unmarshalError"] = err.Error()
+	}
+	// stick the response body into the error object in hopes
+	// it contains something useful to help diagnose the failure.
+	if len(pt.rawBody) > 0 {
+		se.AdditionalInfo = []map[string]interface{}{
+			pt.rawBody,
+		}
 	}
 	pt.Err = se
 }

--- a/autorest/azure/async_test.go
+++ b/autorest/azure/async_test.go
@@ -744,9 +744,28 @@ func TestFuture_MarshallingSuccess(t *testing.T) {
 }
 
 func TestFuture_MarshallingWithError(t *testing.T) {
-	future, err := NewFutureFromResponse(newAsyncResponseWithError(http.MethodPut))
+	r2 := newOperationResourceResponse("busy")
+	r3 := newOperationResourceErrorResponse(operationFailed)
+
+	sender := mocks.NewSender()
+	sender.AppendAndRepeatResponse(r2, 2)
+	sender.AppendResponse(r3)
+	client := autorest.Client{
+		PollingDelay:    1 * time.Second,
+		PollingDuration: autorest.DefaultPollingDuration,
+		RetryAttempts:   autorest.DefaultRetryAttempts,
+		RetryDuration:   1 * time.Second,
+		Sender:          sender,
+	}
+
+	future, err := NewFutureFromResponse(newSimpleAsyncResp())
 	if err != nil {
 		t.Fatalf("failed to create future: %v", err)
+	}
+
+	err = future.WaitForCompletion(context.Background(), client)
+	if err == nil {
+		t.Fatal("expected non-nil error")
 	}
 
 	data, err := json.Marshal(future)
@@ -773,16 +792,9 @@ func TestFuture_MarshallingWithError(t *testing.T) {
 }
 
 func TestFuture_CreateFromFailedOperation(t *testing.T) {
-	future, err := NewFutureFromResponse(newAsyncResponseWithError(http.MethodPut))
-	if err != nil {
-		t.Fatalf("failed to create future: %v", err)
-	}
-	done, err := future.Done(mocks.NewSender())
+	_, err := NewFutureFromResponse(newAsyncResponseWithError(http.MethodPut))
 	if err == nil {
-		t.Fatalf("Done should have returned an error")
-	}
-	if !done {
-		t.Fatalf("should be done")
+		t.Fatal("expected non-nil error")
 	}
 }
 

--- a/version/version.go
+++ b/version/version.go
@@ -20,7 +20,7 @@ import (
 )
 
 // Number contains the semantic version of this SDK.
-const Number = "v10.15.0"
+const Number = "v10.15.1"
 
 var (
 	userAgent = fmt.Sprintf("Go/%s (%s-%s) go-autorest/%s",


### PR DESCRIPTION
If an LRO returns a failure in the initial response return an error
object at that point so the caller doesn't have to poll.
For failed LROs without an OData v4 error include the response body in
the error's AdditionalInfo field to aid in diagnosing the failure.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.