### PR TITLE
Add support for multi-tenant authentication

### DIFF
--- a/autorest/adal/config.go
+++ b/autorest/adal/config.go
@@ -15,8 +15,13 @@ package adal
 //  limitations under the License.
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
+)
+
+const (
+	activeDirectoryEndpointTemplate = "%s/oauth2/%s%s"
 )
 
 // OAuthConfig represents the endpoints needed
@@ -60,7 +65,6 @@ func NewOAuthConfigWithAPIVersion(activeDirectoryEndpoint, tenantID string, apiV
 		}
 		api = fmt.Sprintf("?api-version=%s", *apiVersion)
 	}
-	const activeDirectoryEndpointTemplate = "%s/oauth2/%s%s"
 	u, err := url.Parse(activeDirectoryEndpoint)
 	if err != nil {
 		return nil, err
@@ -88,4 +92,59 @@ func NewOAuthConfigWithAPIVersion(activeDirectoryEndpoint, tenantID string, apiV
 		TokenEndpoint:      *tokenURL,
 		DeviceCodeEndpoint: *deviceCodeURL,
 	}, nil
+}
+
+// MultiTenantOAuthConfig provides endpoints for primary and aulixiary tenant IDs.
+type MultiTenantOAuthConfig interface {
+	PrimaryTenant() *OAuthConfig
+	AuxiliaryTenants() []*OAuthConfig
+}
+
+// Config contains optional OAuthConfig creation arguments.
+type Config struct {
+	APIVersion string
+}
+
+func (c Config) apiVersion() string {
+	if c.APIVersion != "" {
+		return fmt.Sprintf("?api-version=%s", c.APIVersion)
+	}
+	return "1.0"
+}
+
+// NewMultiTenantOAuthConfig creates an object that support multitenant OAuth configuration.
+func NewMultiTenantOAuthConfig(activeDirectoryEndpoint, primaryTenantID string, auxiliaryTenantIDs []string, cfg Config) (MultiTenantOAuthConfig, error) {
+	if len(auxiliaryTenantIDs) == 0 || len(auxiliaryTenantIDs) > 3 {
+		return nil, errors.New("must specify one to three auxiliary tenants")
+	}
+	mtCfg := multiTenantOAuthConfig{
+		cfgs: make([]*OAuthConfig, len(auxiliaryTenantIDs)+1),
+	}
+	apiVer := cfg.apiVersion()
+	pri, err := NewOAuthConfigWithAPIVersion(activeDirectoryEndpoint, primaryTenantID, &apiVer)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create OAuthConfig for primary tenant: %v", err)
+	}
+	mtCfg.cfgs[0] = pri
+	for i := range auxiliaryTenantIDs {
+		aux, err := NewOAuthConfig(activeDirectoryEndpoint, auxiliaryTenantIDs[i])
+		if err != nil {
+			return nil, fmt.Errorf("failed to create OAuthConfig for tenant '%s': %v", auxiliaryTenantIDs[i], err)
+		}
+		mtCfg.cfgs[i+1] = aux
+	}
+	return mtCfg, nil
+}
+
+type multiTenantOAuthConfig struct {
+	// first config in the slice is the primary tenant
+	cfgs []*OAuthConfig
+}
+
+func (m multiTenantOAuthConfig) PrimaryTenant() *OAuthConfig {
+	return m.cfgs[0]
+}
+
+func (m multiTenantOAuthConfig) AuxiliaryTenants() []*OAuthConfig {
+	return m.cfgs[1:]
 }

--- a/autorest/adal/config.go
+++ b/autorest/adal/config.go
@@ -100,12 +100,12 @@ type MultiTenantOAuthConfig interface {
 	AuxiliaryTenants() []*OAuthConfig
 }
 
