### PR TITLE
token: support for a custom refresh func

### DIFF
--- a/autorest/adal/token.go
+++ b/autorest/adal/token.go
@@ -350,7 +350,7 @@ type ServicePrincipalToken struct {
 	inner             servicePrincipalToken
 	refreshLock       *sync.RWMutex
 	sender            Sender
-	customRefreshFunc *TokenRefresh
+	customRefreshFunc TokenRefresh
 	refreshCallbacks  []TokenRefreshCallback
 	// MaxMSIRefreshAttempts is the maximum number of attempts to refresh an MSI token.
 	MaxMSIRefreshAttempts int
@@ -367,7 +367,7 @@ func (spt *ServicePrincipalToken) SetRefreshCallbacks(callbacks []TokenRefreshCa
 }
 
 // SetCustomRefreshFunc sets a custom refresh function used to refresh the token.
-func (spt *ServicePrincipalToken) SetCustomRefreshFunc(customRefreshFunc *TokenRefresh) {
+func (spt *ServicePrincipalToken) SetCustomRefreshFunc(customRefreshFunc TokenRefresh) {
 	spt.customRefreshFunc = customRefreshFunc
 }
 
@@ -843,8 +843,7 @@ func isIMDS(u url.URL) bool {
 
 func (spt *ServicePrincipalToken) refreshInternal(ctx context.Context, resource string) error {
 	if spt.customRefreshFunc != nil {
-		f := *spt.customRefreshFunc
-		token, err := f(ctx, resource)
+		token, err := spt.customRefreshFunc(ctx, resource)
 		if err != nil {
 			return err
 		}

--- a/autorest/adal/token.go
+++ b/autorest/adal/token.go
@@ -847,10 +847,8 @@ func (spt *ServicePrincipalToken) refreshInternal(ctx context.Context, resource 
 		if err != nil {
 			return err
 		}
-
 		spt.inner.Token = *token
-
-		return spt.InvokeRefreshCallbacks(*token)
+		return spt.InvokeRefreshCallbacks(spt.inner.Token)
 	}
 
 	req, err := http.NewRequest(http.MethodPost, spt.inner.OauthConfig.TokenEndpoint.String(), nil)

--- a/autorest/adal/token.go
+++ b/autorest/adal/token.go
@@ -106,6 +106,9 @@ type RefresherWithContext interface {
 // a successful token refresh
 type TokenRefreshCallback func(Token) error
 
+// TokenRefresh is a type representing a custom callback to refresh a token
+type TokenRefresh func(ctx context.Context, resource string) (*Token, error)
+
 // Token encapsulates the access token used to authorize Azure requests.
 // https://docs.microsoft.com/en-us/azure/active-directory/develop/v1-oauth2-client-creds-grant-flow#service-to-service-access-token-response
 type Token struct {
@@ -344,10 +347,11 @@ func (secret ServicePrincipalAuthorizationCodeSecret) MarshalJSON() ([]byte, err
 
 // ServicePrincipalToken encapsulates a Token created for a Service Principal.
 type ServicePrincipalToken struct {
-	inner            servicePrincipalToken
-	refreshLock      *sync.RWMutex
-	sender           Sender
-	refreshCallbacks []TokenRefreshCallback
+	inner             servicePrincipalToken
+	refreshLock       *sync.RWMutex
+	sender            Sender
+	customRefreshFunc *TokenRefresh
+	refreshCallbacks  []TokenRefreshCallback
 	// MaxMSIRefreshAttempts is the maximum number of attempts to refresh an MSI token.
 	MaxMSIRefreshAttempts int
 }
@@ -360,6 +364,11 @@ func (spt ServicePrincipalToken) MarshalTokenJSON() ([]byte, error) {
 // SetRefreshCallbacks replaces any existing refresh callbacks with the specified callbacks.
 func (spt *ServicePrincipalToken) SetRefreshCallbacks(callbacks []TokenRefreshCallback) {
 	spt.refreshCallbacks = callbacks
+}
+
+// SetCustomRefreshFunc sets a custom refresh function used to refresh the token.
+func (spt *ServicePrincipalToken) SetCustomRefreshFunc(customRefreshFunc *TokenRefresh) {
+	spt.customRefreshFunc = customRefreshFunc
 }
 
 // MarshalJSON implements the json.Marshaler interface.
@@ -833,6 +842,18 @@ func isIMDS(u url.URL) bool {
 }
 
 func (spt *ServicePrincipalToken) refreshInternal(ctx context.Context, resource string) error {
+	if spt.customRefreshFunc != nil {
+		f := *spt.customRefreshFunc
+		token, err := f(ctx, resource)
+		if err != nil {
+			return err
+		}
+
+		spt.inner.Token = *token
+
+		return spt.InvokeRefreshCallbacks(*token)
+	}
+
 	req, err := http.NewRequest(http.MethodPost, spt.inner.OauthConfig.TokenEndpoint.String(), nil)
 	if err != nil {
 		return fmt.Errorf("adal: Failed to build the refresh request. Error = '%v'", err)

--- a/autorest/adal/token_test.go
+++ b/autorest/adal/token_test.go
@@ -100,6 +100,24 @@ func TestServicePrincipalTokenSetAutoRefresh(t *testing.T) {
 	}
 }
 
+func TestServicePrincipalTokenSetCustomRefreshFunc(t *testing.T) {
+	spt := newServicePrincipalToken()
+
+	var refreshFunc TokenRefresh = func(context context.Context, resource string) (*Token, error) {
+		return nil, nil
+	}
+
+	if spt.customRefreshFunc != nil {
+		t.Fatalf("adal: ServicePrincipalToken#SetCustomRefreshFunc had a default custom refresh func when it shouldn't")
+	}
+
+	spt.SetCustomRefreshFunc(&refreshFunc)
+
+	if spt.customRefreshFunc == nil {
+		t.Fatalf("adal: ServicePrincipalToken#SetCustomRefreshFunc didn't have a refresh func")
+	}
+}
+
 func TestServicePrincipalTokenSetRefreshWithin(t *testing.T) {
 	spt := newServicePrincipalToken()
 
@@ -120,6 +138,26 @@ func TestServicePrincipalTokenSetSender(t *testing.T) {
 	spt.SetSender(c)
 	if !reflect.DeepEqual(c, spt.sender) {
 		t.Fatal("adal: ServicePrincipalToken#SetSender did not set the sender")
+	}
+}
+
+func TestServicePrincipalTokenRefreshUsesCustomRefreshFunc(t *testing.T) {
+	spt := newServicePrincipalToken()
+
+	called := false
+	var refreshFunc TokenRefresh = func(context context.Context, resource string) (*Token, error) {
+		called = true
+		return &Token{}, nil
+	}
+	spt.SetCustomRefreshFunc(&refreshFunc)
+	if called {
+		t.Fatalf("adal: ServicePrincipalToken#refreshInternal called the refresh function prior to refreshing")
+	}
+
+	spt.refreshInternal(context.Background(), "https://example.com")
+
+	if !called {
+		t.Fatalf("adal: ServicePrincipalToken#refreshInternal didn't call the refresh function")
 	}
 }
 

--- a/autorest/adal/token_test.go
+++ b/autorest/adal/token_test.go
@@ -111,7 +111,7 @@ func TestServicePrincipalTokenSetCustomRefreshFunc(t *testing.T) {
 		t.Fatalf("adal: ServicePrincipalToken#SetCustomRefreshFunc had a default custom refresh func when it shouldn't")
 	}
 
-	spt.SetCustomRefreshFunc(&refreshFunc)
+	spt.SetCustomRefreshFunc(refreshFunc)
 
 	if spt.customRefreshFunc == nil {
 		t.Fatalf("adal: ServicePrincipalToken#SetCustomRefreshFunc didn't have a refresh func")
@@ -149,7 +149,7 @@ func TestServicePrincipalTokenRefreshUsesCustomRefreshFunc(t *testing.T) {
 		called = true
 		return &Token{}, nil
 	}
-	spt.SetCustomRefreshFunc(&refreshFunc)
+	spt.SetCustomRefreshFunc(refreshFunc)
 	if called {
 		t.Fatalf("adal: ServicePrincipalToken#refreshInternal called the refresh function prior to refreshing")
 	}


### PR DESCRIPTION
This PR adds support for specifying a custom refresh function which allows users defining manual refresh tokens to refresh the token via a callback

Fixes https://github.com/hashicorp/go-azure-helpers/issues/22