### PR TITLE
Add ability to update the user-agent header for ADAL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## v11.4.0
+
+### New Features
+
+- Added `adal.AddToUserAgent()` so callers can append custom data to the user-agent header used for ADAL requests.
+- Exported `adal.UserAgent()` for parity with `autorest.Client`.
+
 ## v11.3.2
 
 ### Bug Fixes

--- a/autorest/adal/token.go
+++ b/autorest/adal/token.go
@@ -796,7 +796,7 @@ func (spt *ServicePrincipalToken) refreshInternal(ctx context.Context, resource 
 	if err != nil {
 		return fmt.Errorf("adal: Failed to build the refresh request. Error = '%v'", err)
 	}
-	req.Header.Add("User-Agent", userAgent())
+	req.Header.Add("User-Agent", UserAgent())
 	req = req.WithContext(ctx)
 	if !isIMDS(spt.inner.OauthConfig.TokenEndpoint) {
 		v := url.Values{}

--- a/autorest/adal/version.go
+++ b/autorest/adal/version.go
@@ -30,6 +30,16 @@ var (
 	)
 )
 
-func userAgent() string {
+// UserAgent returns a string containing the Go version, system architecture and OS, and the adal version.
+func UserAgent() string {
 	return ua
+}
+
+// AddToUserAgent adds an extension to the current user agent
+func AddToUserAgent(extension string) error {
+	if extension != "" {
+		ua = fmt.Sprintf("%s %s", ua, extension)
+		return nil
+	}
+	return fmt.Errorf("Extension was empty, User Agent remained as '%s'", ua)
 }

--- a/autorest/version.go
+++ b/autorest/version.go
@@ -19,7 +19,7 @@ import (
 	"runtime"
 )
 
-const number = "v11.3.2"
+const number = "v11.4.0"
 
 var (
 	userAgent = fmt.Sprintf("Go/%s (%s-%s) go-autorest/%s",


### PR DESCRIPTION
Added function adal.AddToUserAgent() to allow callers to append custom
data to the default user-agent header.
Exported adal.UserAgent() for parity with autorest.Client.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.