### PR TITLE
tracing: fix proxy support for default sender (#379)

### DIFF
--- a/autorest/client.go
+++ b/autorest/client.go
@@ -230,14 +230,16 @@ func (c Client) Do(r *http.Request) (*http.Response, error) {
 // sender returns the Sender to which to send requests.
 func (c Client) sender() Sender {
 	if c.Sender == nil {
-		j, _ := cookiejar.New(nil)
-		tracing.Transport.Base = &http.Transport{
-			TLSClientConfig: &tls.Config{
-				MinVersion: tls.VersionTLS12,
-			},
+		// Use behaviour compatible with DefaultTransport, but require TLS minimum version.
+		var baseTransport = *http.DefaultTransport.(*http.Transport)
+
+		baseTransport.TLSClientConfig = &tls.Config{
+			MinVersion: tls.VersionTLS12,
 		}
-		client := &http.Client{Jar: j, Transport: tracing.Transport}
-		return client
+		tracing.Transport.Base = &baseTransport
+
+		j, _ := cookiejar.New(nil)
+		return &http.Client{Jar: j, Transport: tracing.Transport}
 	}
 
 	return c.Sender


### PR DESCRIPTION
This resolves #379 by using the default of http.DefaultTransport without modifying the global object.