### PR TITLE
Fix WithQueryParameters to properly encode multi-values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v13.0.1
+
+## Bug Fixes
+
+- Fixed `autorest.WithQueryParameters()` so that it properly encodes multi-value query parameters.
+
 ## v13.0.0
 
 ## Breaking Changes

--- a/autorest/preparer.go
+++ b/autorest/preparer.go
@@ -523,7 +523,7 @@ func parseURL(u *url.URL, path string) (*url.URL, error) {
 // WithQueryParameters returns a PrepareDecorators that encodes and applies the query parameters
 // given in the supplied map (i.e., key=value).
 func WithQueryParameters(queryParameters map[string]interface{}) PrepareDecorator {
-	parameters := ensureValueStrings(queryParameters)
+	parameters := MapToValues(queryParameters)
 	return func(p Preparer) Preparer {
 		return PreparerFunc(func(r *http.Request) (*http.Request, error) {
 			r, err := p.Prepare(r)
@@ -531,14 +531,16 @@ func WithQueryParameters(queryParameters map[string]interface{}) PrepareDecorato
 				if r.URL == nil {
 					return r, NewError("autorest", "WithQueryParameters", "Invoked with a nil URL")
 				}
-
 				v := r.URL.Query()
 				for key, value := range parameters {
-					d, err := url.QueryUnescape(value)
-					if err != nil {
-						return r, err
+					for i := range value {
+						d, err := url.QueryUnescape(value[i])
+						if err != nil {
+							return r, err
+						}
+						value[i] = d
 					}
-					v.Add(key, d)
+					v[key] = value
 				}
 				r.URL.RawQuery = v.Encode()
 			}

--- a/autorest/preparer_test.go
+++ b/autorest/preparer_test.go
@@ -320,8 +320,8 @@ func ExampleWithPathParameters() {
 // Create a request with query parameters
 func ExampleWithQueryParameters() {
 	params := map[string]interface{}{
-		"q1": "value1",
-		"q2": "value2",
+		"q1": []string{"value1"},
+		"q2": []string{"value2"},
 	}
 	r, err := Prepare(&http.Request{},
 		WithBaseURL("https://microsoft.com/"),
@@ -835,6 +835,7 @@ func TestModifyingRequestWithExistingQueryParameters(t *testing.T) {
 		WithPath("search"),
 		WithQueryParameters(map[string]interface{}{"q": "golang the best"}),
 		WithQueryParameters(map[string]interface{}{"pq": "golang+encoded"}),
+		WithQueryParameters(map[string]interface{}{"zq": []string{"one", "two"}}),
 	)
 	if err != nil {
 		t.Fatalf("autorest: Preparing an existing request returned an error (%v)", err)
@@ -848,7 +849,7 @@ func TestModifyingRequestWithExistingQueryParameters(t *testing.T) {
 		t.Fatalf("autorest: Preparing an existing request failed when setting the path (%s)", r.URL.Path)
 	}
 
-	if r.URL.RawQuery != "pq=golang+encoded&q=golang+the+best" {
+	if r.URL.RawQuery != "pq=golang+encoded&q=golang+the+best&zq=one&zq=two" {
 		t.Fatalf("autorest: Preparing an existing request failed when setting the query parameters (%s)", r.URL.RawQuery)
 	}
 }

--- a/autorest/version.go
+++ b/autorest/version.go
@@ -19,7 +19,7 @@ import (
 	"runtime"
 )
 
-const number = "v13.0.0"
+const number = "v13.0.1"
 
 var (
 	userAgent = fmt.Sprintf("Go/%s (%s-%s) go-autorest/%s",


### PR DESCRIPTION
The call to ensureValueStrings() was flattening slices into a string and
as a result multi-value query parameters were malformed.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.