### PR TITLE
Init LRO polling URL and method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v10.15.3
+
+### Bug Fixes
+
+- Initialize the polling URL and method for an LRO tracker on each iteration, favoring the Azure-AsyncOperation header.
+
 ## v10.15.2
 
 ### Bug Fixes

--- a/autorest/azure/async.go
+++ b/autorest/azure/async.go
@@ -119,10 +119,10 @@ func (f *Future) Done(sender autorest.Sender) (bool, error) {
 	if err := f.pt.updatePollingState(f.pt.provisioningStateApplicable()); err != nil {
 		return false, err
 	}
-	if err := f.pt.initHeaders(); err != nil {
+	if err := f.pt.initPollingMethod(); err != nil {
 		return false, err
 	}
-	if err := f.pt.updateHeaders(); err != nil {
+	if err := f.pt.updatePollingMethod(); err != nil {
 		return false, err
 	}
 	return f.pt.hasTerminated(), f.pt.pollingError()
@@ -267,7 +267,7 @@ type pollingTracker interface {
 	// these methods can differ per tracker
 
 	// checks the response headers and status code to determine the polling mechanism
-	updateHeaders() error
+	updatePollingMethod() error
 
 	// checks the response for tracker-specific error conditions
 	checkForErrors() error
@@ -279,7 +279,7 @@ type pollingTracker interface {
 
 	// initializes a tracker's polling URL and method, called for each iteration.
 	// these values can be overridden by each polling tracker as required.
-	initHeaders() error
+	initPollingMethod() error
 
 	// initializes the tracker's internal state, call this when the tracker is created
 	initializeState() error
@@ -377,7 +377,7 @@ func (pt *pollingTrackerBase) initializeState() error {
 		pt.updateErrorFromResponse()
 		return pt.pollingError()
 	}
-	return pt.initHeaders()
+	return pt.initPollingMethod()
 }
 
 func (pt pollingTrackerBase) getProvisioningState() *string {
@@ -560,7 +560,7 @@ func (pt pollingTrackerBase) baseCheckForErrors() error {
 }
 
 // default initialization of polling URL/method.  each verb tracker will update this as required.
-func (pt *pollingTrackerBase) initHeaders() error {
+func (pt *pollingTrackerBase) initPollingMethod() error {
 	if ao, err := getURLFromAsyncOpHeader(pt.resp); err != nil {
 		return err
 	} else if ao != "" {
@@ -585,7 +585,7 @@ type pollingTrackerDelete struct {
 	pollingTrackerBase
 }
 
-func (pt *pollingTrackerDelete) updateHeaders() error {
+func (pt *pollingTrackerDelete) updatePollingMethod() error {
 	// for 201 the Location header is required
 	if pt.resp.StatusCode == http.StatusCreated {
 		if lh, err := getURLFromLocationHeader(pt.resp); err != nil {
@@ -641,7 +641,7 @@ type pollingTrackerPatch struct {
 	pollingTrackerBase
 }
 
-func (pt *pollingTrackerPatch) updateHeaders() error {
+func (pt *pollingTrackerPatch) updatePollingMethod() error {
 	// by default we can use the original URL for polling and final GET
 	if pt.URI == "" {
 		pt.URI = pt.resp.Request.URL.String()
@@ -699,7 +699,7 @@ type pollingTrackerPost struct {
 	pollingTrackerBase
 }
 
-func (pt *pollingTrackerPost) updateHeaders() error {
+func (pt *pollingTrackerPost) updatePollingMethod() error {
 	// 201 requires Location header
 	if pt.resp.StatusCode == http.StatusCreated {
 		if lh, err := getURLFromLocationHeader(pt.resp); err != nil {
@@ -755,7 +755,7 @@ type pollingTrackerPut struct {
 	pollingTrackerBase
 }
 
-func (pt *pollingTrackerPut) updateHeaders() error {
+func (pt *pollingTrackerPut) updatePollingMethod() error {
 	// by default we can use the original URL for polling and final GET
 	if pt.URI == "" {
 		pt.URI = pt.resp.Request.URL.String()
@@ -849,7 +849,7 @@ func createPollingTracker(resp *http.Response) (pollingTracker, error) {
 	// this initializes the polling header values, we do this during creation in case the
 	// initial response send us invalid values; this way the API call will return a non-nil
 	// error (not doing this means the error shows up in Future.Done)
-	return pt, pt.updateHeaders()
+	return pt, pt.updatePollingMethod()
 }
 
 // gets the polling URL from the Azure-AsyncOperation header.

--- a/version/version.go
+++ b/version/version.go
@@ -20,7 +20,7 @@ import (
 )
 
 // Number contains the semantic version of this SDK.
-const Number = "v10.15.2"
+const Number = "v10.15.3"
 
 var (
 	userAgent = fmt.Sprintf("Go/%s (%s-%s) go-autorest/%s",


### PR DESCRIPTION
Always initialize the polling URL and method, favoring the
Azure-AsyncOperation header.  Each tracker will update the values as
required.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.