### PR TITLE
Authorizer which uses Azure CLI to obtain the token

### DIFF
--- a/autorest/azure/cli/token.go
+++ b/autorest/azure/cli/token.go
@@ -15,9 +15,13 @@ package cli
 //  limitations under the License.
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
+	"regexp"
+	"runtime"
 	"strconv"
 	"time"
 
@@ -111,4 +115,56 @@ func LoadTokens(path string) ([]Token, error) {
 	}
 
 	return tokens, nil
+}
+
+// GetTokenFromCLI gets a token using Azure CLI 2.0 for local development scenarios.
+func GetTokenFromCLI(resource string) (*Token, error) {
+	// This is the path that a developer can set to tell this class what the install path for Azure CLI is.
+	const azureCLIPath = "AzureCLIPath"
+
+	// The default install paths are used to find Azure CLI. This is for security, so that any path in the calling program's Path environment is not used to execute Azure CLI.
+	azureCLIDefaultPathWindows := fmt.Sprintf("%s\\Microsoft SDKs\\Azure\\CLI2\\wbin; %s\\Microsoft SDKs\\Azure\\CLI2\\wbin", os.Getenv("ProgramFiles(x86)"), os.Getenv("ProgramFiles"))
+
+	// Default path for non-Windows.
+	const azureCLIDefaultPath = "/usr/bin:/usr/local/bin"
+
+	// Validate resource, since it gets sent as a command line argument to Azure CLI
+	const invalidResourceErrorTemplate = "Resource %s is not in expected format. Only alphanumeric characters, [dot], [colon], [hyphen], and [forward slash] are allowed."
+	match, err := regexp.MatchString("^[0-9a-zA-Z-.:/]+$", resource)
+	if err != nil {
+		return nil, err
+	}
+	if !match {
+		return nil, fmt.Errorf(invalidResourceErrorTemplate, resource)
+	}
+
+	// Execute Azure CLI to get token
+	var cliCmd *exec.Cmd
+	if runtime.GOOS == "windows" {
+		cliCmd = exec.Command(fmt.Sprintf("%s\\system32\\cmd.exe", os.Getenv("windir")))
+		cliCmd.Env = os.Environ()
+		cliCmd.Env = append(cliCmd.Env, fmt.Sprintf("PATH=%s;%s", os.Getenv(azureCLIPath), azureCLIDefaultPathWindows))
+		cliCmd.Args = append(cliCmd.Args, "/c")
+	} else {
+		cliCmd = exec.Command(os.Getenv("SHELL"))
+		cliCmd.Env = os.Environ()
+		cliCmd.Env = append(cliCmd.Env, fmt.Sprintf("PATH=%s:%s", os.Getenv(azureCLIPath), azureCLIDefaultPath))
+	}
+	cliCmd.Args = append(cliCmd.Args, "az", "account", "get-access-token", "-o", "json", "--resource", resource)
+
+	var stderr bytes.Buffer
+	cliCmd.Stderr = &stderr
+
+	output, err := cliCmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("Invoking Azure CLI failed with the following error: %s", stderr.String())
+	}
+
+	tokenResponse := Token{}
+	err = json.Unmarshal(output, &tokenResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	return &tokenResponse, err
 }


### PR DESCRIPTION
This PR adds the `NewAuthorizerFromCli` Authorizer factory method, which uses Azure CLI to obtain an access token for the currently logged in user. The implementation is inspired by the [Azure SDK for .NET implementation](https://github.com/Azure/azure-sdk-for-net/blob/b38512ff94eb22446b925f6af2c2bc73207c55a4/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/TokenProviders/AzureCliAccessTokenProvider.cs). These changes would resolve https://github.com/Azure/azure-sdk-for-go/issues/2610.

I've tested the changes on Windows 10 (1803) and Ubuntu 16.04 (through WSL).

There are currently no additional test, because they would depend on an Azure CLI installation with a logged in user. I'm not sure how to mock this, so any pointers are really appreciated if the tests are necessary.