### PR TITLE
Refactor auth package to expose settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## v11.5.0
+
+### New Features
+
+- The `auth` package has been refactored so that the environment and file settings are now available.
+- The methods used in `auth.NewAuthorizerFromEnvironment()` are now exported so that custom authorization chains can be created.
+- Added support for certificate authorization for file-based config.
+
 ## v11.4.0
 
 ### New Features

--- a/autorest/azure/auth/auth.go
+++ b/autorest/azure/auth/auth.go
@@ -220,22 +220,38 @@ func (settings EnvironmentSettings) GetAuthorizer() (autorest.Authorizer, error)
 	return settings.GetMSI().Authorizer()
 }
 
-// NewAuthorizerFromFile creates an Authorizer configured from a configuration file.
+// NewAuthorizerFromFile creates an Authorizer configured from a configuration file in the following order.
+// 1. Client credentials
+// 2. Client certificate
 func NewAuthorizerFromFile(baseURI string) (autorest.Authorizer, error) {
 	settings, err := GetSettingsFromFile()
 	if err != nil {
 		return nil, err
 	}
-	return settings.ClientCredentialsAuthorizer(baseURI)
+	if a, err := settings.ClientCredentialsAuthorizer(baseURI); err == nil {
+		return a, err
+	}
+	if a, err := settings.ClientCertificateAuthorizer(baseURI); err == nil {
+		return a, err
+	}
+	return nil, errors.New("auth file missing client and certificate credentials")
 }
 
-// NewAuthorizerFromFileWithResource creates an Authorizer configured from a configuration file.
+// NewAuthorizerFromFileWithResource creates an Authorizer configured from a configuration file in the following order.
+// 1. Client credentials
+// 2. Client certificate
 func NewAuthorizerFromFileWithResource(resource string) (autorest.Authorizer, error) {
 	s, err := GetSettingsFromFile()
 	if err != nil {
 		return nil, err
 	}
-	return s.ClientCredentialsAuthorizerWithResource(resource)
+	if a, err := s.ClientCredentialsAuthorizerWithResource(resource); err == nil {
+		return a, err
+	}
+	if a, err := s.ClientCertificateAuthorizerWithResource(resource); err == nil {
+		return a, err
+	}
+	return nil, errors.New("auth file missing client and certificate credentials")
 }
 
 // NewAuthorizerFromCLI creates an Authorizer configured from Azure CLI 2.0 for local development scenarios.

--- a/autorest/azure/auth/auth.go
+++ b/autorest/azure/auth/auth.go
@@ -36,22 +36,37 @@ import (
 	"golang.org/x/crypto/pkcs12"
 )
 
+// The possible keys in the Values map.
+const (
+	SubscriptionID          = "AZURE_SUBSCRIPTION_ID"
+	TenantID                = "AZURE_TENANT_ID"
+	ClientID                = "AZURE_CLIENT_ID"
+	ClientSecret            = "AZURE_CLIENT_SECRET"
+	CertificatePath         = "AZURE_CERTIFICATE_PATH"
+	CertificatePassword     = "AZURE_CERTIFICATE_PASSWORD"
+	Username                = "AZURE_USERNAME"
+	Password                = "AZURE_PASSWORD"
+	EnvironmentName         = "AZURE_ENVIRONMENT"
+	Resource                = "AZURE_AD_RESOURCE"
+	ActiveDirectoryEndpoint = "ActiveDirectoryEndpoint"
+	ResourceManagerEndpoint = "ResourceManagerEndpoint"
+	GraphResourceID         = "GraphResourceID"
+	SQLManagementEndpoint   = "SQLManagementEndpoint"
+	GalleryEndpoint         = "GalleryEndpoint"
+	ManagementEndpoint      = "ManagementEndpoint"
+)
+
 // NewAuthorizerFromEnvironment creates an Authorizer configured from environment variables in the order:
 // 1. Client credentials
 // 2. Client certificate
 // 3. Username password
 // 4. MSI
 func NewAuthorizerFromEnvironment() (autorest.Authorizer, error) {
-	settings, err := getAuthenticationSettings()
+	settings, err := GetSettingsFromEnvironment()
 	if err != nil {
 		return nil, err
 	}
-
-	if settings.resource == "" {
-		settings.resource = settings.environment.ResourceManagerEndpoint
-	}
-
-	return settings.getAuthorizer()
+	return settings.GetAuthorizer()
 }
 
 // NewAuthorizerFromEnvironmentWithResource creates an Authorizer configured from environment variables in the order:
