### PR TITLE
Fix azure.NewFutureFromResponse to always return tracker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
   - curl -L -o $GOPATH/bin/dep https://github.com/golang/dep/releases/download/v$DEP_VERSION/dep-linux-amd64 && chmod +x $GOPATH/bin/dep
 
 install:
-  - go get -u github.com/golang/lint/golint
+  - go get -u golang.org/x/lint/golint
   - go get -u github.com/stretchr/testify
   - go get -u github.com/GoASTScanner/gas
   - dep ensure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v11.1.1
+
+### Bug Fixes
+
+- When creating a future always include the polling tracker even if there's a failure; this allows the underlying response to be obtained by the caller.
+
 ## v11.1.0
 
 ### New Features

--- a/autorest/azure/async.go
+++ b/autorest/azure/async.go
@@ -58,10 +58,7 @@ func NewFuture(req *http.Request) Future {
 // with the initial response from an asynchronous operation.
 func NewFutureFromResponse(resp *http.Response) (Future, error) {
 	pt, err := createPollingTracker(resp)
-	if err != nil {
-		return Future{}, err
-	}
-	return Future{pt: pt}, nil
+	return Future{pt: pt}, err
 }
 
 // Response returns the last HTTP response.

--- a/version/version.go
+++ b/version/version.go
@@ -20,7 +20,7 @@ import (
 )
 
 // Number contains the semantic version of this SDK.
-const Number = "v11.1.0"
+const Number = "v11.1.1"
 
 var (
 	userAgent = fmt.Sprintf("Go/%s (%s-%s) go-autorest/%s",


### PR DESCRIPTION
When creating a future always include the polling tracker even if
there's a failure; this allows the underlying response to be obtained
by the caller.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.