### PR TITLE
New Preparer/Responder for `Unmarshalling Bytes`

### DIFF
--- a/autorest/mocks/helpers.go
+++ b/autorest/mocks/helpers.go
@@ -90,6 +90,19 @@ func NewResponse() *http.Response {
 	return NewResponseWithContent("")
 }
 
+// NewResponseWithBytes instantiates a new response with the passed bytes as the body content.
+func NewResponseWithBytes(input []byte) *http.Response {
+	return &http.Response{
+		Status:     "200 OK",
+		StatusCode: 200,
+		Proto:      "HTTP/1.0",
+		ProtoMajor: 1,
+		ProtoMinor: 0,
+		Body:       NewBodyWithBytes(input),
+		Request:    NewRequest(),
+	}
+}
+
 // NewResponseWithContent instantiates a new response with the passed string as the body content.
 func NewResponseWithContent(c string) *http.Response {
 	return &http.Response{

--- a/autorest/mocks/mocks.go
+++ b/autorest/mocks/mocks.go
@@ -37,6 +37,11 @@ func NewBody(s string) *Body {
 	return (&Body{s: s}).reset()
 }
 
+// NewBodyWithBytes creates a new instance of Body.
+func NewBodyWithBytes(b []byte) *Body {
+	return (&Body{s: string(b)}).reset()
+}
+
 // NewBodyClose creates a new instance of Body.
 func NewBodyClose(s string) *Body {
 	return &Body{s: s}

--- a/autorest/mocks/mocks.go
+++ b/autorest/mocks/mocks.go
@@ -39,7 +39,10 @@ func NewBody(s string) *Body {
 
 // NewBodyWithBytes creates a new instance of Body.
 func NewBodyWithBytes(b []byte) *Body {
-	return (&Body{s: string(b)}).reset()
+	return &Body{
+		b:      b,
+		isOpen: true,
+	}
 }
 
 // NewBodyClose creates a new instance of Body.

--- a/autorest/preparer.go
+++ b/autorest/preparer.go
@@ -226,6 +226,25 @@ func WithBaseURL(baseURL string) PrepareDecorator {
 	}
 }
 
+// WithBytes returns a PrepareDecorator that takes a list of bytes
+// which passes the bytes directly to the body
+func WithBytes(input *[]byte) PrepareDecorator {
+	return func(p Preparer) Preparer {
+		return PreparerFunc(func(r *http.Request) (*http.Request, error) {
+			r, err := p.Prepare(r)
+			if err == nil {
+				if input == nil {
+					return r, fmt.Errorf("Input Bytes was nil")
+				}
+
+				r.ContentLength = int64(len(*input))
+				r.Body = ioutil.NopCloser(bytes.NewReader(*input))
+			}
+			return r, err
+		})
+	}
+}
+
 // WithCustomBaseURL returns a PrepareDecorator that replaces brace-enclosed keys within the
 // request base URL (i.e., http.Request.URL) with the corresponding values from the passed map.
 func WithCustomBaseURL(baseURL string, urlParameters map[string]interface{}) PrepareDecorator {

--- a/autorest/preparer_test.go
+++ b/autorest/preparer_test.go
@@ -163,6 +163,30 @@ func ExampleWithBaseURL_second() {
 	// Output: parse :: missing protocol scheme
 }
 
+// Create a request whose Body is a byte array
+func TestWithBytes(t *testing.T) {
+	input := []byte{41, 82, 109}
+
+	r, err := Prepare(&http.Request{},
+		WithBytes(&input))
+	if err != nil {
+		t.Fatalf("ERROR: %v\n", err)
+	}
+
+	b, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		t.Fatalf("ERROR: %v\n", err)
+	}
+
+	if len(b) != len(input) {
+		t.Fatalf("Expected the Body to contain %d bytes but got %d", len(input), len(b))
+	}
+
+	if !reflect.DeepEqual(b, input) {
+		t.Fatalf("Body doesn't contain the same bytes: %s (Expected %s)", b, input)
+	}
+}
+
 func ExampleWithCustomBaseURL() {
 	r, err := Prepare(&http.Request{},
 		WithCustomBaseURL("https://{account}.{service}.core.windows.net/",

--- a/autorest/responder.go
+++ b/autorest/responder.go
@@ -164,7 +164,7 @@ func ByUnmarshallingBytes(v *[]byte) RespondDecorator {
 				if errInner != nil {
 					err = fmt.Errorf("Error occurred reading http.Response#Body - Error = '%v'", errInner)
 				} else {
-					copy(*v, bytes)
+					v = &bytes
 				}
 			}
 			return err

--- a/autorest/responder.go
+++ b/autorest/responder.go
@@ -164,7 +164,7 @@ func ByUnmarshallingBytes(v *[]byte) RespondDecorator {
 				if errInner != nil {
 					err = fmt.Errorf("Error occurred reading http.Response#Body - Error = '%v'", errInner)
 				} else {
-					v = &bytes
+					*v = bytes
 				}
 			}
 			return err

--- a/autorest/responder.go
+++ b/autorest/responder.go
@@ -153,6 +153,25 @@ func ByClosingIfError() RespondDecorator {
 	}
 }
 
+// ByUnmarshallingBytes returns a RespondDecorator that copies the Bytes returned in the
+// response Body into the value pointed to by v.
+func ByUnmarshallingBytes(v *[]byte) RespondDecorator {
+	return func(r Responder) Responder {
+		return ResponderFunc(func(resp *http.Response) error {
+			err := r.Respond(resp)
+			if err == nil {
+				bytes, errInner := ioutil.ReadAll(resp.Body)
+				if errInner != nil {
+					err = fmt.Errorf("Error occurred reading http.Response#Body - Error = '%v'", errInner)
+				} else {
+					copy(*v, bytes)
+				}
+			}
+			return err
+		})
+	}
+}
+
 // ByUnmarshallingJSON returns a RespondDecorator that decodes a JSON document returned in the
 // response Body into the value pointed to by v.
 func ByUnmarshallingJSON(v interface{}) RespondDecorator {

--- a/autorest/responder_test.go
+++ b/autorest/responder_test.go
@@ -48,6 +48,25 @@ func ExampleWithErrorUnlessOK() {
 	// Output: GET of https://microsoft.com/a/b/c/ returned HTTP 200
 }
 
+func TestByUnmarshallingBytes(t *testing.T) {
+	expected := []byte("Lorem Ipsum Dolor")
+
+	// we'll create a fixed-sized array here, since that's the expectation
+	var bytes = make([]byte, len(expected))
+
+	Respond(mocks.NewResponseWithBytes(expected),
+		ByUnmarshallingBytes(&bytes),
+		ByClosing())
+
+	if len(bytes) != len(expected) {
+		t.Fatalf("Expected Response to be %d bytes but got %d bytes", len(expected), len(bytes))
+	}
+
+	if !reflect.DeepEqual(expected, bytes) {
+		t.Fatalf("Expected Response to be %s but got %s", expected, bytes)
+	}
+}
+
 func ExampleByUnmarshallingJSON() {
 	c := `
 	{

--- a/autorest/responder_test.go
+++ b/autorest/responder_test.go
@@ -52,7 +52,7 @@ func TestByUnmarshallingBytes(t *testing.T) {
 	expected := []byte("Lorem Ipsum Dolor")
 
 	// we'll create a fixed-sized array here, since that's the expectation
-	var bytes = make([]byte, len(expected))
+	bytes := make([]byte, len(expected))
 
 	Respond(mocks.NewResponseWithBytes(expected),
 		ByUnmarshallingBytes(&bytes),


### PR DESCRIPTION
This PR adds a Preparer and a Responder for passing an arbitrary Byte array to the Request, and parsing it from the Response. This is intentionally not using a Reader since the Byte array content is assumed to be coming from specific ranges of a File.

We're using this in the [Get File](https://docs.microsoft.com/en-us/rest/api/storageservices/get-file) and [Put File](https://docs.microsoft.com/en-us/rest/api/storageservices/put-range) endpoints within the Storage SDK we're building that's compatible with Go-Autorest (where I can confirm this works as expected).

---

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [x] I've tested my changes, adding unit tests if applicable.
 - [x] I've added Apache 2.0 Headers to the top of any new source files.
 - [x] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.