### PR TITLE
Fix final GET for LRO PUT operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v11.3.1
+
+### Bug Fixes
+
+- For an LRO PUT operation the final GET URL was incorrectly set to the Location polling header in some cases.
+
 ## v11.3.0
 
 ### New Features

--- a/autorest/azure/async.go
+++ b/autorest/azure/async.go
@@ -824,8 +824,6 @@ func (pt *pollingTrackerPut) updatePollingMethod() error {
 				pt.URI = lh
 				pt.Pm = PollingLocation
 			}
-			// when both headers are returned we use the value in the Location header for the final GET
-			pt.FinalGetURI = lh
 		}
 		// make sure a polling URL was found
 		if pt.URI == "" {

--- a/autorest/azure/async_test.go
+++ b/autorest/azure/async_test.go
@@ -434,7 +434,7 @@ func TestCreatePutTracker202SuccessLocation(t *testing.T) {
 	if pt.pollingMethod() != PollingLocation {
 		t.Fatalf("wrong polling method: %s", pt.pollingMethod())
 	}
-	if pt.finalGetURL() != mocks.TestLocationURL {
+	if pt.finalGetURL() != resp.Request.URL.String() {
 		t.Fatalf("wrong final GET URL: %s", pt.finalGetURL())
 	}
 }
@@ -450,7 +450,7 @@ func TestCreatePutTracker202SuccessBoth(t *testing.T) {
 	if pt.pollingMethod() != PollingAsyncOperation {
 		t.Fatalf("wrong polling method: %s", pt.pollingMethod())
 	}
-	if pt.finalGetURL() != mocks.TestLocationURL {
+	if pt.finalGetURL() != resp.Request.URL.String() {
 		t.Fatalf("wrong final GET URL: %s", pt.finalGetURL())
 	}
 }

--- a/autorest/version.go
+++ b/autorest/version.go
@@ -19,7 +19,7 @@ import (
 	"runtime"
 )
 
-const number = "v11.3.0"
+const number = "v11.3.1"
 
 var (
 	userAgent = fmt.Sprintf("Go/%s (%s-%s) go-autorest/%s",


### PR DESCRIPTION
For an LRO PUT operation the final GET URL was incorrectly set to the
Location polling URL in some cases.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.