### PR TITLE
Add ability to cancel device code flow auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## v13.2.0
+
+### New Features
+
+- Added the following functions to replace their versions that don't take a context.
+  - `adal.InitiateDeviceAuthWithContext()`
+  - `adal.CheckForUserCompletionWithContext()`
+  - `adal.WaitForUserCompletionWithContext()`
+
 ## v13.1.0
 
 ### New Features

--- a/autorest/version.go
+++ b/autorest/version.go
@@ -19,7 +19,7 @@ import (
 	"runtime"
 )
 
-const number = "v13.1.0"
+const number = "v13.2.0"
 
 var (
 	userAgent = fmt.Sprintf("Go/%s (%s-%s) go-autorest/%s",

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,7 +5,6 @@ variables:
   GOROOT: '/usr/local/go1.12'
   GOPATH: '$(system.defaultWorkingDirectory)/work'
   sdkPath: '$(GOPATH)/src/github.com/$(build.repository.name)'
-  GO111MODULE: 'on'
 
 steps:
 - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,6 +5,7 @@ variables:
   GOROOT: '/usr/local/go1.12'
   GOPATH: '$(system.defaultWorkingDirectory)/work'
   sdkPath: '$(GOPATH)/src/github.com/$(build.repository.name)'
+  GO111MODULE: 'on'
 
 steps:
 - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,7 @@ steps:
     go get github.com/jstemmer/go-junit-report
     go get github.com/axw/gocov/gocov
     go get github.com/AlekSi/gocov-xml
-    go get -u gopkg.in/matm/v1/gocov-html
+    go get -u github.com/matm/gocov-html
   workingDirectory: '$(sdkPath)'
   displayName: 'Install Dependencies'
 - script: |


### PR DESCRIPTION
Added functions for device code flow that take a context.
Enforce Go modules mode in CI.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.