### PR TITLE
Add MSI for App Service / Functions support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v13.1.0
+
+### New Features
+
+- Added support for MSI authentication on Azure App Service and Azure Functions.
+
 ## v13.0.2
 
 ### Bug Fixes

--- a/autorest/adal/token.go
+++ b/autorest/adal/token.go
@@ -667,17 +667,17 @@ func GetMSIEndpoint() (string, error) {
 
 // NewServicePrincipalTokenFromMSI creates a ServicePrincipalToken via the MSI VM Extension.
 // It will use the system assigned identity when creating the token.
-func NewServicePrincipalTokenFromMSI(msiEndpoint string, resource string, callbacks ...TokenRefreshCallback) (*ServicePrincipalToken, error) {
+func NewServicePrincipalTokenFromMSI(msiEndpoint, resource string, callbacks ...TokenRefreshCallback) (*ServicePrincipalToken, error) {
 	return newServicePrincipalTokenFromMSI(msiEndpoint, resource, nil, callbacks...)
 }
 
 // NewServicePrincipalTokenFromMSIWithUserAssignedID creates a ServicePrincipalToken via the MSI VM Extension.
 // It will use the specified user assigned identity when creating the token.
-func NewServicePrincipalTokenFromMSIWithUserAssignedID(msiEndpoint string, resource string, userAssignedID string, callbacks ...TokenRefreshCallback) (*ServicePrincipalToken, error) {
+func NewServicePrincipalTokenFromMSIWithUserAssignedID(msiEndpoint, resource string, userAssignedID string, callbacks ...TokenRefreshCallback) (*ServicePrincipalToken, error) {
 	return newServicePrincipalTokenFromMSI(msiEndpoint, resource, &userAssignedID, callbacks...)
 }
 
-func newServicePrincipalTokenFromMSI(msiEndpoint string, resource string, userAssignedID *string, callbacks ...TokenRefreshCallback) (*ServicePrincipalToken, error) {
+func newServicePrincipalTokenFromMSI(msiEndpoint, resource string, userAssignedID *string, callbacks ...TokenRefreshCallback) (*ServicePrincipalToken, error) {
 	if err := validateStringParam(msiEndpoint, "msiEndpoint"); err != nil {
 		return nil, err
 	}
@@ -829,7 +829,7 @@ func isIMDS(u url.URL) bool {
 	if err != nil {
 		return false
 	}
-	return u.Host == imds.Host && u.Path == imds.Path || isAppService()
+	return (u.Host == imds.Host && u.Path == imds.Path) || isAppService()
 }
 
 func (spt *ServicePrincipalToken) refreshInternal(ctx context.Context, resource string) error {

--- a/autorest/adal/token.go
+++ b/autorest/adal/token.go
@@ -63,6 +63,12 @@ const (
 
 	// the default number of attempts to refresh an MSI authentication token
 	defaultMaxMSIRefreshAttempts = 5
+
+	// asMSIEndpointEnv is the environment variable used to store the endpoint on App Service and Functions
+	asMSIEndpointEnv = "MSI_ENDPOINT"
+
+	// asMSISecretEnv is the environment variable used to store the request secret on App Service and Functions
+	asMSISecretEnv = "MSI_SECRET"
 )
 
 // OAuthTokenProvider is an interface which should be implemented by an access token retriever
@@ -635,17 +641,17 @@ func GetMSIVMEndpoint() (string, error) {
 }
 
 func isAppService() bool {
-	_, endpointEnvExists := os.LookupEnv("MSI_ENDPOINT")
-	_, secretEnvExists := os.LookupEnv("MSI_SECRET")
+	_, asMSIEndpointEnvExists := os.LookupEnv(asMSIEndpointEnv)
+	_, asMSISecretEnvExists := os.LookupEnv(asMSISecretEnv)
 
-	return endpointEnvExists && secretEnvExists
+	return asMSIEndpointEnvExists && asMSISecretEnvExists
 }
 
 // GetMSIAppServiceEndpoint get the MSI endpoint for App Service and Functions
 func GetMSIAppServiceEndpoint() (string, error) {
-	asMSIEndpoint, endpointEnvExists := os.LookupEnv("MSI_ENDPOINT")
+	asMSIEndpoint, asMSIEndpointEnvExists := os.LookupEnv(asMSIEndpointEnv)
 
-	if endpointEnvExists {
+	if asMSIEndpointEnvExists {
 		return asMSIEndpoint, nil
 	}
 	return "", errors.New("MSI endpoint not found")
@@ -834,7 +840,7 @@ func (spt *ServicePrincipalToken) refreshInternal(ctx context.Context, resource 
 	req.Header.Add("User-Agent", UserAgent())
 	// Add header when runtime is on App Service or Functions
 	if isAppService() {
-		asMSISecret, _ := os.LookupEnv("MSI_SECRET")
+		asMSISecret, _ := os.LookupEnv(asMSISecretEnv)
 		req.Header.Add("Secret", asMSISecret)
 	}
 	req = req.WithContext(ctx)

--- a/autorest/adal/token.go
+++ b/autorest/adal/token.go
@@ -667,17 +667,17 @@ func GetMSIEndpoint() (string, error) {
 
 // NewServicePrincipalTokenFromMSI creates a ServicePrincipalToken via the MSI VM Extension.
 // It will use the system assigned identity when creating the token.
-func NewServicePrincipalTokenFromMSI(msiEndpoint, resource string, callbacks ...TokenRefreshCallback) (*ServicePrincipalToken, error) {
+func NewServicePrincipalTokenFromMSI(msiEndpoint string, resource string, callbacks ...TokenRefreshCallback) (*ServicePrincipalToken, error) {
 	return newServicePrincipalTokenFromMSI(msiEndpoint, resource, nil, callbacks...)
 }
 
 // NewServicePrincipalTokenFromMSIWithUserAssignedID creates a ServicePrincipalToken via the MSI VM Extension.
 // It will use the specified user assigned identity when creating the token.
-func NewServicePrincipalTokenFromMSIWithUserAssignedID(msiEndpoint, resource string, userAssignedID string, callbacks ...TokenRefreshCallback) (*ServicePrincipalToken, error) {
+func NewServicePrincipalTokenFromMSIWithUserAssignedID(msiEndpoint string, resource string, userAssignedID string, callbacks ...TokenRefreshCallback) (*ServicePrincipalToken, error) {
 	return newServicePrincipalTokenFromMSI(msiEndpoint, resource, &userAssignedID, callbacks...)
 }
 
-func newServicePrincipalTokenFromMSI(msiEndpoint, resource string, userAssignedID *string, callbacks ...TokenRefreshCallback) (*ServicePrincipalToken, error) {
+func newServicePrincipalTokenFromMSI(msiEndpoint string, resource string, userAssignedID *string, callbacks ...TokenRefreshCallback) (*ServicePrincipalToken, error) {
 	if err := validateStringParam(msiEndpoint, "msiEndpoint"); err != nil {
 		return nil, err
 	}
@@ -829,7 +829,7 @@ func isIMDS(u url.URL) bool {
 	if err != nil {
 		return false
 	}
-	return u.Host == imds.Host && u.Path == imds.Path
+	return u.Host == imds.Host && u.Path == imds.Path || isAppService()
 }
 
 func (spt *ServicePrincipalToken) refreshInternal(ctx context.Context, resource string) error {

--- a/autorest/adal/token_test.go
+++ b/autorest/adal/token_test.go
@@ -26,6 +26,7 @@ import (
 	"math/big"
 	"net/http"
 	"net/url"
+	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -735,6 +736,22 @@ func TestGetVMEndpoint(t *testing.T) {
 	}
 
 	if endpoint != msiEndpoint {
+		t.Fatal("Didn't get correct endpoint")
+	}
+}
+
+func TestGetAppServiceEndpoint(t *testing.T) {
+	testEndpoint := "http://172.16.1.2:8081/msi/token"
+	if err := os.Setenv("MSI_ENDPOINT", testEndpoint); err != nil {
+		t.Fatalf("os.Setenv: %v", err)
+	}
+
+	endpoint, err := GetMSIAppServiceEndpoint()
+	if err != nil {
+		t.Fatal("Coudn't get App Service endpoint")
+	}
+
+	if endpoint != testEndpoint {
 		t.Fatal("Didn't get correct endpoint")
 	}
 }

--- a/autorest/adal/token_test.go
+++ b/autorest/adal/token_test.go
@@ -741,7 +741,7 @@ func TestGetVMEndpoint(t *testing.T) {
 }
 
 func TestGetAppServiceEndpoint(t *testing.T) {
-	testEndpoint := "http://172.16.1.2:8081/msi/token"
+	const testEndpoint = "http://172.16.1.2:8081/msi/token"
 	if err := os.Setenv("MSI_ENDPOINT", testEndpoint); err != nil {
 		t.Fatalf("os.Setenv: %v", err)
 	}
@@ -753,6 +753,61 @@ func TestGetAppServiceEndpoint(t *testing.T) {
 
 	if endpoint != testEndpoint {
 		t.Fatal("Didn't get correct endpoint")
+	}
+
+	if err := os.Unsetenv("MSI_ENDPOINT"); err != nil {
+		t.Fatalf("os.Unsetenv: %v", err)
+	}
+}
+
+func TestGetMSIEndpoint(t *testing.T) {
+	const (
+		testEndpoint = "http://172.16.1.2:8081/msi/token"
+		testSecret   = "DEADBEEF-BBBB-AAAA-DDDD-DDD000000DDD"
+	)
+
+	// Test VM well-known endpoint is returned
+	if err := os.Unsetenv("MSI_ENDPOINT"); err != nil {
+		t.Fatalf("os.Unsetenv: %v", err)
+	}
+
+	if err := os.Unsetenv("MSI_SECRET"); err != nil {
+		t.Fatalf("os.Unsetenv: %v", err)
+	}
+
+	vmEndpoint, err := GetMSIEndpoint()
+	if err != nil {
+		t.Fatal("Coudn't get VM endpoint")
+	}
+
+	if vmEndpoint != msiEndpoint {
+		t.Fatal("Didn't get correct endpoint")
+	}
+
+	// Test App Service endpoint is returned
+	if err := os.Setenv("MSI_ENDPOINT", testEndpoint); err != nil {
+		t.Fatalf("os.Setenv: %v", err)
+	}
+
+	if err := os.Setenv("MSI_SECRET", testSecret); err != nil {
+		t.Fatalf("os.Setenv: %v", err)
+	}
+
+	asEndpoint, err := GetMSIEndpoint()
+	if err != nil {
+		t.Fatal("Coudn't get App Service endpoint")
+	}
+
+	if asEndpoint != testEndpoint {
+		t.Fatal("Didn't get correct endpoint")
+	}
+
+	if err := os.Unsetenv("MSI_ENDPOINT"); err != nil {
+		t.Fatalf("os.Unsetenv: %v", err)
+	}
+
+	if err := os.Unsetenv("MSI_SECRET"); err != nil {
+		t.Fatalf("os.Unsetenv: %v", err)
 	}
 }
 

--- a/autorest/adal/token_test.go
+++ b/autorest/adal/token_test.go
@@ -742,7 +742,7 @@ func TestGetVMEndpoint(t *testing.T) {
 
 func TestGetAppServiceEndpoint(t *testing.T) {
 	const testEndpoint = "http://172.16.1.2:8081/msi/token"
-	if err := os.Setenv("MSI_ENDPOINT", testEndpoint); err != nil {
+	if err := os.Setenv(asMSIEndpointEnv, testEndpoint); err != nil {
 		t.Fatalf("os.Setenv: %v", err)
 	}
 
@@ -755,7 +755,7 @@ func TestGetAppServiceEndpoint(t *testing.T) {
 		t.Fatal("Didn't get correct endpoint")
 	}
 
-	if err := os.Unsetenv("MSI_ENDPOINT"); err != nil {
+	if err := os.Unsetenv(asMSIEndpointEnv); err != nil {
 		t.Fatalf("os.Unsetenv: %v", err)
 	}
 }
@@ -767,11 +767,11 @@ func TestGetMSIEndpoint(t *testing.T) {
 	)
 
 	// Test VM well-known endpoint is returned
-	if err := os.Unsetenv("MSI_ENDPOINT"); err != nil {
+	if err := os.Unsetenv(asMSIEndpointEnv); err != nil {
 		t.Fatalf("os.Unsetenv: %v", err)
 	}
 
-	if err := os.Unsetenv("MSI_SECRET"); err != nil {
+	if err := os.Unsetenv(asMSISecretEnv); err != nil {
 		t.Fatalf("os.Unsetenv: %v", err)
 	}
 
@@ -785,11 +785,11 @@ func TestGetMSIEndpoint(t *testing.T) {
 	}
 
 	// Test App Service endpoint is returned
-	if err := os.Setenv("MSI_ENDPOINT", testEndpoint); err != nil {
+	if err := os.Setenv(asMSIEndpointEnv, testEndpoint); err != nil {
 		t.Fatalf("os.Setenv: %v", err)
 	}
 
-	if err := os.Setenv("MSI_SECRET", testSecret); err != nil {
+	if err := os.Setenv(asMSISecretEnv, testSecret); err != nil {
 		t.Fatalf("os.Setenv: %v", err)
 	}
 
@@ -802,11 +802,11 @@ func TestGetMSIEndpoint(t *testing.T) {
 		t.Fatal("Didn't get correct endpoint")
 	}
 
-	if err := os.Unsetenv("MSI_ENDPOINT"); err != nil {
+	if err := os.Unsetenv(asMSIEndpointEnv); err != nil {
 		t.Fatalf("os.Unsetenv: %v", err)
 	}
 
-	if err := os.Unsetenv("MSI_SECRET"); err != nil {
+	if err := os.Unsetenv(asMSISecretEnv); err != nil {
 		t.Fatalf("os.Unsetenv: %v", err)
 	}
 }

--- a/autorest/azure/auth/auth.go
+++ b/autorest/azure/auth/auth.go
@@ -715,7 +715,7 @@ type MSIConfig struct {
 
 // Authorizer gets the authorizer from MSI.
 func (mc MSIConfig) Authorizer() (autorest.Authorizer, error) {
-	msiEndpoint, err := adal.GetMSIVMEndpoint()
+	msiEndpoint, err := adal.GetMSIEndpoint()
 	if err != nil {
 		return nil, err
 	}

--- a/autorest/version.go
+++ b/autorest/version.go
@@ -19,7 +19,7 @@ import (
 	"runtime"
 )
 
-const number = "v13.0.2"
+const number = "v13.1.0"
 
 var (
 	userAgent = fmt.Sprintf("Go/%s (%s-%s) go-autorest/%s",


### PR DESCRIPTION
This adds support for the different method of MSI token acquisition on Azure App Service and Azure Functions.

Fixes #447 

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [x] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [x] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.