### PR TITLE
Adding a new Authorizer for SAS Token Authentication

### DIFF
--- a/autorest/authorization_sas.go
+++ b/autorest/authorization_sas.go
@@ -1,0 +1,73 @@
+package autorest
+
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// SASTokenAuthorizer implements an authorization for SAS Token Authentication
+// this can be used for interaction with Blob Storage Endpoints
+type SASTokenAuthorizer struct {
+	sasToken string
+}
+
+// NewSASTokenAuthorizer creates a SASTokenAuthorizer using the given credentials
+func NewSASTokenAuthorizer(sasToken string) (*SASTokenAuthorizer, error) {
+	if strings.TrimSpace(sasToken) == "" {
+		return nil, fmt.Errorf("`sasToken` cannot be empty!")
+	}
+
+	token := sasToken
+	if strings.HasPrefix(sasToken, "?") {
+		token = strings.TrimPrefix(sasToken, "?")
+	}
+
+	return &SASTokenAuthorizer{
+		sasToken: token,
+	}, nil
+}
+
+// WithAuthorization returns a PrepareDecorator that adds an HTTP Authorization header whose
+// value is "SharedKey " followed by the computed key.
+// This can be used for the Blob, Queue, and File Services
+//
+// from: https://docs.microsoft.com/en-us/rest/api/storageservices/authorize-with-shared-key
+// You may use Shared Key Lite authorization to authorize a request made against the
+// 2009-09-19 version and later of the Blob and Queue services,
+// and version 2014-02-14 and later of the File services.
+func (sas *SASTokenAuthorizer) WithAuthorization() PrepareDecorator {
+	return func(p Preparer) Preparer {
+		return PreparerFunc(func(r *http.Request) (*http.Request, error) {
+			r, err := p.Prepare(r)
+			if err != nil {
+				return r, err
+			}
+
+			queryString := r.URL.RawQuery
+			if queryString != "" {
+				queryString = fmt.Sprintf("%s&%s", queryString, sas.sasToken)
+			} else {
+				queryString = sas.sasToken
+			}
+
+			r.URL.RawQuery = queryString
+			r.RequestURI = r.URL.String()
+			return Prepare(r)
+		})
+	}
+}

