### PR TITLE
Use accessTokens.json from AZURE_CONFIG_DIR before falling back on ~/.azure/

### DIFF
--- a/autorest/azure/cli/profile.go
+++ b/autorest/azure/cli/profile.go
@@ -51,9 +51,13 @@ type User struct {
 
 const azureProfileJSON = "azureProfile.json"
 
+func configDir() string {
+	return os.Getenv("AZURE_CONFIG_DIR")
+}
+
 // ProfilePath returns the path where the Azure Profile is stored from the Azure CLI
 func ProfilePath() (string, error) {
-	if cfgDir := os.Getenv("AZURE_CONFIG_DIR"); cfgDir != "" {
+	if cfgDir := configDir(); cfgDir != "" {
 		return filepath.Join(cfgDir, azureProfileJSON), nil
 	}
 	return homedir.Expand("~/.azure/" + azureProfileJSON)

--- a/autorest/azure/cli/token.go
+++ b/autorest/azure/cli/token.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"strconv"
@@ -43,6 +44,8 @@ type Token struct {
 	TokenType        string `json:"tokenType"`
 	UserID           string `json:"userId"`
 }
+
+const accessTokensJSON = "accessTokens.json"
 
 // ToADALToken converts an Azure CLI `Token`` to an `adal.Token``
 func (t Token) ToADALToken() (converted adal.Token, err error) {
@@ -68,17 +71,19 @@ func (t Token) ToADALToken() (converted adal.Token, err error) {
 // AccessTokensPath returns the path where access tokens are stored from the Azure CLI
 // TODO(#199): add unit test.
 func AccessTokensPath() (string, error) {
-	// Azure-CLI allows user to customize the path of access tokens thorugh environment variable.
-	var accessTokenPath = os.Getenv("AZURE_ACCESS_TOKEN_FILE")
-	var err error
+	// Azure-CLI allows user to customize the path of access tokens through environment variable.
+	if accessTokenPath := os.Getenv("AZURE_ACCESS_TOKEN_FILE"); accessTokenPath != "" {
+		return accessTokenPath, nil
+	}
+
+	// Azure-CLI allows user to customize the path to Azure config directory through environment variable.
+	if cfgDir := configDir(); cfgDir != "" {
+		return filepath.Join(cfgDir, accessTokensJSON), nil
+	}
 
 	// Fallback logic to default path on non-cloud-shell environment.
 	// TODO(#200): remove the dependency on hard-coding path.
-	if accessTokenPath == "" {
-		accessTokenPath, err = homedir.Expand("~/.azure/accessTokens.json")
-	}
-
-	return accessTokenPath, err
+	return homedir.Expand("~/.azure/" + accessTokensJSON)
 }
 
 // ParseExpirationDate parses either a Azure CLI or CloudShell date into a time object


### PR DESCRIPTION
This PR makes `AccessTokensPath()` use `accessTokens.json` from the directory configured by the `AZURE_CONFIG_DIR` environment variable if the `AZURE_ACCESS_TOKEN_FILE` environment variable is not set before falling back on `~/.azure/`.

This matches the behavior of the azure-cli:
- https://github.com/Azure/azure-cli/blob/azure-cli-2.0.73/src/azure-cli-core/azure/cli/core/_profile.py#L879
- https://github.com/Azure/azure-cli/blob/azure-cli-2.0.73/src/azure-cli-core/azure/cli/core/_environment.py#L9

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [x] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [x] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.