### PR TITLE
Let upstream clients decide if they want to infinitely retry on certain HTTP codes, should not be decided by library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v10.15.5
+
+### Bug Fixes
+- REVERT: Don't count http.StatusTooManyRequests (429) against the retry cap, 
+  since this needs to be decided by upstream caller based on response status code.
+
 ## v10.15.4
 
 ### Bug Fixes

--- a/autorest/sender.go
+++ b/autorest/sender.go
@@ -217,7 +217,7 @@ func DoRetryForStatusCodes(attempts int, backoff time.Duration, codes ...int) Se
 			rr := NewRetriableRequest(r)
 			// Increment to add the first call (attempts denotes number of retries)
 			attempts++
-			for attempt := 0; attempt < attempts; {
+			for attempt := 0; attempt < attempts; attempt++ {
 				err = rr.Prepare()
 				if err != nil {
 					return resp, err

--- a/autorest/sender.go
+++ b/autorest/sender.go
@@ -236,11 +236,6 @@ func DoRetryForStatusCodes(attempts int, backoff time.Duration, codes ...int) Se
 				if !delayed && !DelayForBackoff(backoff, attempt, r.Context().Done()) {
 					return nil, r.Context().Err()
 				}
-				// don't count a 429 against the number of attempts
-				// so that we continue to retry until it succeeds
-				if resp == nil || resp.StatusCode != http.StatusTooManyRequests {
-					attempt++
-				}
 			}
 			return resp, err
 		})

--- a/autorest/sender_test.go
+++ b/autorest/sender_test.go
@@ -788,7 +788,7 @@ func newAcceptedResponse() *http.Response {
 }
 
 func TestDelayWithRetryAfterWithSuccess(t *testing.T) {
-	after, retries := 2, 2
+	after, retries := 5, 2
 	totalSecs := after * retries
 
 	client := mocks.NewSender()
@@ -800,7 +800,7 @@ func TestDelayWithRetryAfterWithSuccess(t *testing.T) {
 	d := time.Second * time.Duration(totalSecs)
 	start := time.Now()
 	r, _ := SendWithSender(client, mocks.NewRequest(),
-		DoRetryForStatusCodes(1, time.Duration(time.Second), http.StatusTooManyRequests),
+		DoRetryForStatusCodes(5, time.Duration(time.Second), http.StatusTooManyRequests),
 	)
 
 	if time.Since(start) < d {

--- a/version/version.go
+++ b/version/version.go
@@ -20,7 +20,7 @@ import (
 )
 
 // Number contains the semantic version of this SDK.
-const Number = "v10.15.4"
+const Number = "v10.15.5"
 
 var (
 	userAgent = fmt.Sprintf("Go/%s (%s-%s) go-autorest/%s",


### PR DESCRIPTION
…in HTTP codes, should not be decided by library

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [X ] I've tested my changes, adding unit tests if applicable.
 - [X] I've added Apache 2.0 Headers to the top of any new source files.
 - [X] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [X] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.