### PR TITLE
support for parsing error messages from xml responses

### DIFF
--- a/autorest/azure/azure.go
+++ b/autorest/azure/azure.go
@@ -310,7 +310,7 @@ func WithErrorUnlessStatusCode(codes ...int) autorest.RespondDecorator {
 					// try to unmarshal the body in hopes of getting something.
 					rawBody := map[string]interface{}{}
 					decoder := autorest.NewDecoder(encodedAs, bytes.NewReader(b.Bytes()))
-					if err := decoder.Decode(&e.ServiceError); err != nil {
+					if err := decoder.Decode(&rawBody); err != nil {
 						return err
 					}
 

--- a/autorest/azure/azure.go
+++ b/autorest/azure/azure.go
@@ -144,7 +144,7 @@ type RequestError struct {
 	autorest.DetailedError
 
 	// The error returned by the Azure service.
-	ServiceError *ServiceError `json:"error",xml:"Error"`
+	ServiceError *ServiceError `json:"error", xml:"Error"`
 
 	// The request id (from the x-ms-request-id-header) of the request.
 	RequestID string

--- a/autorest/azure/azure.go
+++ b/autorest/azure/azure.go
@@ -18,6 +18,7 @@ package azure
 
 import (
 	"encoding/json"
+	"encoding/xml"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -143,7 +144,7 @@ type RequestError struct {
 	autorest.DetailedError
 
 	// The error returned by the Azure service.
-	ServiceError *ServiceError `json:"error"`
+	ServiceError *ServiceError `json:"error",xml:"Error"`
 
 	// The request id (from the x-ms-request-id-header) of the request.
 	RequestID string
@@ -285,26 +286,45 @@ func WithErrorUnlessStatusCode(codes ...int) autorest.RespondDecorator {
 				var e RequestError
 				defer resp.Body.Close()
 
+				encodedAs := autorest.EncodedAsJSON
+				if strings.Contains(resp.Header.Get("Content-Type"), "xml") {
+					encodedAs = autorest.EncodedAsXML
+				}
+
 				// Copy and replace the Body in case it does not contain an error object.
 				// This will leave the Body available to the caller.
-				b, decodeErr := autorest.CopyAndDecode(autorest.EncodedAsJSON, resp.Body, &e)
+				b, decodeErr := autorest.CopyAndDecode(encodedAs, resp.Body, &e)
 				resp.Body = ioutil.NopCloser(&b)
 				if decodeErr != nil {
 					return fmt.Errorf("autorest/azure: error response cannot be parsed: %q error: %v", b.String(), decodeErr)
 				}
 				if e.ServiceError == nil {
 					// Check if error is unwrapped ServiceError
-					if err := json.Unmarshal(b.Bytes(), &e.ServiceError); err != nil {
-						return err
+					if encodedAs == autorest.EncodedAsXML {
+						if err := xml.Unmarshal(b.Bytes(), &e.ServiceError); err != nil {
+							return err
+						}
+					} else {
+						if err := json.Unmarshal(b.Bytes(), &e.ServiceError); err != nil {
+							return err
+						}
 					}
 				}
 				if e.ServiceError.Message == "" {
 					// if we're here it means the returned error wasn't OData v4 compliant.
-					// try to unmarshal the body as raw JSON in hopes of getting something.
+					// try to unmarshal the body in hopes of getting something.
 					rawBody := map[string]interface{}{}
-					if err := json.Unmarshal(b.Bytes(), &rawBody); err != nil {
-						return err
+
+					if encodedAs == autorest.EncodedAsXML {
+						if err := xml.Unmarshal(b.Bytes(), &rawBody); err != nil {
+							return err
+						}
+					} else {
+						if err := json.Unmarshal(b.Bytes(), &rawBody); err != nil {
+							return err
+						}
 					}
+
 					e.ServiceError = &ServiceError{
 						Code:    "Unknown",
 						Message: "Unknown service error",

--- a/autorest/azure/azure.go
+++ b/autorest/azure/azure.go
@@ -144,7 +144,7 @@ type RequestError struct {
 	autorest.DetailedError
 
 	// The error returned by the Azure service.
-	ServiceError *ServiceError `json:"error", xml:"Error"`
+	ServiceError *ServiceError `json:"error" xml:"Error"`
 
 	// The request id (from the x-ms-request-id-header) of the request.
 	RequestID string


### PR DESCRIPTION
This PR adds support for parsing Errors from Data Plane API's which return XML rather than JSON, by parsing the Content-Type header. Since there's a few different Content-Types for XML (application/xml, text/xml plus some vendor specific ones), I've opted to parse the response as XML if the `Content-Type` contains `xml` - which isn't great but seems better than just passing those two?

This means when a Conflict is returned from the Sender, that HTTP Response:

```
HTTP/1.1 409 The specified container is being deleted. Try operation later.
Content-Length: 252
Content-Type: application/xml
Server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
x-ms-request-id: dcad0bff-301e-00f4-16c7-5949cd000000
x-ms-version: 2018-11-09
x-ms-error-code: ContainerBeingDeleted
Date: Fri, 23 Aug 2019 15:30:39 GMT
Connection: keep-alive

<?xml version="1.0" encoding="utf-8"?><Error><Code>ContainerBeingDeleted</Code><Message>The specified container is being deleted. Try operation later.
RequestId:dcad0bff-301e-00f4-16c7-5949cd000000
Time:2019-08-23T15:30:40.1896782Z</Message></Error>
```

now returns the error:

```
containers.Client#Create: Failure sending request: StatusCode=409 -- Original Error: autorest/azure: Service returned an error. Status=<nil> Code="ContainerBeingDeleted" Message="The specified container is being deleted. Try operation later.\nRequestId:bd47103c-b01e-000b-58c8-597455000000\nTime:2019-08-23T15:36:03.8834842Z"
```

.. and that a regular error being returned from the API:

```
HTTP/1.1 400 XML specified is not syntactically valid.
Content-Length: 331
Content-Type: application/xml
Server: Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0
x-ms-request-id: 69faabeb-b003-00a5-4cd1-59dffd000000
x-ms-version: 2018-11-09
x-ms-error-code: InvalidXmlDocument
Date: Fri, 23 Aug 2019 16:42:23 GMT
Connection: keep-alive

<?xml version="1.0" encoding="utf-8"?><Error><Code>InvalidXmlDocument</Code><Message>XML specified is not syntactically valid.
RequestId:69faabeb-b003-00a5-4cd1-59dffd000000
Time:2019-08-23T16:42:24.2857895Z</Message><LineNumber>2</LineNumber><LinePosition>56</LinePosition><Reason>Unexpected value for Version.</Reason></Error>
```

also gets deserialized correctly:

```
Error: Error updating Azure Storage Account `queue_properties` "issue3939dev": queues.Client#SetServiceProperties: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code="InvalidXmlDocument" Message="XML specified is not syntactically valid.\nRequestId:69faabeb-b003-00a5-4cd1-59dffd000000\nTime:2019-08-23T16:42:24.2857895Z"
```

---

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [x] I've tested my changes, adding unit tests if applicable.
 - [x] I've added Apache 2.0 Headers to the top of any new source files.
 - [x] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.

Fixes https://github.com/tombuildsstuff/giovanni/issues/7