### PR TITLE
Allow a new authorizer to be created from a configuration file by specifying a resource instead of a base url.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ _obj
 _test
 .DS_Store
 .idea/
+.vscode/
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/autorest/azure/auth/auth_test.go
+++ b/autorest/azure/auth/auth_test.go
@@ -47,6 +47,15 @@ func TestNewAuthorizerFromFile(t *testing.T) {
 	}
 }
 
+func TestNewAuthorizerFromFileWithResource(t *testing.T) {
+	os.Setenv("AZURE_AUTH_LOCATION", filepath.Join(getCredsPath(), "credsutf16le.json"))
+	authorizer, err := NewAuthorizerFromFileWithResource("https://my.vault.azure.net")
+	if err != nil || authorizer == nil {
+		t.Logf("NewAuthorizerFromFileWithResource failed, got error %v", err)
+		t.Fail()
+	}
+}
+
 func TestNewAuthorizerFromEnvironment(t *testing.T) {
 	os.Setenv("AZURE_TENANT_ID", expectedFile.TenantID)
 	os.Setenv("AZURE_CLIENT_ID", expectedFile.ClientID)
@@ -54,7 +63,19 @@ func TestNewAuthorizerFromEnvironment(t *testing.T) {
 	authorizer, err := NewAuthorizerFromEnvironment()
 
 	if err != nil || authorizer == nil {
-		t.Logf("NewAuthorizerFromFile failed, got error %v", err)
+		t.Logf("NewAuthorizerFromEnvironment failed, got error %v", err)
+		t.Fail()
+	}
+}
+
+func TestNewAuthorizerFromEnvironmentWithResource(t *testing.T) {
+	os.Setenv("AZURE_TENANT_ID", expectedFile.TenantID)
+	os.Setenv("AZURE_CLIENT_ID", expectedFile.ClientID)
+	os.Setenv("AZURE_CLIENT_SECRET", expectedFile.ClientSecret)
+	authorizer, err := NewAuthorizerFromEnvironmentWithResource("https://my.vault.azure.net")
+
+	if err != nil || authorizer == nil {
+		t.Logf("NewAuthorizerFromEnvironmentWithResource failed, got error %v", err)
 		t.Fail()
 	}
 }


### PR DESCRIPTION
This enables resource like KeyVault and Container Registry to use an authorizer configured from a configuration file.