### PR TITLE
Add the x5c header for certificate issuer + subject name auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v11.0.1
+
+### New Features
+
+- Added `x5c` header to client assertion for certificate Issuer+Subject Name authentication.
+
 ## v11.0.0
 
 ### Breaking Changes

--- a/autorest/adal/token.go
+++ b/autorest/adal/token.go
@@ -226,6 +226,8 @@ func (secret *ServicePrincipalCertificateSecret) SignJwt(spt *ServicePrincipalTo
 
 	token := jwt.New(jwt.SigningMethodRS256)
 	token.Header["x5t"] = thumbprint
+	x5c := []string{base64.StdEncoding.EncodeToString(secret.Certificate.Raw)}
+	token.Header["x5c"] = x5c
 	token.Claims = jwt.MapClaims{
 		"aud": spt.inner.OauthConfig.TokenEndpoint.String(),
 		"iss": spt.inner.ClientID,

--- a/autorest/adal/token_test.go
+++ b/autorest/adal/token_test.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/Azure/go-autorest/autorest/date"
 	"github.com/Azure/go-autorest/autorest/mocks"
+	jwt "github.com/dgrijalva/jwt-go"
 )
 
 const (
@@ -320,6 +321,17 @@ func TestServicePrincipalTokenCertficateRefreshSetsBody(t *testing.T) {
 			values["grant_type"][0] != "client_credentials" ||
 			values["resource"][0] != "resource" {
 			t.Fatalf("adal: ServicePrincipalTokenCertificate#Refresh did not correctly set the HTTP Request Body.")
+		}
+
+		tok, _ := jwt.Parse(values["client_assertion"][0], nil)
+		if tok == nil {
+			t.Fatalf("adal: ServicePrincipalTokenCertificate#Expected client_assertion to be a JWT")
+		}
+		if _, ok := tok.Header["x5t"]; !ok {
+			t.Fatalf("adal: ServicePrincipalTokenCertificate#Expected client_assertion to have an x5t header")
+		}
+		if _, ok := tok.Header["x5c"]; !ok {
+			t.Fatalf("adal: ServicePrincipalTokenCertificate#Expected client_assertion to have an x5c header")
 		}
 	})
 }


### PR DESCRIPTION
See https://tools.ietf.org/html/draft-ietf-jose-json-web-key-41#section-4.7 for the `x5c` header description
AAD allows authentication based on certificate Issuer and Subject Name like in
https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/blob/0c6d6fd76c707b6132e4bc20cd2e71622907d0c6/adal/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/ClientCreds/JsonWebToken.cs#L212

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [X] I've tested my changes, adding unit tests if applicable.
 - [N/A] I've added Apache 2.0 Headers to the top of any new source files.
 - [N/A] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
   IMHO, this warrants immediate release because this is a security feature that helps with certificate rollover
 - [X] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.