### PR TITLE
Add HTTP status code response helpers

### DIFF
--- a/autorest/client.go
+++ b/autorest/client.go
@@ -73,6 +73,22 @@ type Response struct {
 	*http.Response `json:"-"`
 }
 
+// IsHTTPStatus returns true if the returned HTTP status code matches the provided status code.
+// If there was no response (i.e. the underlying http.Response is nil) the return value is false.
+func (r Response) IsHTTPStatus(statusCode int) bool {
+	if r.Response == nil {
+		return false
+	}
+	return r.Response.StatusCode == statusCode
+}
+
+// HasHTTPStatus returns true if the returned HTTP status code matches one of the provided status codes.
+// If there was no response (i.e. the underlying http.Response is nil) or not status codes are provided
+// the return value is false.
+func (r Response) HasHTTPStatus(statusCodes ...int) bool {
+	return ResponseHasStatusCode(r.Response, statusCodes...)
+}
+
 // LoggingInspector implements request and response inspectors that log the full request and
 // response to a supplied log.
 type LoggingInspector struct {

--- a/autorest/client_test.go
+++ b/autorest/client_test.go
@@ -435,6 +435,37 @@ func TestCookies(t *testing.T) {
 	}
 }
 
+func TestResponseIsHTTPStatus(t *testing.T) {
+	r := Response{}
+	if r.IsHTTPStatus(http.StatusBadRequest) {
+		t.Fatal("autorest: expected false for nil response")
+	}
+	r.Response = &http.Response{StatusCode: http.StatusOK}
+	if r.IsHTTPStatus(http.StatusBadRequest) {
+		t.Fatal("autorest: expected false")
+	}
+	if !r.IsHTTPStatus(http.StatusOK) {
+		t.Fatal("autorest: expected true")
+	}
+}
+
+func TestResponseHasHTTPStatus(t *testing.T) {
+	r := Response{}
+	if r.HasHTTPStatus(http.StatusBadRequest, http.StatusInternalServerError) {
+		t.Fatal("autorest: expected false for nil response")
+	}
+	r.Response = &http.Response{StatusCode: http.StatusAccepted}
+	if r.HasHTTPStatus(http.StatusBadRequest, http.StatusInternalServerError) {
+		t.Fatal("autorest: expected false")
+	}
+	if !r.HasHTTPStatus(http.StatusOK, http.StatusCreated, http.StatusAccepted) {
+		t.Fatal("autorest: expected true")
+	}
+	if r.HasHTTPStatus() {
+		t.Fatal("autorest: expected false for no status codes")
+	}
+}
+
 func randomString(n int) string {
 	const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
 	r := rand.New(rand.NewSource(time.Now().UTC().UnixNano()))


### PR DESCRIPTION
Added IsHTTPStatus() and HasHTTPStatus() methods to autorest.Response

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.