### PR TITLE
Fix logging of request/response URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v10.15.2
+
+### Bug Fixes
+
+- Use fmt.Fprint when printing request/response so that any escape sequences aren't treated as format specifiers.
+
 ## v10.15.1
 
 ### Bug Fixes

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -282,7 +282,7 @@ func (fl fileLogger) WriteRequest(req *http.Request, filter Filter) {
 	}
 	fl.mu.Lock()
 	defer fl.mu.Unlock()
-	fmt.Fprintf(fl.logFile, b.String())
+	fmt.Fprint(fl.logFile, b.String())
 	fl.logFile.Sync()
 }
 
@@ -311,7 +311,7 @@ func (fl fileLogger) WriteResponse(resp *http.Response, filter Filter) {
 	}
 	fl.mu.Lock()
 	defer fl.mu.Unlock()
-	fmt.Fprintf(fl.logFile, b.String())
+	fmt.Fprint(fl.logFile, b.String())
 	fl.logFile.Sync()
 }
 

--- a/version/version.go
+++ b/version/version.go
@@ -20,7 +20,7 @@ import (
 )
 
 // Number contains the semantic version of this SDK.
-const Number = "v10.15.1"
+const Number = "v10.15.2"
 
 var (
 	userAgent = fmt.Sprintf("Go/%s (%s-%s) go-autorest/%s",


### PR DESCRIPTION
The call to fmt.Fprintf() to write the request/response was treating URL
escape sequences as format specifiers leading to incorrect URL logging.
Switched to fmt.Fprint() to resolve the issue.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.