### PR TITLE
Make cli.ProfilePath respect AZURE_CONFIG_DIR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v11.2.4
+
+### Bug Fixes
+
+- Function `cli.ProfilePath` now respects environment `AZURE_CONFIG_DIR` if available.
+
 ## v11.2.1
 
 NOTE: Versions of Go prior to 1.10 have been removed from CI as they no

--- a/autorest/azure/cli/profile.go
+++ b/autorest/azure/cli/profile.go
@@ -19,6 +19,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"os"
+	"path/filepath"
 
 	"github.com/dimchansky/utfbom"
 	"github.com/mitchellh/go-homedir"
@@ -47,9 +49,14 @@ type User struct {
 	Type string `json:"type"`
 }
 
+const azureProfileJSON = "azureProfile.json"
+
 // ProfilePath returns the path where the Azure Profile is stored from the Azure CLI
 func ProfilePath() (string, error) {
-	return homedir.Expand("~/.azure/azureProfile.json")
+	if cfgDir := os.Getenv("AZURE_CONFIG_DIR"); cfgDir != "" {
+		return filepath.Join(cfgDir, azureProfileJSON), nil
+	}
+	return homedir.Expand("~/.azure/" + azureProfileJSON)
 }
 
 // LoadProfile restores a Profile object from a file located at 'path'.

--- a/version/version.go
+++ b/version/version.go
@@ -20,7 +20,7 @@ import (
 )
 
 // Number contains the semantic version of this SDK.
-const Number = "v11.2.3"
+const Number = "v11.2.4"
 
 var (
 	userAgent = fmt.Sprintf("Go/%s (%s-%s) go-autorest/%s",
@@ -31,7 +31,7 @@ var (
 	)
 )
 
-// UserAgent returns a string containing the Go version, system archityecture and OS, and the go-autorest version.
+// UserAgent returns a string containing the Go version, system architecture and OS, and the go-autorest version.
 func UserAgent() string {
 	return userAgent
 }


### PR DESCRIPTION
If AZURE_CONFIG_DIR environment variable is set use its value to
determine the location of azureProfile.json.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.