### PR TITLE
Environment: adding the Storage Management Endpoint for AzureAD auth

### DIFF
--- a/autorest/azure/environments.go
+++ b/autorest/azure/environments.go
@@ -49,12 +49,13 @@ type ResourceIdentifier struct {
 
 // Environment represents a set of endpoints for each of Azure's Clouds.
 type Environment struct {
-	Name                         string             `json:"name"`
-	ManagementPortalURL          string             `json:"managementPortalURL"`
-	PublishSettingsURL           string             `json:"publishSettingsURL"`
-	ServiceManagementEndpoint    string             `json:"serviceManagementEndpoint"`
-	ResourceManagerEndpoint      string             `json:"resourceManagerEndpoint"`
-	ActiveDirectoryEndpoint      string             `json:"activeDirectoryEndpoint"`
+	Name                         string `json:"name"`
+	ManagementPortalURL          string `json:"managementPortalURL"`
+	PublishSettingsURL           string `json:"publishSettingsURL"`
+	ServiceManagementEndpoint    string `json:"serviceManagementEndpoint"`
+	ResourceManagerEndpoint      string `json:"resourceManagerEndpoint"`
+	ActiveDirectoryEndpoint      string `json:"activeDirectoryEndpoint"`
+	StorageEndpoint              string
 	GalleryEndpoint              string             `json:"galleryEndpoint"`
 	KeyVaultEndpoint             string             `json:"keyVaultEndpoint"`
 	GraphEndpoint                string             `json:"graphEndpoint"`
@@ -82,6 +83,7 @@ var (
 		ServiceManagementEndpoint:    "https://management.core.windows.net/",
 		ResourceManagerEndpoint:      "https://management.azure.com/",
 		ActiveDirectoryEndpoint:      "https://login.microsoftonline.com/",
+		StorageEndpoint:              "https://storage.azure.com/",
 		GalleryEndpoint:              "https://gallery.azure.com/",
 		KeyVaultEndpoint:             "https://vault.azure.net/",
 		GraphEndpoint:                "https://graph.windows.net/",
@@ -114,6 +116,7 @@ var (
 		ServiceManagementEndpoint:    "https://management.core.usgovcloudapi.net/",
 		ResourceManagerEndpoint:      "https://management.usgovcloudapi.net/",
 		ActiveDirectoryEndpoint:      "https://login.microsoftonline.us/",
+		StorageEndpoint:              "https://storage.azure.com/",
 		GalleryEndpoint:              "https://gallery.usgovcloudapi.net/",
 		KeyVaultEndpoint:             "https://vault.usgovcloudapi.net/",
 		GraphEndpoint:                "https://graph.windows.net/",
@@ -146,6 +149,7 @@ var (
 		ServiceManagementEndpoint:    "https://management.core.chinacloudapi.cn/",
 		ResourceManagerEndpoint:      "https://management.chinacloudapi.cn/",
 		ActiveDirectoryEndpoint:      "https://login.chinacloudapi.cn/",
+		StorageEndpoint:              "https://storage.azure.com/",
 		GalleryEndpoint:              "https://gallery.chinacloudapi.cn/",
 		KeyVaultEndpoint:             "https://vault.azure.cn/",
 		GraphEndpoint:                "https://graph.chinacloudapi.cn/",
@@ -178,6 +182,7 @@ var (
 		ServiceManagementEndpoint:    "https://management.core.cloudapi.de/",
 		ResourceManagerEndpoint:      "https://management.microsoftazure.de/",
 		ActiveDirectoryEndpoint:      "https://login.microsoftonline.de/",
+		StorageEndpoint:              "https://storage.azure.com/",
 		GalleryEndpoint:              "https://gallery.cloudapi.de/",
 		KeyVaultEndpoint:             "https://vault.microsoftazure.de/",
 		GraphEndpoint:                "https://graph.cloudapi.de/",


### PR DESCRIPTION
It's possible to authenticate to Azure Storage [using Azure Active Directory authentication](https://docs.microsoft.com/en-us/rest/api/storageservices/authenticate-with-azure-active-directory), which requires generating an Authentication Token against the Storage Management Endpoint.

This PR adds a new variable to the Environment struct which is the Storage Management Endpoint; I can confirm in both Azure Public and Azure Germany that these endpoints are valid, and return tokens via the Azure CLI command:

```bash
$ az account get-access-token --resource "https://storage.azure.com/" -o=json
```

I can confirm this endpoint works in the Azure Storage SDK that we're building using go-autorest as a base for the items above, however I'm unable to confirm the following (but have asked around):

* the Azure China Endpoint
* the Azure Government Endpoint
* if the Endpoint is returned from the MetaData service ([it appears not](http://management.azure.com/metadata/endpoints?api-version=1.0) - but I'm not sure if that fields not returned)

---

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [x] I've tested my changes, adding unit tests if applicable.
 - [x] I've added Apache 2.0 Headers to the top of any new source files.
 - [x] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.