### PR TITLE
Fix CHANGELOG and version info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # CHANGELOG
 
-## v13.3.1
+## v13.3.2
 
 ### Bug Fixes
 
 - Updated `autorest.AsStringSlice()` to convert slice elements to their string representation.
+
+## v13.3.1
+
+- Updated external dependencies.
+
+### Bug Fixes
 
 ## v13.3.0
 

--- a/autorest/version.go
+++ b/autorest/version.go
@@ -19,7 +19,7 @@ import (
 	"runtime"
 )
 
-const number = "v13.3.1"
+const number = "v13.3.2"
 
 var (
 	userAgent = fmt.Sprintf("Go/%s (%s-%s) go-autorest/%s",


### PR DESCRIPTION
v13.3.1 was released however the CHANGELOG and version.go files were not
updated as part of that release.  The files have been updated to
accurately reflect the latest version info.
