### PR TITLE
Adding ByteSlicePtr

### DIFF
--- a/autorest/to/convert.go
+++ b/autorest/to/convert.go
@@ -145,3 +145,8 @@ func Float64(i *float64) float64 {
 func Float64Ptr(i float64) *float64 {
 	return &i
 }
+
+// ByteSlicePtr returns a pointer to the passed byte slice.
+func ByteSlicePtr(b []byte) *[]byte {
+	return &b
+}

--- a/autorest/to/convert_test.go
+++ b/autorest/to/convert_test.go
@@ -232,3 +232,11 @@ func TestFloat64Ptr(t *testing.T) {
 			v, *Float64Ptr(v))
 	}
 }
+
+func TestByteSlicePtr(t *testing.T) {
+	v := []byte("bytes")
+	if out := ByteSlicePtr(v); !reflect.DeepEqual(*out, v) {
+		t.Fatalf("to: ByteSlicePtr failed to return the correct slice -- expected %v, received %v",
+			v, *out)
+	}
+}


### PR DESCRIPTION
Adding `to.ByteSlicePtr(b []byte)`.  Would love to have this little tool in this great collection.

--- 

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [x] I've tested my changes, adding unit tests if applicable.
 - [x] I've added Apache 2.0 Headers to the top of any new source files.
 - [x] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.