### PR TITLE
Deprecate the version package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v11.2.8
+
+### Bug Fixes
+
+- Deprecate content in the `version` package.  The functionality has been superseded by content in the `autorest` package.
+
 ## v11.2.7
 
 ### Bug Fixes

--- a/autorest/client.go
+++ b/autorest/client.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/Azure/go-autorest/logger"
 	"github.com/Azure/go-autorest/tracing"
-	"github.com/Azure/go-autorest/version"
 )
 
 const (
@@ -175,7 +174,7 @@ func NewClientWithUserAgent(ua string) Client {
 		PollingDuration: DefaultPollingDuration,
 		RetryAttempts:   DefaultRetryAttempts,
 		RetryDuration:   DefaultRetryDuration,
-		UserAgent:       version.UserAgent(),
+		UserAgent:       UserAgent(),
 	}
 	c.Sender = c.sender()
 	c.AddToUserAgent(ua)

--- a/autorest/client_test.go
+++ b/autorest/client_test.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/Azure/go-autorest/autorest/mocks"
 	"github.com/Azure/go-autorest/tracing"
-	"github.com/Azure/go-autorest/version"
 )
 
 func TestLoggingInspectorWithInspection(t *testing.T) {
@@ -128,7 +127,7 @@ func TestLoggingInspectorByInspectingRestoresBody(t *testing.T) {
 func TestNewClientWithUserAgent(t *testing.T) {
 	ua := "UserAgent"
 	c := NewClientWithUserAgent(ua)
-	completeUA := fmt.Sprintf("%s %s", version.UserAgent(), ua)
+	completeUA := fmt.Sprintf("%s %s", UserAgent(), ua)
 
 	if c.UserAgent != completeUA {
 		t.Fatalf("autorest: NewClientWithUserAgent failed to set the UserAgent -- expected %s, received %s",
@@ -144,7 +143,7 @@ func TestAddToUserAgent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("autorest: AddToUserAgent returned error -- expected nil, received %s", err)
 	}
-	completeUA := fmt.Sprintf("%s %s %s", version.UserAgent(), ua, ext)
+	completeUA := fmt.Sprintf("%s %s %s", UserAgent(), ua, ext)
 
 	if c.UserAgent != completeUA {
 		t.Fatalf("autorest: AddToUserAgent failed to add an extension to the UserAgent -- expected %s, received %s",

--- a/autorest/version.go
+++ b/autorest/version.go
@@ -1,7 +1,5 @@
 package autorest
 
-import "github.com/Azure/go-autorest/version"
-
 // Copyright 2017 Microsoft Corporation
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +14,28 @@ import "github.com/Azure/go-autorest/version"
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+import (
+	"fmt"
+	"runtime"
+)
+
+const number = "v11.2.8"
+
+var (
+	userAgent = fmt.Sprintf("Go/%s (%s-%s) go-autorest/%s",
+		runtime.Version(),
+		runtime.GOARCH,
+		runtime.GOOS,
+		number,
+	)
+)
+
+// UserAgent returns a string containing the Go version, system architecture and OS, and the go-autorest version.
+func UserAgent() string {
+	return userAgent
+}
+
 // Version returns the semantic version (see http://semver.org).
 func Version() string {
-	return version.Number
+	return number
 }

--- a/version/version.go
+++ b/version/version.go
@@ -19,6 +19,7 @@ import (
 	"runtime"
 )
 
+// Deprecated: please use autorest.Version() instead.
 // Number contains the semantic version of this SDK.
 const Number = "v11.2.7"
 
@@ -31,6 +32,7 @@ var (
 	)
 )
 
+// Deprecated: please use autorest.UserAgent() instead.
 // UserAgent returns a string containing the Go version, system architecture and OS, and the go-autorest version.
 func UserAgent() string {
 	return userAgent

--- a/version/version.go
+++ b/version/version.go
@@ -21,7 +21,7 @@ import (
 
 // Deprecated: please use autorest.Version() instead.
 // Number contains the semantic version of this SDK.
-const Number = "v11.2.7"
+const Number = "v11.2.8"
 
 var (
 	userAgent = fmt.Sprintf("Go/%s (%s-%s) go-autorest/%s",


### PR DESCRIPTION
The version package has been deprecated, superseded by content in the
autorest package.  This is in preparation for implementing modules.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.