### PR TITLE
Improve the code to support int and other types and cast them to string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v13.3.1
+
+### Bug Fixes
+
+- Updated `autorest.AsStringSlice()` to convert slice elements to their string representation.
+
 ## v13.3.0
 
 ### New Features

--- a/autorest/utility.go
+++ b/autorest/utility.go
@@ -140,13 +140,13 @@ func MapToValues(m map[string]interface{}) url.Values {
 	return v
 }
 
-// AsStringSlice method converts interface{} to []string. This expects a
-//that the parameter passed to be a slice or array of a type that has the underlying
-//type a string.
+// AsStringSlice method converts interface{} to []string.
+// s must be of type slice or array or an error is returned.
+// Each element of s will be converted to its string representation.
 func AsStringSlice(s interface{}) ([]string, error) {
 	v := reflect.ValueOf(s)
 	if v.Kind() != reflect.Slice && v.Kind() != reflect.Array {
-		return nil, NewError("autorest", "AsStringSlice", "the value's type is not an array.")
+		return nil, NewError("autorest", "AsStringSlice", "the value's type is not a slice or array.")
 	}
 	stringSlice := make([]string, 0, v.Len())
 

--- a/autorest/utility.go
+++ b/autorest/utility.go
@@ -151,7 +151,7 @@ func AsStringSlice(s interface{}) ([]string, error) {
 	stringSlice := make([]string, 0, v.Len())
 
 	for i := 0; i < v.Len(); i++ {
-		stringSlice = append(stringSlice, v.Index(i).String())
+		stringSlice = append(stringSlice, fmt.Sprintf("%v", v.Index(i)))
 	}
 	return stringSlice, nil
 }

--- a/autorest/utility_test.go
+++ b/autorest/utility_test.go
@@ -262,6 +262,15 @@ func TestStringWithEnumSlice(t *testing.T) {
 	}
 }
 
+func TestStringWithIntegerSlice(t *testing.T) {
+	type TestEnumType int32
+	s := []TestEnumType{1, 2}
+	if got, want := String(s, ","), "1,2"; got != want {
+		t.Logf("got:  %q\nwant: %q", got, want)
+		t.Fail()
+	}
+}
+
 func ExampleAsStringSlice() {
 	type TestEnumType string
 

--- a/autorest/version.go
+++ b/autorest/version.go
@@ -19,7 +19,7 @@ import (
 	"runtime"
 )
 
-const number = "v13.3.0"
+const number = "v13.3.1"
 
 var (
 	userAgent = fmt.Sprintf("Go/%s (%s-%s) go-autorest/%s",


### PR DESCRIPTION
Hey, how about this solution @jhendrixMSFT? This code accepts interface but casts types not always right. I mean isn't this more correct to cast not only string arrays to string if that function accepts not only strings? If we accept it then we don't need to fix a swagger spec.

realates with https://github.com/Azure/azure-sdk-for-go/issues/6586

As part of submitting, please make sure you can make the following assertions:
 - [x] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.