### PR TITLE
Handle ContentLength equals -1 case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v11.2.6
+
+### Bug Fixes
+
+- If zero bytes are read from a polling response body don't attempt to unmarshal them.
+
 ## v11.2.5
 
 ### Bug Fixes

--- a/version/version.go
+++ b/version/version.go
@@ -20,7 +20,7 @@ import (
 )
 
 // Number contains the semantic version of this SDK.
-const Number = "v11.2.5"
+const Number = "v11.2.6"
 
 var (
 	userAgent = fmt.Sprintf("Go/%s (%s-%s) go-autorest/%s",


### PR DESCRIPTION
Reference Issue: #318

When HTTP response status is NoContent (204) ContentLenght of the HTTP response is -1. Code checks if ContentLenght != 0 then tries to parse the response, which fails in case ContentLength is -1. 

I modified the code to parse response only if ContentLenght > 0

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.