### PR TITLE
Fix GetTokenFromCLI cannot work in zsh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v11.5.2
+
+### Bug Fixes
+
+- Fixed `GetTokenFromCLI` did not work with zsh.
+
 ## v11.5.1
 
 ### Bug Fixes

--- a/autorest/azure/cli/token.go
+++ b/autorest/azure/cli/token.go
@@ -126,7 +126,7 @@ func GetTokenFromCLI(resource string) (*Token, error) {
 	azureCLIDefaultPathWindows := fmt.Sprintf("%s\\Microsoft SDKs\\Azure\\CLI2\\wbin; %s\\Microsoft SDKs\\Azure\\CLI2\\wbin", os.Getenv("ProgramFiles(x86)"), os.Getenv("ProgramFiles"))
 
 	// Default path for non-Windows.
-	const azureCLIDefaultPath = "/usr/bin:/usr/local/bin"
+	const azureCLIDefaultPath = "/bin:/sbin:/usr/bin:/usr/local/bin"
 
 	// Validate resource, since it gets sent as a command line argument to Azure CLI
 	const invalidResourceErrorTemplate = "Resource %s is not in expected format. Only alphanumeric characters, [dot], [colon], [hyphen], and [forward slash] are allowed."
@@ -144,13 +144,13 @@ func GetTokenFromCLI(resource string) (*Token, error) {
 		cliCmd = exec.Command(fmt.Sprintf("%s\\system32\\cmd.exe", os.Getenv("windir")))
 		cliCmd.Env = os.Environ()
 		cliCmd.Env = append(cliCmd.Env, fmt.Sprintf("PATH=%s;%s", os.Getenv(azureCLIPath), azureCLIDefaultPathWindows))
-		cliCmd.Args = append(cliCmd.Args, "/c")
+		cliCmd.Args = append(cliCmd.Args, "/c", "az")
 	} else {
-		cliCmd = exec.Command(os.Getenv("SHELL"))
+		cliCmd = exec.Command("az")
 		cliCmd.Env = os.Environ()
 		cliCmd.Env = append(cliCmd.Env, fmt.Sprintf("PATH=%s:%s", os.Getenv(azureCLIPath), azureCLIDefaultPath))
 	}
-	cliCmd.Args = append(cliCmd.Args, "az", "account", "get-access-token", "-o", "json", "--resource", resource)
+	cliCmd.Args = append(cliCmd.Args, "account", "get-access-token", "-o", "json", "--resource", resource)
 
 	var stderr bytes.Buffer
 	cliCmd.Stderr = &stderr

--- a/autorest/version.go
+++ b/autorest/version.go
@@ -19,7 +19,7 @@ import (
 	"runtime"
 )
 
-const number = "v11.5.1"
+const number = "v11.5.2"
 
 var (
 	userAgent = fmt.Sprintf("Go/%s (%s-%s) go-autorest/%s",


### PR DESCRIPTION
GetTokenFromCLI uses shell to launch az when obtaining tokens.
This approach may produce an error under zsh as zsh doesn't always
assume the shell script to be located in /usr/bin.

As the environment variable PATH is set when executing, it can
rely on the shell to locate az CLI script rather than explicitly
specifying the shell.
