### PR TITLE
Return response when request is cancelled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v10.15.5
+
+### Bug Fixes
+
+- In `DoRetryForStatusCodes`, if a request's context is cancelled return the last response.
+
 ## v10.15.4
 
 ### Bug Fixes

--- a/autorest/sender.go
+++ b/autorest/sender.go
@@ -234,7 +234,7 @@ func DoRetryForStatusCodes(attempts int, backoff time.Duration, codes ...int) Se
 				}
 				delayed := DelayWithRetryAfter(resp, r.Context().Done())
 				if !delayed && !DelayForBackoff(backoff, attempt, r.Context().Done()) {
-					return nil, r.Context().Err()
+					return resp, r.Context().Err()
 				}
 				// don't count a 429 against the number of attempts
 				// so that we continue to retry until it succeeds

--- a/version/version.go
+++ b/version/version.go
@@ -20,7 +20,7 @@ import (
 )
 
 // Number contains the semantic version of this SDK.
-const Number = "v10.15.4"
+const Number = "v10.15.5"
 
 var (
 	userAgent = fmt.Sprintf("Go/%s (%s-%s) go-autorest/%s",


### PR DESCRIPTION
If the request's context is cancelled return the last response.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.