### PR TITLE
Drain response bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+## v11.10.0
+
+### New Features
+
+- Added helper `autorest.DrainResponseBody()` for draining HTTP response bodies.
+
+### Bug Fixes
+
+- The retry senders now drain their response bodies between retry attempts.
+- Method `Future.GetResult()` no longer leaks its connection.
+
 ## v11.9.0
 
 ### New Features

--- a/autorest/adal/token.go
+++ b/autorest/adal/token.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"math"
 	"net"
@@ -907,6 +908,10 @@ func retryForIMDS(sender Sender, req *http.Request, maxAttempts int) (resp *http
 	delay := time.Duration(0)
 
 	for attempt < maxAttempts {
+		if resp != nil && resp.Body != nil {
+			io.Copy(ioutil.Discard, resp.Body)
+			resp.Body.Close()
+		}
 		resp, err = sender.Do(req)
 		// retry on temporary network errors, e.g. transient network failures.
 		// if we don't receive a response then assume we can't connect to the

--- a/autorest/azure/async.go
+++ b/autorest/azure/async.go
@@ -294,7 +294,17 @@ func (f Future) GetResult(sender autorest.Sender) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	return sender.Do(req)
+	resp, err := sender.Do(req)
+	if err == nil && resp.Body != nil {
+		// copy the body and close it so callers don't have to
+		defer resp.Body.Close()
+		b, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return resp, err
+		}
+		resp.Body = ioutil.NopCloser(bytes.NewReader(b))
+	}
+	return resp, err
 }
 
 type pollingTracker interface {

--- a/autorest/sender.go
+++ b/autorest/sender.go
@@ -196,6 +196,7 @@ func DoRetryForAttempts(attempts int, backoff time.Duration) SendDecorator {
 				if err != nil {
 					return resp, err
 				}
+				DrainResponseBody(resp)
 				resp, err = s.Do(rr.Request())
 				if err == nil {
 					return resp, err
@@ -223,6 +224,7 @@ func DoRetryForStatusCodes(attempts int, backoff time.Duration, codes ...int) Se
 				if err != nil {
 					return resp, err
 				}
+				DrainResponseBody(resp)
 				resp, err = s.Do(rr.Request())
 				// if the error isn't temporary don't bother retrying
 				if err != nil && !IsTemporaryNetworkError(err) {
@@ -280,6 +282,7 @@ func DoRetryForDuration(d time.Duration, backoff time.Duration) SendDecorator {
 				if err != nil {
 					return resp, err
 				}
+				DrainResponseBody(resp)
 				resp, err = s.Do(rr.Request())
 				if err == nil {
 					return resp, err

--- a/autorest/utility.go
+++ b/autorest/utility.go
@@ -20,6 +20,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -225,4 +226,14 @@ func IsTemporaryNetworkError(err error) bool {
 		return true
 	}
 	return false
+}
+
+// DrainResponseBody reads the response body then closes it.
+func DrainResponseBody(resp *http.Response) error {
+	if resp != nil && resp.Body != nil {
+		_, err := io.Copy(ioutil.Discard, resp.Body)
+		resp.Body.Close()
+		return err
+	}
+	return nil
 }

--- a/autorest/utility_test.go
+++ b/autorest/utility_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -458,5 +459,43 @@ func withErrorRespondDecorator(e *error) RespondDecorator {
 			*e = fmt.Errorf("autorest: Faux Respond Error")
 			return *e
 		})
+	}
+}
+
+type mockDrain struct {
+	read   bool
+	closed bool
+}
+
+func (md *mockDrain) Read(b []byte) (int, error) {
+	md.read = true
+	b = append(b, 0xff)
+	return 1, io.EOF
+}
+
+func (md *mockDrain) Close() error {
+	md.closed = true
+	return nil
+}
+
+func TestDrainResponseBody(t *testing.T) {
+	err := DrainResponseBody(nil)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	err = DrainResponseBody(&http.Response{})
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	md := &mockDrain{}
+	err = DrainResponseBody(&http.Response{Body: md})
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if !md.closed {
+		t.Fatal("mockDrain wasn't closed")
+	}
+	if !md.read {
+		t.Fatal("mockDrain wasn't read")
 	}
 }

--- a/autorest/version.go
+++ b/autorest/version.go
@@ -19,7 +19,7 @@ import (
 	"runtime"
 )
 
-const number = "v11.9.0"
+const number = "v11.10.0"
 
 var (
 	userAgent = fmt.Sprintf("Go/%s (%s-%s) go-autorest/%s",


### PR DESCRIPTION
The retry helpers and a few other methods weren't reading and closing
response bodies leading to connection leaks.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.