### PR TITLE
Added SendDecorator autorest.ReadResponseBody()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## v13.1.0
+
+### New Features
+
+- Added SendDecorator `autorest.ReadResponseBody()` which will read the response body, wrapping it in a nop-closing byte reader attached to the HTTP response.
+  Add this decorator after a retry decorator so if the read fails the retry decorator will retry the operation.
+
 ## v13.0.2
 
 ### Bug Fixes

--- a/autorest/version.go
+++ b/autorest/version.go
@@ -19,7 +19,7 @@ import (
 	"runtime"
 )
 
-const number = "v13.0.2"
+const number = "v13.1.0"
 
 var (
 	userAgent = fmt.Sprintf("Go/%s (%s-%s) go-autorest/%s",


### PR DESCRIPTION
This decorator will read the response body, wrapping it in a nop-closing
byte reader attached to the HTTP response.  Add it after a retry
decorator so if the read fails the retry decorator will retry the
operation.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.