### PR TITLE
Pin utfbom and go-homedir to v1.0.0 and remove the explicit dependency on x/crypto master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v10.15.5
+
+- Pin utfbom and go-homedir dependencies to v1.0.0 and remove the explicit dependency on x/crypto master.
+
 ## v10.15.4
 
 ### Bug Fixes

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -18,20 +18,20 @@
   version = "v3.2.0"
 
 [[projects]]
-  branch = "master"
   digest = "1:7f175a633086a933d1940a7e7dc2154a0070a7c25fb4a2f671f3eef1a34d1fd7"
   name = "github.com/dimchansky/utfbom"
   packages = ["."]
   pruneopts = ""
   revision = "5448fe645cb1964ba70ac8f9f2ffe975e61a536c"
+  version = "v1.0.0"
 
 [[projects]]
-  branch = "master"
   digest = "1:096a8a9182648da3d00ff243b88407838902b6703fc12657f76890e08d1899bf"
   name = "github.com/mitchellh/go-homedir"
   packages = ["."]
   pruneopts = ""
   revision = "ae18d6b8b3205b561c79e8e5f69bff09736185f4"
+  version = "v1.0.0"
 
 [[projects]]
   digest = "1:256484dbbcd271f9ecebc6795b2df8cad4c458dd0f5fd82a8c2fa0c29f233411"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -25,17 +25,13 @@
   version = "3.1.0"
 
 [[constraint]]
-  branch = "master"
   name = "github.com/dimchansky/utfbom"
+  version = "1.0.0"
 
 [[constraint]]
-  branch = "master"
   name = "github.com/mitchellh/go-homedir"
+  version = "1.0.0"
 
 [[constraint]]
   name = "github.com/stretchr/testify"
   version = "1.2.0"
-
-[[constraint]]
-  branch = "master"
-  name = "golang.org/x/crypto"


### PR DESCRIPTION
I ran into some issues today with a build pipeline that has this project as a dependency. Some changes to `x/crypto` weren't valid with some of my other dependencies, and the explicit pinning to master here causes pain upstream (having to use dep `overrides`). I don't see any reason why go-autorest needs to always be pinned to master, so I've removed this - `dep` will use the most recent valid version it can.

While I was at it, I also added specific versions (`v1.0.0`) for utfbom and go-homedir.

None of these changes actually change the dependencies in any way, as seen with the simple diff on the `Gopkg.lock` file. This just helps other repos which import this project.

As for checking the boxes that this is an "urgent bug fix" and warrants its own release, that's up to you - I altered the changelog in a separate commit. But given this is dealing with how projects import go-autorest, I think it would be prudent to tag a patch release with these changes.

---

As part of submitting, please make sure you can make the following assertions:
 - [x] I've tested my changes, adding unit tests if applicable.
 - [x] I've added Apache 2.0 Headers to the top of any new source files.
 - [x] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [x] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.