### PR TITLE
LRO fix for polling failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v10.15.4
+
+### Bug Fixes
+
+- If a polling operation returns a failure status code return the associated error.
+
 ## v10.15.3
 
 ### Bug Fixes

--- a/autorest/azure/async.go
+++ b/autorest/azure/async.go
@@ -428,6 +428,7 @@ func (pt *pollingTrackerBase) pollForStatus(sender autorest.Sender) error {
 	} else {
 		// check response body for error content
 		pt.updateErrorFromResponse()
+		err = pt.pollingError()
 	}
 	return err
 }

--- a/autorest/azure/async_test.go
+++ b/autorest/azure/async_test.go
@@ -527,8 +527,8 @@ func TestAsyncPollingReturnsWrappedError(t *testing.T) {
 	sender := mocks.NewSender()
 	sender.AppendResponse(newOperationResourceErrorResponse("Failed"))
 	err = pt.pollForStatus(sender)
-	if err != nil {
-		t.Fatalf("failed to poll for status: %v", err)
+	if err == nil {
+		t.Fatal("unexpected nil polling error")
 	}
 	err = pt.pollingError()
 	if err == nil {
@@ -552,8 +552,8 @@ func TestLocationPollingReturnsWrappedError(t *testing.T) {
 	sender := mocks.NewSender()
 	sender.AppendResponse(newProvisioningStatusErrorResponse("Failed"))
 	err = pt.pollForStatus(sender)
-	if err != nil {
-		t.Fatalf("failed to poll for status: %v", err)
+	if err == nil {
+		t.Fatal("unexpected nil polling error")
 	}
 	err = pt.pollingError()
 	if err == nil {
@@ -577,8 +577,8 @@ func TestLocationPollingReturnsUnwrappedError(t *testing.T) {
 	sender := mocks.NewSender()
 	sender.AppendResponse(newProvisioningStatusUnwrappedErrorResponse("Failed"))
 	err = pt.pollForStatus(sender)
-	if err != nil {
-		t.Fatalf("failed to poll for status: %v", err)
+	if err == nil {
+		t.Fatal("unexpected nil polling error")
 	}
 	err = pt.pollingError()
 	if err == nil {

--- a/version/version.go
+++ b/version/version.go
@@ -20,7 +20,7 @@ import (
 )
 
 // Number contains the semantic version of this SDK.
-const Number = "v10.15.3"
+const Number = "v10.15.4"
 
 var (
 	userAgent = fmt.Sprintf("Go/%s (%s-%s) go-autorest/%s",


### PR DESCRIPTION
If a polling operation returns a failure status code return the
associated error.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.