### PR TITLE
Set minimum version of TLS to 1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,9 @@ sudo: false
 language: go
 
 go:
-  - master
-  - 1.11.x
   - 1.10.x
-
-matrix:
-  allow_failures:
-    - go: master
+  - 1.11.x
+  - 1.12.x
 
 env:
   - DEP_VERSION="0.5.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v11.5.1
+
+### Bug Fixes
+
+- In `Client.sender()` set the minimum TLS version on HTTP clients to 1.2.
+
 ## v11.5.0
 
 ### New Features

--- a/autorest/adal/persist_test.go
+++ b/autorest/adal/persist_test.go
@@ -133,13 +133,13 @@ func TestSaveToken(t *testing.T) {
 	var actualToken Token
 	var expectedToken Token
 
-	json.Unmarshal([]byte(MockTokenJSON), expectedToken)
+	json.Unmarshal([]byte(MockTokenJSON), &expectedToken)
 
 	contents, err := ioutil.ReadFile(f.Name())
 	if err != nil {
 		t.Fatal("!!")
 	}
-	json.Unmarshal(contents, actualToken)
+	json.Unmarshal(contents, &actualToken)
 
 	if !reflect.DeepEqual(actualToken, expectedToken) {
 		t.Fatal("azure: token was not serialized correctly")

--- a/autorest/client.go
+++ b/autorest/client.go
@@ -16,6 +16,7 @@ package autorest
 
 import (
 	"bytes"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -230,6 +231,12 @@ func (c Client) Do(r *http.Request) (*http.Response, error) {
 func (c Client) sender() Sender {
 	if c.Sender == nil {
 		j, _ := cookiejar.New(nil)
+		tracing.Transport.Base = &http.Transport{
+			TLSClientConfig: &tls.Config{
+				MinVersion:               tls.VersionTLS12,
+				PreferServerCipherSuites: true,
+			},
+		}
 		client := &http.Client{Jar: j, Transport: tracing.Transport}
 		return client
 	}

--- a/autorest/client.go
+++ b/autorest/client.go
@@ -233,8 +233,7 @@ func (c Client) sender() Sender {
 		j, _ := cookiejar.New(nil)
 		tracing.Transport.Base = &http.Transport{
 			TLSClientConfig: &tls.Config{
-				MinVersion:               tls.VersionTLS12,
-				PreferServerCipherSuites: true,
+				MinVersion: tls.VersionTLS12,
 			},
 		}
 		client := &http.Client{Jar: j, Transport: tracing.Transport}

--- a/autorest/version.go
+++ b/autorest/version.go
@@ -19,7 +19,7 @@ import (
 	"runtime"
 )
 
-const number = "v11.5.0"
+const number = "v11.5.1"
 
 var (
 	userAgent = fmt.Sprintf("Go/%s (%s-%s) go-autorest/%s",


### PR DESCRIPTION
When creating an HTTP client set the minimum version of TLS to 1.2 and
prefer server ciphers.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.