### PR TITLE
Adding a new Preparer for the `MERGE` header

### DIFF
--- a/autorest/preparer.go
+++ b/autorest/preparer.go
@@ -191,6 +191,9 @@ func AsGet() PrepareDecorator { return WithMethod("GET") }
 // AsHead returns a PrepareDecorator that sets the HTTP method to HEAD.
 func AsHead() PrepareDecorator { return WithMethod("HEAD") }
 
+// AsMerge returns a PrepareDecorator that sets the HTTP method to MERGE.
+func AsMerge() PrepareDecorator { return WithMethod("MERGE") }
+
 // AsOptions returns a PrepareDecorator that sets the HTTP method to OPTIONS.
 func AsOptions() PrepareDecorator { return WithMethod("OPTIONS") }
 

--- a/autorest/preparer_test.go
+++ b/autorest/preparer_test.go
@@ -468,6 +468,13 @@ func TestAsHead(t *testing.T) {
 	}
 }
 
+func TestAsMerge(t *testing.T) {
+	r, _ := Prepare(mocks.NewRequest(), AsMerge())
+	if r.Method != "MERGE" {
+		t.Fatal("autorest: AsMerge failed to set HTTP method header to MERGE")
+	}
+}
+
 func TestAsOptions(t *testing.T) {
 	r, _ := Prepare(mocks.NewRequest(), AsOptions())
 	if r.Method != "OPTIONS" {


### PR DESCRIPTION
Some of [the Storage API's use the HTTP Header `MERGE`](https://docs.microsoft.com/en-us/rest/api/storageservices/insert-or-merge-entity) - since this SDK provides convenience wrappers for other methods - this PR adds a convenience method for the Merge header too.

---

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [x] I've tested my changes, adding unit tests if applicable.
 - [x] I've added Apache 2.0 Headers to the top of any new source files.
 - [x] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.