--- a/autorest/authorization_sas_test.go
+++ b/autorest/authorization_sas_test.go
@@ -1,0 +1,99 @@
+package autorest
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+func TestSasNewSasAuthorizerEmptyToken(t *testing.T) {
+	auth, err := NewSASTokenAuthorizer("")
+	if err == nil {
+		t.Fatalf("azure: SASTokenAuthorizer#NewSASTokenAuthorizer didn't return an error")
+	}
+
+	if auth != nil {
+		t.Fatalf("azure: SASTokenAuthorizer#NewSASTokenAuthorizer returned an authorizer")
+	}
+}
+
+func TestSasNewSasAuthorizerEmptyTokenWithWhitespace(t *testing.T) {
+	auth, err := NewSASTokenAuthorizer("  ")
+	if err == nil {
+		t.Fatalf("azure: SASTokenAuthorizer#NewSASTokenAuthorizer didn't return an error")
+	}
+
+	if auth != nil {
+		t.Fatalf("azure: SASTokenAuthorizer#NewSASTokenAuthorizer returned an authorizer")
+	}
+}
+
+func TestSasNewSasAuthorizerValidToken(t *testing.T) {
+	auth, err := NewSASTokenAuthorizer("abc123")
+	if err != nil {
+		t.Fatalf("azure: SASTokenAuthorizer#NewSASTokenAuthorizer returned an error")
+	}
+
+	if auth == nil {
+		t.Fatalf("azure: SASTokenAuthorizer#NewSASTokenAuthorizer didn't return an authorizer")
+	}
+}
+
+func TestSasAuthorizerRequest(t *testing.T) {
+	testData := []struct{
+		name string
+		token string
+		input string
+		expected string
+	}{
+		{
+			name: "empty querystring without a prefix",
+			token: "abc123",
+			input: "https://example.com/foo/bar",
+			expected: "https://example.com/foo/bar?abc123",
+		},
+		{
+			name: "empty querystring with a prefix",
+			token: "?abc123",
+			input: "https://example.com/foo/bar",
+			expected: "https://example.com/foo/bar?abc123",
+		},
+		{
+			name: "existing querystring without a prefix",
+			token: "abc123",
+			input: "https://example.com/foo/bar?hello=world",
+			expected: "https://example.com/foo/bar?hello=world&abc123",
+		},
+		{
+			name: "existing querystring with a prefix",
+			token: "?abc123",
+			input: "https://example.com/foo/bar?hello=world",
+			expected: "https://example.com/foo/bar?hello=world&abc123",
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing Case %q..", v.name)
+		auth, err := NewSASTokenAuthorizer(v.token)
+		if err != nil {
+			t.Fatalf("azure: SASTokenAuthorizer#WithAuthorization expected %q but got an error", v.expected)
+		}
+		url, _ := url.ParseRequestURI(v.input)
+		httpReq := &http.Request{
+			URL: url,
+		}
+
+		req, err := Prepare(httpReq, auth.WithAuthorization())
+		if err != nil {
+			t.Fatalf("azure: SASTokenAuthorizer#WithAuthorization returned an error (%v)", err)
+		}
+
+		if req.RequestURI != v.expected {
+			t.Fatalf("azure: SASTokenAuthorizer#WithAuthorization failed to set QueryString header - got %q but expected %q", req.RequestURI, v.expected)
+		}
+
+		if req.Header.Get(http.CanonicalHeaderKey("Authorization")) != "" {
+			t.Fatal("azure: SASTokenAuthorizer#WithAuthorization set an Authorization header when it shouldn't!")
+		}
+	}
+}

--- a/autorest/authorization_sas_test.go
+++ b/autorest/authorization_sas_test.go
@@ -1,5 +1,19 @@
 package autorest
 
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 import (
 	"net/http"
 	"net/url"
@@ -40,34 +54,34 @@ func TestSasNewSasAuthorizerValidToken(t *testing.T) {
 }
 
 func TestSasAuthorizerRequest(t *testing.T) {
-	testData := []struct{
-		name string
-		token string
-		input string
+	testData := []struct {
+		name     string
+		token    string
+		input    string
 		expected string
 	}{
 		{
-			name: "empty querystring without a prefix",
-			token: "abc123",
-			input: "https://example.com/foo/bar",
+			name:     "empty querystring without a prefix",
+			token:    "abc123",
+			input:    "https://example.com/foo/bar",
 			expected: "https://example.com/foo/bar?abc123",
 		},
 		{
-			name: "empty querystring with a prefix",
-			token: "?abc123",
-			input: "https://example.com/foo/bar",
+			name:     "empty querystring with a prefix",
+			token:    "?abc123",
+			input:    "https://example.com/foo/bar",
 			expected: "https://example.com/foo/bar?abc123",
 		},
 		{
-			name: "existing querystring without a prefix",
-			token: "abc123",
-			input: "https://example.com/foo/bar?hello=world",
+			name:     "existing querystring without a prefix",
+			token:    "abc123",
+			input:    "https://example.com/foo/bar?hello=world",
 			expected: "https://example.com/foo/bar?hello=world&abc123",
 		},
 		{
-			name: "existing querystring with a prefix",
-			token: "?abc123",
-			input: "https://example.com/foo/bar?hello=world",
+			name:     "existing querystring with a prefix",
+			token:    "?abc123",
+			input:    "https://example.com/foo/bar?hello=world",
 			expected: "https://example.com/foo/bar?hello=world&abc123",
 		},
 	}


### PR DESCRIPTION
This commit introduces a new Authorizer for authenticating with Blob Storage using a SAS Token

```
$ go test -v ./autorest/ -run="TestSas"
=== RUN   TestSasNewSasAuthorizerEmptyToken
--- PASS: TestSasNewSasAuthorizerEmptyToken (0.00s)
=== RUN   TestSasNewSasAuthorizerEmptyTokenWithWhitespace
--- PASS: TestSasNewSasAuthorizerEmptyTokenWithWhitespace (0.00s)
=== RUN   TestSasNewSasAuthorizerValidToken
--- PASS: TestSasNewSasAuthorizerValidToken (0.00s)
=== RUN   TestSasAuthorizerRequest
--- PASS: TestSasAuthorizerRequest (0.00s)
    authorization_sas_test.go:76: [DEBUG] Testing Case "empty querystring without a prefix"..
    authorization_sas_test.go:76: [DEBUG] Testing Case "empty querystring with a prefix"..
    authorization_sas_test.go:76: [DEBUG] Testing Case "existing querystring without a prefix"..
    authorization_sas_test.go:76: [DEBUG] Testing Case "existing querystring with a prefix"..
PASS
ok  	github.com/Azure/go-autorest/autorest	0.011s
```

Fixes https://github.com/tombuildsstuff/giovanni/issues/19

cc @mbfrahry