-// Config contains optional OAuthConfig creation arguments.
-type Config struct {
+// Options contains optional OAuthConfig creation arguments.
+type Options struct {
 	APIVersion string
 }
 
-func (c Config) apiVersion() string {
+func (c Options) apiVersion() string {
 	if c.APIVersion != "" {
 		return fmt.Sprintf("?api-version=%s", c.APIVersion)
 	}
@@ -113,14 +113,15 @@ func (c Config) apiVersion() string {
 }
 
 // NewMultiTenantOAuthConfig creates an object that support multitenant OAuth configuration.
-func NewMultiTenantOAuthConfig(activeDirectoryEndpoint, primaryTenantID string, auxiliaryTenantIDs []string, cfg Config) (MultiTenantOAuthConfig, error) {
+// See https://docs.microsoft.com/en-us/azure/azure-resource-manager/authenticate-multi-tenant for more information.
+func NewMultiTenantOAuthConfig(activeDirectoryEndpoint, primaryTenantID string, auxiliaryTenantIDs []string, options Options) (MultiTenantOAuthConfig, error) {
 	if len(auxiliaryTenantIDs) == 0 || len(auxiliaryTenantIDs) > 3 {
 		return nil, errors.New("must specify one to three auxiliary tenants")
 	}
 	mtCfg := multiTenantOAuthConfig{
 		cfgs: make([]*OAuthConfig, len(auxiliaryTenantIDs)+1),
 	}
-	apiVer := cfg.apiVersion()
+	apiVer := options.apiVersion()
 	pri, err := NewOAuthConfigWithAPIVersion(activeDirectoryEndpoint, primaryTenantID, &apiVer)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create OAuthConfig for primary tenant: %v", err)

--- a/autorest/adal/config_test.go
+++ b/autorest/adal/config_test.go
@@ -94,7 +94,7 @@ func TestNewOAuthConfigWithAPIVersionNotNil(t *testing.T) {
 }
 
 func TestNewMultiTenantOAuthConfig(t *testing.T) {
-	cfg, err := NewMultiTenantOAuthConfig(TestActiveDirectoryEndpoint, TestTenantID, TestAuxTenantIDs, Config{})
+	cfg, err := NewMultiTenantOAuthConfig(TestActiveDirectoryEndpoint, TestTenantID, TestAuxTenantIDs, Options{})
 	if err != nil {
 		t.Fatalf("autorest/adal: unexpected error while creating multitenant config: %v", err)
 	}
@@ -115,11 +115,11 @@ func TestNewMultiTenantOAuthConfig(t *testing.T) {
 }
 
 func TestNewMultiTenantOAuthConfigFail(t *testing.T) {
-	_, err := NewMultiTenantOAuthConfig(TestActiveDirectoryEndpoint, TestTenantID, nil, Config{})
+	_, err := NewMultiTenantOAuthConfig(TestActiveDirectoryEndpoint, TestTenantID, nil, Options{})
 	if err == nil {
 		t.Fatal("autorest/adal: expected non-nil error")
 	}
-	_, err = NewMultiTenantOAuthConfig(TestActiveDirectoryEndpoint, TestTenantID, []string{"one", "two", "three", "four"}, Config{})
+	_, err = NewMultiTenantOAuthConfig(TestActiveDirectoryEndpoint, TestTenantID, []string{"one", "two", "three", "four"}, Options{})
 	if err == nil {
 		t.Fatal("autorest/adal: expected non-nil error")
 	}

--- a/autorest/adal/config_test.go
+++ b/autorest/adal/config_test.go
@@ -15,81 +15,112 @@ package adal
 //  limitations under the License.
 
 import (
+	"fmt"
 	"testing"
 )
 
-func TestNewOAuthConfig(t *testing.T) {
-	const testActiveDirectoryEndpoint = "https://login.test.com"
-	const testTenantID = "tenant-id-test"
+const TestAuxTenantPrefix = "aux-tenant-test-"
 
-	config, err := NewOAuthConfig(testActiveDirectoryEndpoint, testTenantID)
+var (
+	TestAuxTenantIDs = []string{TestAuxTenantPrefix + "0", TestAuxTenantPrefix + "1", TestAuxTenantPrefix + "2"}
+)
+
+func TestNewOAuthConfig(t *testing.T) {
+	config, err := NewOAuthConfig(TestActiveDirectoryEndpoint, TestTenantID)
 	if err != nil {
 		t.Fatalf("autorest/adal: Unexpected error while creating oauth configuration for tenant: %v.", err)
 	}
 
-	expected := "https://login.test.com/tenant-id-test/oauth2/authorize?api-version=1.0"
+	expected := fmt.Sprintf("https://login.test.com/%s/oauth2/authorize?api-version=1.0", TestTenantID)
 	if config.AuthorizeEndpoint.String() != expected {
 		t.Fatalf("autorest/adal: Incorrect authorize url for Tenant from Environment. expected(%s). actual(%v).", expected, config.AuthorizeEndpoint)
 	}
 
-	expected = "https://login.test.com/tenant-id-test/oauth2/token?api-version=1.0"
+	expected = fmt.Sprintf("https://login.test.com/%s/oauth2/token?api-version=1.0", TestTenantID)
 	if config.TokenEndpoint.String() != expected {
 		t.Fatalf("autorest/adal: Incorrect authorize url for Tenant from Environment. expected(%s). actual(%v).", expected, config.TokenEndpoint)
 	}
 
-	expected = "https://login.test.com/tenant-id-test/oauth2/devicecode?api-version=1.0"
+	expected = fmt.Sprintf("https://login.test.com/%s/oauth2/devicecode?api-version=1.0", TestTenantID)
 	if config.DeviceCodeEndpoint.String() != expected {
 		t.Fatalf("autorest/adal Incorrect devicecode url for Tenant from Environment. expected(%s). actual(%v).", expected, config.DeviceCodeEndpoint)
 	}
 }
 
 func TestNewOAuthConfigWithAPIVersionNil(t *testing.T) {
-	const testActiveDirectoryEndpoint = "https://login.test.com"
-	const testTenantID = "tenant-id-test"
-
-	config, err := NewOAuthConfigWithAPIVersion(testActiveDirectoryEndpoint, testTenantID, nil)
+	config, err := NewOAuthConfigWithAPIVersion(TestActiveDirectoryEndpoint, TestTenantID, nil)
 	if err != nil {
 		t.Fatalf("autorest/adal: Unexpected error while creating oauth configuration for tenant: %v.", err)
 	}
 
-	expected := "https://login.test.com/tenant-id-test/oauth2/authorize"
+	expected := fmt.Sprintf("https://login.test.com/%s/oauth2/authorize", TestTenantID)
 	if config.AuthorizeEndpoint.String() != expected {
 		t.Fatalf("autorest/adal: Incorrect authorize url for Tenant from Environment. expected(%s). actual(%v).", expected, config.AuthorizeEndpoint)
 	}
 
-	expected = "https://login.test.com/tenant-id-test/oauth2/token"
+	expected = fmt.Sprintf("https://login.test.com/%s/oauth2/token", TestTenantID)
 	if config.TokenEndpoint.String() != expected {
 		t.Fatalf("autorest/adal: Incorrect authorize url for Tenant from Environment. expected(%s). actual(%v).", expected, config.TokenEndpoint)
 	}
 
-	expected = "https://login.test.com/tenant-id-test/oauth2/devicecode"
+	expected = fmt.Sprintf("https://login.test.com/%s/oauth2/devicecode", TestTenantID)
 	if config.DeviceCodeEndpoint.String() != expected {
 		t.Fatalf("autorest/adal Incorrect devicecode url for Tenant from Environment. expected(%s). actual(%v).", expected, config.DeviceCodeEndpoint)
 	}
 }
 
 func TestNewOAuthConfigWithAPIVersionNotNil(t *testing.T) {
-	const testActiveDirectoryEndpoint = "https://login.test.com"
-	const testTenantID = "tenant-id-test"
 	apiVersion := "2.0"
 
-	config, err := NewOAuthConfigWithAPIVersion(testActiveDirectoryEndpoint, testTenantID, &apiVersion)
+	config, err := NewOAuthConfigWithAPIVersion(TestActiveDirectoryEndpoint, TestTenantID, &apiVersion)
 	if err != nil {
 		t.Fatalf("autorest/adal: Unexpected error while creating oauth configuration for tenant: %v.", err)
 	}
 
-	expected := "https://login.test.com/tenant-id-test/oauth2/authorize?api-version=2.0"
+	expected := fmt.Sprintf("https://login.test.com/%s/oauth2/authorize?api-version=2.0", TestTenantID)
 	if config.AuthorizeEndpoint.String() != expected {
 		t.Fatalf("autorest/adal: Incorrect authorize url for Tenant from Environment. expected(%s). actual(%v).", expected, config.AuthorizeEndpoint)
 	}
 
-	expected = "https://login.test.com/tenant-id-test/oauth2/token?api-version=2.0"
+	expected = fmt.Sprintf("https://login.test.com/%s/oauth2/token?api-version=2.0", TestTenantID)
 	if config.TokenEndpoint.String() != expected {
 		t.Fatalf("autorest/adal: Incorrect authorize url for Tenant from Environment. expected(%s). actual(%v).", expected, config.TokenEndpoint)
 	}
 
-	expected = "https://login.test.com/tenant-id-test/oauth2/devicecode?api-version=2.0"
+	expected = fmt.Sprintf("https://login.test.com/%s/oauth2/devicecode?api-version=2.0", TestTenantID)
 	if config.DeviceCodeEndpoint.String() != expected {
 		t.Fatalf("autorest/adal Incorrect devicecode url for Tenant from Environment. expected(%s). actual(%v).", expected, config.DeviceCodeEndpoint)
+	}
+}
+
+func TestNewMultiTenantOAuthConfig(t *testing.T) {
+	cfg, err := NewMultiTenantOAuthConfig(TestActiveDirectoryEndpoint, TestTenantID, TestAuxTenantIDs, Config{})
+	if err != nil {
+		t.Fatalf("autorest/adal: unexpected error while creating multitenant config: %v", err)
+	}
+	expected := fmt.Sprintf("https://login.test.com/%s/oauth2/authorize?api-version=1.0", TestTenantID)
+	if ep := cfg.PrimaryTenant().AuthorizeEndpoint.String(); ep != expected {
+		t.Fatalf("autorest/adal: Incorrect authorize url for Tenant from Environment. expected(%s). actual(%v).", expected, ep)
+	}
+	aux := cfg.AuxiliaryTenants()
+	if len(aux) == 0 {
+		t.Fatal("autorest/adal: unexpected zero-length auxiliary tenants")
+	}
+	for i := range aux {
+		expected := fmt.Sprintf("https://login.test.com/aux-tenant-test-%d/oauth2/authorize?api-version=1.0", i)
+		if ep := aux[i].AuthorizeEndpoint.String(); ep != expected {
+			t.Fatalf("autorest/adal: Incorrect authorize url for Tenant from Environment. expected(%s). actual(%v).", expected, ep)
+		}
+	}
+}
+
+func TestNewMultiTenantOAuthConfigFail(t *testing.T) {
+	_, err := NewMultiTenantOAuthConfig(TestActiveDirectoryEndpoint, TestTenantID, nil, Config{})
+	if err == nil {
+		t.Fatal("autorest/adal: expected non-nil error")
+	}
+	_, err = NewMultiTenantOAuthConfig(TestActiveDirectoryEndpoint, TestTenantID, []string{"one", "two", "three", "four"}, Config{})
+	if err == nil {
+		t.Fatal("autorest/adal: expected non-nil error")
 	}
 }

--- a/autorest/adal/token_test.go
+++ b/autorest/adal/token_test.go
@@ -846,7 +846,7 @@ func TestMarshalInnerToken(t *testing.T) {
 }
 
 func TestNewMultiTenantServicePrincipalToken(t *testing.T) {
-	cfg, err := NewMultiTenantOAuthConfig(TestActiveDirectoryEndpoint, TestTenantID, TestAuxTenantIDs, Config{})
+	cfg, err := NewMultiTenantOAuthConfig(TestActiveDirectoryEndpoint, TestTenantID, TestAuxTenantIDs, Options{})
 	if err != nil {
 		t.Fatalf("autorest/adal: unexpected error while creating multitenant config: %v", err)
 	}

--- a/autorest/adal/token_test.go
+++ b/autorest/adal/token_test.go
@@ -845,6 +845,22 @@ func TestMarshalInnerToken(t *testing.T) {
 	}
 }
 
+func TestNewMultiTenantServicePrincipalToken(t *testing.T) {
+	cfg, err := NewMultiTenantOAuthConfig(TestActiveDirectoryEndpoint, TestTenantID, TestAuxTenantIDs, Config{})
+	if err != nil {
+		t.Fatalf("autorest/adal: unexpected error while creating multitenant config: %v", err)
+	}
+	mt, err := NewMultiTenantServicePrincipalToken(cfg, "clientID", "superSecret", "resource")
+	if !strings.Contains(mt.PrimaryToken.inner.OauthConfig.AuthorizeEndpoint.String(), TestTenantID) {
+		t.Fatal("didn't find primary tenant ID in primary SPT")
+	}
+	for i := range mt.AuxiliaryTokens {
+		if ep := mt.AuxiliaryTokens[i].inner.OauthConfig.AuthorizeEndpoint.String(); !strings.Contains(ep, fmt.Sprintf("%s%d", TestAuxTenantPrefix, i)) {
+			t.Fatalf("didn't find auxiliary tenant ID in token %s", ep)
+		}
+	}
+}
+
 func newTokenJSON(expiresOn string, resource string) string {
 	return fmt.Sprintf(`{
 		"access_token" : "accessToken",

--- a/autorest/azure/auth/auth.go
+++ b/autorest/azure/auth/auth.go
@@ -570,7 +570,7 @@ func (ccc ClientCredentialsConfig) ServicePrincipalToken() (*adal.ServicePrincip
 
 // MultiTenantServicePrincipalToken creates a MultiTenantServicePrincipalToken from client credentials.
 func (ccc ClientCredentialsConfig) MultiTenantServicePrincipalToken() (*adal.MultiTenantServicePrincipalToken, error) {
-	oauthConfig, err := adal.NewMultiTenantOAuthConfig(ccc.AADEndpoint, ccc.TenantID, ccc.AuxTenants, adal.Config{})
+	oauthConfig, err := adal.NewMultiTenantOAuthConfig(ccc.AADEndpoint, ccc.TenantID, ccc.AuxTenants, adal.Options{})
 	if err != nil {
 		return nil, err
 	}

--- a/autorest/azure/auth/auth.go
+++ b/autorest/azure/auth/auth.go
@@ -40,6 +40,7 @@ import (
 const (
 	SubscriptionID          = "AZURE_SUBSCRIPTION_ID"
 	TenantID                = "AZURE_TENANT_ID"
+	AuxiliaryTenantIDs      = "AZURE_AUXILIARY_TENANT_IDS"
 	ClientID                = "AZURE_CLIENT_ID"
 	ClientSecret            = "AZURE_CLIENT_SECRET"
 	CertificatePath         = "AZURE_CERTIFICATE_PATH"
@@ -96,6 +97,7 @@ func GetSettingsFromEnvironment() (s EnvironmentSettings, err error) {
 	}
 	s.setValue(SubscriptionID)
 	s.setValue(TenantID)
+	s.setValue(AuxiliaryTenantIDs)
 	s.setValue(ClientID)
 	s.setValue(ClientSecret)
 	s.setValue(CertificatePath)
@@ -145,6 +147,12 @@ func (settings EnvironmentSettings) GetClientCredentials() (ClientCredentialsCon
 	config := NewClientCredentialsConfig(clientID, secret, tenantID)
 	config.AADEndpoint = settings.Environment.ActiveDirectoryEndpoint
 	config.Resource = settings.Values[Resource]
+	if auxTenants, ok := settings.Values[AuxiliaryTenantIDs]; ok {
+		config.AuxTenants = strings.Split(auxTenants, ";")
+		for i := range config.AuxTenants {
+			config.AuxTenants[i] = strings.TrimSpace(config.AuxTenants[i])
+		}
+	}
 	return config, nil
 }
 
@@ -546,6 +554,7 @@ type ClientCredentialsConfig struct {
 	ClientID     string
 	ClientSecret string
 	TenantID     string
+	AuxTenants   []string
 	AADEndpoint  string
 	Resource     string
 }
@@ -559,13 +568,29 @@ func (ccc ClientCredentialsConfig) ServicePrincipalToken() (*adal.ServicePrincip
 	return adal.NewServicePrincipalToken(*oauthConfig, ccc.ClientID, ccc.ClientSecret, ccc.Resource)
 }
 
+// MultiTenantServicePrincipalToken creates a MultiTenantServicePrincipalToken from client credentials.
+func (ccc ClientCredentialsConfig) MultiTenantServicePrincipalToken() (*adal.MultiTenantServicePrincipalToken, error) {
+	oauthConfig, err := adal.NewMultiTenantOAuthConfig(ccc.AADEndpoint, ccc.TenantID, ccc.AuxTenants, adal.Config{})
+	if err != nil {
+		return nil, err
+	}
+	return adal.NewMultiTenantServicePrincipalToken(oauthConfig, ccc.ClientID, ccc.ClientSecret, ccc.Resource)
+}
+
 // Authorizer gets the authorizer from client credentials.
 func (ccc ClientCredentialsConfig) Authorizer() (autorest.Authorizer, error) {
-	spToken, err := ccc.ServicePrincipalToken()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get oauth token from client credentials: %v", err)
+	if len(ccc.AuxTenants) == 0 {
+		spToken, err := ccc.ServicePrincipalToken()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get SPT from client credentials: %v", err)
+		}
+		return autorest.NewBearerAuthorizer(spToken), nil
 	}
-	return autorest.NewBearerAuthorizer(spToken), nil
+	mtSPT, err := ccc.MultiTenantServicePrincipalToken()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get multitenant SPT from client credentials: %v", err)
+	}
+	return autorest.NewMultiTenantServicePrincipalTokenAuthorizer(mtSPT), nil
 }
 
 // ClientCertificateConfig provides the options to get a bearer authorizer from a client certificate.

--- a/autorest/preparer.go
+++ b/autorest/preparer.go
@@ -31,9 +31,10 @@ const (
 	mimeTypeOctetStream = "application/octet-stream"
 	mimeTypeFormPost    = "application/x-www-form-urlencoded"
 
-	headerAuthorization = "Authorization"
-	headerContentType   = "Content-Type"
-	headerUserAgent     = "User-Agent"
+	headerAuthorization    = "Authorization"
+	headerAuxAuthorization = "x-ms-authorization-auxiliary"
+	headerContentType      = "Content-Type"
+	headerUserAgent        = "User-Agent"
 )
 
 // Preparer is the interface that wraps the Prepare method.


### PR DESCRIPTION
Support for multi-tenant via x-ms-authorization-auxiliary header has
been added for client credentials with secret scenario; this basically
bundles multiple OAuthConfig and ServicePrincipalToken types into
corresponding MultiTenant* types along with a new authorizer that adds
the primary and auxiliary token headers to the reqest.
The authenticaion helpers have been updated to support this scenario; if
environment var AZURE_AUXILIARY_TENANT_IDS is set with a semicolon
delimited list of tenants the multi-tenant codepath will kick in to
create the appropriate authorizer.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.