### PR TITLE
Adding a new `WithXML` method

### DIFF
--- a/autorest/preparer.go
+++ b/autorest/preparer.go
@@ -17,6 +17,7 @@ package autorest
 import (
 	"bytes"
 	"encoding/json"
+	"encoding/xml"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -370,6 +371,28 @@ func WithJSON(v interface{}) PrepareDecorator {
 				if err == nil {
 					r.ContentLength = int64(len(b))
 					r.Body = ioutil.NopCloser(bytes.NewReader(b))
+				}
+			}
+			return r, err
+		})
+	}
+}
+
+// WithXML returns a PrepareDecorator that encodes the data passed as XML into the body of the
+// request and sets the Content-Length header.
+func WithXML(v interface{}) PrepareDecorator {
+	return func(p Preparer) Preparer {
+		return PreparerFunc(func(r *http.Request) (*http.Request, error) {
+			r, err := p.Prepare(r)
+			if err == nil {
+				b, err := xml.Marshal(v)
+				if err == nil {
+					// we have to tack on an XML header
+					withHeader := xml.Header + string(b)
+					bytesWithHeader := []byte(withHeader)
+
+					r.ContentLength = int64(len(bytesWithHeader))
+					r.Body = ioutil.NopCloser(bytes.NewReader(bytesWithHeader))
 				}
 			}
 			return r, err

--- a/autorest/preparer_test.go
+++ b/autorest/preparer_test.go
@@ -238,6 +238,26 @@ func ExampleWithJSON() {
 	// Output: Request Body contains {"name":"Rob Pike","age":42}
 }
 
+// Create a request whose Body is the XML encoding of a structure
+func ExampleWithXML() {
+	t := mocks.T{Name: "Rob Pike", Age: 42}
+
+	r, err := Prepare(&http.Request{},
+		WithXML(&t))
+	if err != nil {
+		fmt.Printf("ERROR: %v\n", err)
+	}
+
+	b, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		fmt.Printf("ERROR: %v\n", err)
+	} else {
+		fmt.Printf("Request Body contains %s\n", string(b))
+	}
+	// Output: Request Body contains <?xml version="1.0" encoding="UTF-8"?>
+	// <T><Name>Rob Pike</Name><Age>42</Age></T>
+}
+
 // Create a request from a path with escaped parameters
 func ExampleWithEscapedPathParameters() {
 	params := map[string]interface{}{


### PR DESCRIPTION
This PR includes a new Preparer `WithXML` which serializes XML (including the document header) into the HTTP Request

---

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [x] I've tested my changes, adding unit tests if applicable.
 - [x] I've added Apache 2.0 Headers to the top of any new source files.
 - [x] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.