@@ -60,126 +75,181 @@ func NewAuthorizerFromEnvironment() (autorest.Authorizer, error) {
 // 3. Username password
 // 4. MSI
 func NewAuthorizerFromEnvironmentWithResource(resource string) (autorest.Authorizer, error) {
-	settings, err := getAuthenticationSettings()
+	settings, err := GetSettingsFromEnvironment()
 	if err != nil {
 		return nil, err
 	}
-	settings.resource = resource
-	return settings.getAuthorizer()
+	settings.Values[Resource] = resource
+	return settings.GetAuthorizer()
 }
 
-type settings struct {
-	tenantID            string
-	clientID            string
-	clientSecret        string
-	certificatePath     string
-	certificatePassword string
-	username            string
-	password            string
-	envName             string
-	resource            string
-	environment         azure.Environment
+// EnvironmentSettings contains the available authentication settings.
+type EnvironmentSettings struct {
+	Values      map[string]string
+	Environment azure.Environment
 }
 
-func getAuthenticationSettings() (s settings, err error) {
-	s = settings{
-		tenantID:            os.Getenv("AZURE_TENANT_ID"),
-		clientID:            os.Getenv("AZURE_CLIENT_ID"),
-		clientSecret:        os.Getenv("AZURE_CLIENT_SECRET"),
-		certificatePath:     os.Getenv("AZURE_CERTIFICATE_PATH"),
-		certificatePassword: os.Getenv("AZURE_CERTIFICATE_PASSWORD"),
-		username:            os.Getenv("AZURE_USERNAME"),
-		password:            os.Getenv("AZURE_PASSWORD"),
-		envName:             os.Getenv("AZURE_ENVIRONMENT"),
-		resource:            os.Getenv("AZURE_AD_RESOURCE"),
+// GetSettingsFromEnvironment returns the available authentication settings from the environment.
+func GetSettingsFromEnvironment() (s EnvironmentSettings, err error) {
+	s = EnvironmentSettings{
+		Values: map[string]string{},
 	}
-
-	if s.envName == "" {
-		s.environment = azure.PublicCloud
+	s.setValue(SubscriptionID)
+	s.setValue(TenantID)
+	s.setValue(ClientID)
+	s.setValue(ClientSecret)
+	s.setValue(CertificatePath)
+	s.setValue(CertificatePassword)
+	s.setValue(Username)
+	s.setValue(Password)
+	s.setValue(EnvironmentName)
+	s.setValue(Resource)
+	if v := s.Values[EnvironmentName]; v == "" {
+		s.Environment = azure.PublicCloud
 	} else {
-		s.environment, err = azure.EnvironmentFromName(s.envName)
+		s.Environment, err = azure.EnvironmentFromName(v)
+	}
+	if s.Values[Resource] == "" {
+		s.Values[Resource] = s.Environment.ResourceManagerEndpoint
 	}
 	return
 }
 
-func (settings settings) getAuthorizer() (autorest.Authorizer, error) {
+// GetSubscriptionID returns the available subscription ID or an empty string.
+func (settings EnvironmentSettings) GetSubscriptionID() string {
+	return settings.Values[SubscriptionID]
+}
+
+// adds the specified environment variable value to the Values map if it exists
+func (settings EnvironmentSettings) setValue(key string) {
+	if v := os.Getenv(key); v != "" {
+		settings.Values[key] = v
+	}
+}
+
+// helper to return client and tenant IDs
+func (settings EnvironmentSettings) getClientAndTenant() (string, string) {
+	clientID := settings.Values[ClientID]
+	tenantID := settings.Values[TenantID]
+	return clientID, tenantID
+}
+
+// GetClientCredentials creates a config object from the available client credentials.
+// An error is returned if no client credentials are available.
+func (settings EnvironmentSettings) GetClientCredentials() (ClientCredentialsConfig, error) {
+	secret := settings.Values[ClientSecret]
+	if secret == "" {
+		return ClientCredentialsConfig{}, errors.New("missing client secret")
+	}
+	clientID, tenantID := settings.getClientAndTenant()
+	config := NewClientCredentialsConfig(clientID, secret, tenantID)
+	config.AADEndpoint = settings.Environment.ActiveDirectoryEndpoint
+	config.Resource = settings.Values[Resource]
+	return config, nil
+}
+
+// GetClientCertificate creates a config object from the available certificate credentials.
+// An error is returned if no certificate credentials are available.
+func (settings EnvironmentSettings) GetClientCertificate() (ClientCertificateConfig, error) {
+	certPath := settings.Values[CertificatePath]
+	if certPath == "" {
+		return ClientCertificateConfig{}, errors.New("missing certificate path")
+	}
+	certPwd := settings.Values[CertificatePassword]
+	clientID, tenantID := settings.getClientAndTenant()
+	config := NewClientCertificateConfig(certPath, certPwd, clientID, tenantID)
+	config.AADEndpoint = settings.Environment.ActiveDirectoryEndpoint
+	config.Resource = settings.Values[Resource]
+	return config, nil
+}
+
+// GetUsernamePassword creates a config object from the available username/password credentials.
+// An error is returned if no username/password credentials are available.
+func (settings EnvironmentSettings) GetUsernamePassword() (UsernamePasswordConfig, error) {
+	username := settings.Values[Username]
+	password := settings.Values[Password]
+	if username == "" || password == "" {
+		return UsernamePasswordConfig{}, errors.New("missing username/password")
+	}
+	clientID, tenantID := settings.getClientAndTenant()
+	config := NewUsernamePasswordConfig(username, password, clientID, tenantID)
+	config.AADEndpoint = settings.Environment.ActiveDirectoryEndpoint
+	config.Resource = settings.Values[Resource]
+	return config, nil
+}
+
+// GetMSI creates a MSI config object from the available client ID.
+func (settings EnvironmentSettings) GetMSI() MSIConfig {
+	config := NewMSIConfig()
+	config.Resource = settings.Values[Resource]
+	config.ClientID = settings.Values[ClientID]
+	return config
+}
+
+// GetDeviceFlow creates a device-flow config object from the available client and tenant IDs.
+func (settings EnvironmentSettings) GetDeviceFlow() DeviceFlowConfig {
+	clientID, tenantID := settings.getClientAndTenant()
+	config := NewDeviceFlowConfig(clientID, tenantID)
+	config.AADEndpoint = settings.Environment.ActiveDirectoryEndpoint
+	config.Resource = settings.Values[Resource]
+	return config
+}
+
+// GetAuthorizer creates an Authorizer configured from environment variables in the order:
+// 1. Client credentials
+// 2. Client certificate
+// 3. Username password
+// 4. MSI
+func (settings EnvironmentSettings) GetAuthorizer() (autorest.Authorizer, error) {
 	//1.Client Credentials
-	if settings.clientSecret != "" {
-		config := NewClientCredentialsConfig(settings.clientID, settings.clientSecret, settings.tenantID)
-		config.AADEndpoint = settings.environment.ActiveDirectoryEndpoint
-		config.Resource = settings.resource
-		return config.Authorizer()
+	if c, e := settings.GetClientCredentials(); e == nil {
+		return c.Authorizer()
 	}
 
 	//2. Client Certificate
-	if settings.certificatePath != "" {
-		config := NewClientCertificateConfig(settings.certificatePath, settings.certificatePassword, settings.clientID, settings.tenantID)
-		config.AADEndpoint = settings.environment.ActiveDirectoryEndpoint
-		config.Resource = settings.resource
-		return config.Authorizer()
+	if c, e := settings.GetClientCertificate(); e == nil {
+		return c.Authorizer()
 	}
 
 	//3. Username Password
-	if settings.username != "" && settings.password != "" {
-		config := NewUsernamePasswordConfig(settings.username, settings.password, settings.clientID, settings.tenantID)
-		config.AADEndpoint = settings.environment.ActiveDirectoryEndpoint
-		config.Resource = settings.resource
-		return config.Authorizer()
+	if c, e := settings.GetUsernamePassword(); e == nil {
+		return c.Authorizer()
 	}
 
 	// 4. MSI
-	config := NewMSIConfig()
-	config.Resource = settings.resource
-	config.ClientID = settings.clientID
-	return config.Authorizer()
+	return settings.GetMSI().Authorizer()
 }
 
 // NewAuthorizerFromFile creates an Authorizer configured from a configuration file.
 func NewAuthorizerFromFile(baseURI string) (autorest.Authorizer, error) {
-	file, err := getAuthFile()
+	settings, err := GetSettingsFromFile()
 	if err != nil {
 		return nil, err
 	}
-
-	resource, err := getResourceForToken(*file, baseURI)
-	if err != nil {
-		return nil, err
-	}
-	return NewAuthorizerFromFileWithResource(resource)
+	return settings.ClientCredentialsAuthorizer(baseURI)
 }
 
 // NewAuthorizerFromFileWithResource creates an Authorizer configured from a configuration file.
 func NewAuthorizerFromFileWithResource(resource string) (autorest.Authorizer, error) {
-	file, err := getAuthFile()
+	s, err := GetSettingsFromFile()
 	if err != nil {
 		return nil, err
 	}
-
-	config, err := adal.NewOAuthConfig(file.ActiveDirectoryEndpoint, file.TenantID)
-	if err != nil {
-		return nil, err
-	}
-
-	spToken, err := adal.NewServicePrincipalToken(*config, file.ClientID, file.ClientSecret, resource)
-	if err != nil {
-		return nil, err
-	}
-
-	return autorest.NewBearerAuthorizer(spToken), nil
+	return s.ClientCredentialsAuthorizerWithResource(resource)
 }
 
 // NewAuthorizerFromCLI creates an Authorizer configured from Azure CLI 2.0 for local development scenarios.
 func NewAuthorizerFromCLI() (autorest.Authorizer, error) {
-	settings, err := getAuthenticationSettings()
+	settings, err := GetSettingsFromEnvironment()
 	if err != nil {
 		return nil, err
 	}
 
-	if settings.resource == "" {
-		settings.resource = settings.environment.ResourceManagerEndpoint
+	if settings.Values[Resource] == "" {
+		settings.Values[Resource] = settings.Environment.ResourceManagerEndpoint
 	}
 
-	return NewAuthorizerFromCLIWithResource(settings.resource)
+	return NewAuthorizerFromCLIWithResource(settings.Values[Resource])
 }
 
 // NewAuthorizerFromCLIWithResource creates an Authorizer configured from Azure CLI 2.0 for local development scenarios.
@@ -197,44 +267,117 @@ func NewAuthorizerFromCLIWithResource(resource string) (autorest.Authorizer, err
 	return autorest.NewBearerAuthorizer(&adalToken), nil
 }
 
-func getAuthFile() (*file, error) {
+// GetSettingsFromFile returns the available authentication settings from an Azure CLI authentication file.
+func GetSettingsFromFile() (FileSettings, error) {
+	s := FileSettings{}
 	fileLocation := os.Getenv("AZURE_AUTH_LOCATION")
 	if fileLocation == "" {
-		return nil, errors.New("environment variable AZURE_AUTH_LOCATION is not set")
+		return s, errors.New("environment variable AZURE_AUTH_LOCATION is not set")
 	}
 
 	contents, err := ioutil.ReadFile(fileLocation)
 	if err != nil {
-		return nil, err
+		return s, err
 	}
 
 	// Auth file might be encoded
 	decoded, err := decode(contents)
 	if err != nil {
-		return nil, err
+		return s, err
 	}
 
-	authFile := file{}
+	authFile := map[string]interface{}{}
 	err = json.Unmarshal(decoded, &authFile)
+	if err != nil {
+		return s, err
+	}
+
+	s.Values = map[string]string{}
+	s.setKeyValue(ClientID, authFile["clientId"])
+	s.setKeyValue(ClientSecret, authFile["clientSecret"])
+	s.setKeyValue(CertificatePath, authFile["clientCertificate"])
+	s.setKeyValue(CertificatePassword, authFile["clientCertificatePassword"])
+	s.setKeyValue(SubscriptionID, authFile["subscriptionId"])
+	s.setKeyValue(TenantID, authFile["tenantId"])
+	s.setKeyValue(ActiveDirectoryEndpoint, authFile["activeDirectoryEndpointUrl"])
+	s.setKeyValue(ResourceManagerEndpoint, authFile["resourceManagerEndpointUrl"])
+	s.setKeyValue(GraphResourceID, authFile["activeDirectoryGraphResourceId"])
+	s.setKeyValue(SQLManagementEndpoint, authFile["sqlManagementEndpointUrl"])
+	s.setKeyValue(GalleryEndpoint, authFile["galleryEndpointUrl"])
+	s.setKeyValue(ManagementEndpoint, authFile["managementEndpointUrl"])
+	return s, nil
+}
+
+// FileSettings contains the available authentication settings.
+type FileSettings struct {
+	Values map[string]string
+}
+
+// GetSubscriptionID returns the available subscription ID or an empty string.
+func (settings FileSettings) GetSubscriptionID() string {
+	return settings.Values[SubscriptionID]
+}
+
+// adds the specified value to the Values map if it isn't nil
+func (settings FileSettings) setKeyValue(key string, val interface{}) {
+	if val != nil {
+		settings.Values[key] = val.(string)
+	}
+}
+
+// returns the specified AAD endpoint or the public cloud endpoint if unspecified
+func (settings FileSettings) getAADEndpoint() string {
+	if v, ok := settings.Values[ActiveDirectoryEndpoint]; ok {
+		return v
+	}
+	return azure.PublicCloud.ActiveDirectoryEndpoint
+}
+
+// ClientCredentialsAuthorizer creates an authorizer from the available client credentials.
+func (settings FileSettings) ClientCredentialsAuthorizer(baseURI string) (autorest.Authorizer, error) {
+	resource, err := settings.getResourceForToken(baseURI)
+	if err != nil {
+		return nil, err
+	}
+	return settings.ClientCredentialsAuthorizerWithResource(resource)
+}
+
+// ClientCredentialsAuthorizerWithResource creates an authorizer from the available client credentials and the specified resource.
+func (settings FileSettings) ClientCredentialsAuthorizerWithResource(resource string) (autorest.Authorizer, error) {
+	if _, ok := settings.Values[ClientSecret]; !ok {
+		return nil, errors.New("missing client secret")
+	}
+	config, err := adal.NewOAuthConfig(settings.getAADEndpoint(), settings.Values[TenantID])
 	if err != nil {
 		return nil, err
 	}
 
-	return &authFile, nil
+	spToken, err := adal.NewServicePrincipalToken(*config, settings.Values[ClientID], settings.Values[ClientSecret], resource)
+	if err != nil {
+		return nil, err
+	}
+
+	return autorest.NewBearerAuthorizer(spToken), nil
 }
 
-// File represents the authentication file
-type file struct {
-	ClientID                string `json:"clientId,omitempty"`
-	ClientSecret            string `json:"clientSecret,omitempty"`
-	SubscriptionID          string `json:"subscriptionId,omitempty"`
-	TenantID                string `json:"tenantId,omitempty"`
-	ActiveDirectoryEndpoint string `json:"activeDirectoryEndpointUrl,omitempty"`
-	ResourceManagerEndpoint string `json:"resourceManagerEndpointUrl,omitempty"`
-	GraphResourceID         string `json:"activeDirectoryGraphResourceId,omitempty"`
-	SQLManagementEndpoint   string `json:"sqlManagementEndpointUrl,omitempty"`
-	GalleryEndpoint         string `json:"galleryEndpointUrl,omitempty"`
-	ManagementEndpoint      string `json:"managementEndpointUrl,omitempty"`
+// ClientCertificateAuthorizer creates an authorizer from the available certificate credentials.
+func (settings FileSettings) ClientCertificateAuthorizer(baseURI string) (autorest.Authorizer, error) {
+	resource, err := settings.getResourceForToken(baseURI)
+	if err != nil {
+		return nil, err
+	}
+	return settings.ClientCertificateAuthorizerWithResource(resource)
+}
+
+// ClientCertificateAuthorizerWithResource creates an authorizer from the available certificate credentials and the specified resource.
+func (settings FileSettings) ClientCertificateAuthorizerWithResource(resource string) (autorest.Authorizer, error) {
+	if _, ok := settings.Values[CertificatePath]; !ok {
+		return nil, errors.New("missing certificate path")
+	}
+	cfg := NewClientCertificateConfig(settings.Values[CertificatePath], settings.Values[CertificatePassword], settings.Values[ClientID], settings.Values[TenantID])
+	cfg.AADEndpoint = settings.getAADEndpoint()
+	cfg.Resource = resource
+	return cfg.Authorizer()
 }
 
 func decode(b []byte) ([]byte, error) {
@@ -259,7 +402,7 @@ func decode(b []byte) ([]byte, error) {
 	return ioutil.ReadAll(reader)
 }
 
-func getResourceForToken(f file, baseURI string) (string, error) {
+func (settings FileSettings) getResourceForToken(baseURI string) (string, error) {
 	// Compare dafault base URI from the SDK to the endpoints from the public cloud
 	// Base URI and token resource are the same string. This func finds the authentication
 	// file field that matches the SDK base URI. The SDK defines the public cloud
@@ -269,15 +412,15 @@ func getResourceForToken(f file, baseURI string) (string, error) {
 	}
 	switch baseURI {
 	case azure.PublicCloud.ServiceManagementEndpoint:
-		return f.ManagementEndpoint, nil
+		return settings.Values[ManagementEndpoint], nil
 	case azure.PublicCloud.ResourceManagerEndpoint:
-		return f.ResourceManagerEndpoint, nil
+		return settings.Values[ResourceManagerEndpoint], nil
 	case azure.PublicCloud.ActiveDirectoryEndpoint:
-		return f.ActiveDirectoryEndpoint, nil
+		return settings.Values[ActiveDirectoryEndpoint], nil
 	case azure.PublicCloud.GalleryEndpoint:
-		return f.GalleryEndpoint, nil
+		return settings.Values[GalleryEndpoint], nil
 	case azure.PublicCloud.GraphEndpoint:
-		return f.GraphResourceID, nil
+		return settings.Values[GraphResourceID], nil
 	}
 	return "", fmt.Errorf("auth: base URI not found in endpoints")
 }

--- a/autorest/azure/auth/auth_test.go
+++ b/autorest/azure/auth/auth_test.go
@@ -15,28 +15,184 @@
 package auth
 
 import (
-	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
+
+	"github.com/Azure/go-autorest/autorest/azure"
 )
 
 var (
-	expectedFile = file{
-		ClientID:                "client-id-123",
-		ClientSecret:            "client-secret-456",
-		SubscriptionID:          "sub-id-789",
-		TenantID:                "tenant-id-123",
-		ActiveDirectoryEndpoint: "https://login.microsoftonline.com",
-		ResourceManagerEndpoint: "https://management.azure.com/",
-		GraphResourceID:         "https://graph.windows.net/",
-		SQLManagementEndpoint:   "https://management.core.windows.net:8443/",
-		GalleryEndpoint:         "https://gallery.azure.com/",
-		ManagementEndpoint:      "https://management.core.windows.net/",
+	expectedEnvironment = EnvironmentSettings{
+		Values: map[string]string{
+			SubscriptionID:      "sub-abc-123",
+			TenantID:            "tenant-abc-123",
+			ClientID:            "client-abc-123",
+			ClientSecret:        "client-secret-123",
+			CertificatePath:     "~/some/path/cert.pfx",
+			CertificatePassword: "certificate-password",
+			Username:            "user-name-abc",
+			Password:            "user-password-123",
+			Resource:            "my-resource",
+		},
+		Environment: azure.PublicCloud,
+	}
+	expectedFile = FileSettings{
+		Values: map[string]string{
+			ClientID:                "client-id-123",
+			ClientSecret:            "client-secret-456",
+			SubscriptionID:          "sub-id-789",
+			TenantID:                "tenant-id-123",
+			ActiveDirectoryEndpoint: "https://login.microsoftonline.com",
+			ResourceManagerEndpoint: "https://management.azure.com/",
+			GraphResourceID:         "https://graph.windows.net/",
+			SQLManagementEndpoint:   "https://management.core.windows.net:8443/",
+			GalleryEndpoint:         "https://gallery.azure.com/",
+			ManagementEndpoint:      "https://management.core.windows.net/",
+		},
 	}
 )
+
+func setDefaultEnv() {
+	os.Setenv(SubscriptionID, expectedEnvironment.Values[SubscriptionID])
+	os.Setenv(TenantID, expectedEnvironment.Values[TenantID])
+	os.Setenv(ClientID, expectedEnvironment.Values[ClientID])
+	os.Setenv(ClientSecret, expectedEnvironment.Values[ClientSecret])
+	os.Setenv(CertificatePath, expectedEnvironment.Values[CertificatePath])
+	os.Setenv(CertificatePassword, expectedEnvironment.Values[CertificatePassword])
+	os.Setenv(Username, expectedEnvironment.Values[Username])
+	os.Setenv(Password, expectedEnvironment.Values[Password])
+	os.Setenv(Resource, expectedEnvironment.Values[Resource])
+}
+
+func TestGetSettingsFromEnvironment(t *testing.T) {
+	setDefaultEnv()
+	settings, err := GetSettingsFromEnvironment()
+	if err != nil {
+		t.Logf("failed to get settings: %v", err)
+		t.Fail()
+	}
+	if !reflect.DeepEqual(expectedEnvironment, settings) {
+		t.Logf("expected %v, got %v", expectedEnvironment, settings)
+		t.Fail()
+	}
+	if settings.GetSubscriptionID() != expectedEnvironment.Values[SubscriptionID] {
+		t.Log("settings.GetSubscriptionID() return value didn't match")
+		t.Fail()
+	}
+}
+
+func TestGetSettingsFromEnvironmentBadEnvironmentName(t *testing.T) {
+	os.Setenv(EnvironmentName, "badenvironment")
+	defer func() {
+		// must undo this value else other tests will fail
+		os.Setenv(EnvironmentName, "")
+	}()
+	_, err := GetSettingsFromEnvironment()
+	if err == nil {
+		t.Log("unexpected nil error")
+		t.Fail()
+	}
+}
+
+func TestEnvGetClientCertificate(t *testing.T) {
+	setDefaultEnv()
+	settings, err := GetSettingsFromEnvironment()
+	if err != nil {
+		t.Logf("failed to get settings: %v", err)
+		t.Fail()
+	}
+	cfg, err := settings.GetClientCertificate()
+	if err != nil {
+		t.Logf("failed to get config for client cert: %v", err)
+		t.Fail()
+	}
+	if cfg.CertificatePath != expectedEnvironment.Values[CertificatePath] {
+		t.Log("bad certificate path")
+		t.Fail()
+	}
+	if cfg.CertificatePassword != expectedEnvironment.Values[CertificatePassword] {
+		t.Log("bad certificate password")
+		t.Fail()
+	}
+	// should fail as the certificate doesn't exist
+	_, err = cfg.Authorizer()
+	if err == nil {
+		t.Log("unexpected nil error")
+		t.Fail()
+	}
+}
+
+func TestEnvGetUsernamePassword(t *testing.T) {
+	setDefaultEnv()
+	settings, err := GetSettingsFromEnvironment()
+	if err != nil {
+		t.Logf("failed to get settings: %v", err)
+		t.Fail()
+	}
+	cfg, err := settings.GetUsernamePassword()
+	if err != nil {
+		t.Logf("failed to get config for username/password: %v", err)
+		t.Fail()
+	}
+	_, err = cfg.Authorizer()
+	if err != nil {
+		t.Logf("failed to get authorizer for username/password: %v", err)
+		t.Fail()
+	}
+}
+
+func TestEnvGetMSI(t *testing.T) {
+	setDefaultEnv()
+	settings, err := GetSettingsFromEnvironment()
+	if err != nil {
+		t.Logf("failed to get settings: %v", err)
+		t.Fail()
+	}
+	cfg := settings.GetMSI()
+	_, err = cfg.Authorizer()
+	if err != nil {
+		t.Logf("failed to get authorizer for MSI: %v", err)
+		t.Fail()
+	}
+}
+
+func TestEnvGetDeviceFlow(t *testing.T) {
+	setDefaultEnv()
+	settings, err := GetSettingsFromEnvironment()
+	if err != nil {
+		t.Logf("failed to get settings: %v", err)
+		t.Fail()
+	}
+	cfg := settings.GetDeviceFlow()
+	// TODO mock device flow?
+	if cfg.ClientID != expectedEnvironment.Values[ClientID] {
+		t.Log("bad client ID")
+		t.Fail()
+	}
+	if cfg.TenantID != expectedEnvironment.Values[TenantID] {
+		t.Log("bad tenant ID")
+		t.Fail()
+	}
+}
+
+func TestGetSettingsFromFile(t *testing.T) {
+	os.Setenv("AZURE_AUTH_LOCATION", "./testdata/credsutf16le.json")
+	settings, err := GetSettingsFromFile()
+	if err != nil {
+		t.Logf("failed to load config file: %v", err)
+		t.Fail()
+	}
+	if !reflect.DeepEqual(expectedFile, settings) {
+		t.Logf("expected %v, got %v", expectedFile, settings)
+		t.Fail()
+	}
+	if settings.GetSubscriptionID() != expectedFile.Values[SubscriptionID] {
+		t.Log("settings.GetSubscriptionID() return value didn't match")
+		t.Fail()
+	}
+}
 
 func TestNewAuthorizerFromFile(t *testing.T) {
 	os.Setenv("AZURE_AUTH_LOCATION", "./testdata/credsutf16le.json")
@@ -57,9 +213,7 @@ func TestNewAuthorizerFromFileWithResource(t *testing.T) {
 }
 
 func TestNewAuthorizerFromEnvironment(t *testing.T) {
-	os.Setenv("AZURE_TENANT_ID", expectedFile.TenantID)
-	os.Setenv("AZURE_CLIENT_ID", expectedFile.ClientID)
-	os.Setenv("AZURE_CLIENT_SECRET", expectedFile.ClientSecret)
+	setDefaultEnv()
 	authorizer, err := NewAuthorizerFromEnvironment()
 
 	if err != nil || authorizer == nil {
@@ -69,9 +223,7 @@ func TestNewAuthorizerFromEnvironment(t *testing.T) {
 }
 
 func TestNewAuthorizerFromEnvironmentWithResource(t *testing.T) {
-	os.Setenv("AZURE_TENANT_ID", expectedFile.TenantID)
-	os.Setenv("AZURE_CLIENT_ID", expectedFile.ClientID)
-	os.Setenv("AZURE_CLIENT_SECRET", expectedFile.ClientSecret)
+	setDefaultEnv()
 	authorizer, err := NewAuthorizerFromEnvironmentWithResource("https://my.vault.azure.net")
 
 	if err != nil || authorizer == nil {
@@ -87,37 +239,32 @@ func TestDecodeAndUnmarshal(t *testing.T) {
 		"credsutf16be.json",
 	}
 	for _, test := range tests {
-		b, err := ioutil.ReadFile(filepath.Join("./testdata/", test))
+		os.Setenv("AZURE_AUTH_LOCATION", filepath.Join("./testdata/", test))
+		settings, err := GetSettingsFromFile()
 		if err != nil {
 			t.Logf("error reading file '%s': %s", test, err)
 			t.Fail()
 		}
-		decoded, err := decode(b)
-		if err != nil {
-			t.Logf("error decoding file '%s': %s", test, err)
-			t.Fail()
-		}
-		var got file
-		err = json.Unmarshal(decoded, &got)
-		if err != nil {
-			t.Logf("error unmarshaling file '%s': %s", test, err)
-			t.Fail()
-		}
-		if !reflect.DeepEqual(expectedFile, got) {
-			t.Logf("unmarshaled map expected %v, got %v", expectedFile, got)
+		if !reflect.DeepEqual(expectedFile, settings) {
+			t.Logf("unmarshaled map expected %v, got %v", expectedFile, settings)
 			t.Fail()
 		}
 	}
 }
 
-func areMapsEqual(a, b map[string]string) bool {
-	if len(a) != len(b) {
-		return false
+func TestFileClientCertificateAuthorizer(t *testing.T) {
+	os.Setenv("AZURE_AUTH_LOCATION", "./testdata/credsutf8.json")
+	settings, err := GetSettingsFromFile()
+	if err != nil {
+		t.Logf("failed to load file settings: %v", err)
+		t.Fail()
 	}
-	for k := range a {
-		if a[k] != b[k] {
-			return false
-		}
+	// add certificate settings
+	settings.Values[CertificatePath] = "~/fake/path/cert.pfx"
+	settings.Values[CertificatePassword] = "fake-password"
+	_, err = settings.ClientCertificateAuthorizer("https://management.azure.com")
+	if err == nil {
+		t.Log("unexpected nil error")
+		t.Fail()
 	}
-	return true
 }

--- a/autorest/version.go
+++ b/autorest/version.go
@@ -19,7 +19,7 @@ import (
 	"runtime"
 )
 
-const number = "v11.4.0"
+const number = "v11.5.0"
 
 var (
 	userAgent = fmt.Sprintf("Go/%s (%s-%s) go-autorest/%s",


### PR DESCRIPTION
The loading of environment and file settings has been refactored and
exported so that consumers have access to the raw data.
The steps performed in NewAuthorizerFromEnvironment() have been broken
down into methods on EnvironmentSettings so that consumers can build
custom authorization chains.
Added support for certificate authorization for file-based config.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.