### PR TITLE
Enable exponential back-off when retrying on 429

### DIFF
--- a/autorest/sender.go
+++ b/autorest/sender.go
@@ -295,7 +295,8 @@ func doRetryForStatusCodesImpl(s Sender, r *http.Request, count429 bool, attempt
 			return resp, err
 		}
 		delayed := DelayWithRetryAfter(resp, r.Context().Done())
-		// enforce a 2 minute cap when not counting 429 if there isn't one.
+		// enforce a 2 minute cap between requests when 429 status codes are
+		// not going to be counted as an attempt and when the cap is 0.
 		// this should only happen in the absense of a retry-after header.
 		if !count429 && cap == 0 {
 			cap = 2 * time.Minute

--- a/autorest/sender.go
+++ b/autorest/sender.go
@@ -297,7 +297,7 @@ func doRetryForStatusCodesImpl(s Sender, r *http.Request, count429 bool, attempt
 		delayed := DelayWithRetryAfter(resp, r.Context().Done())
 		// enforce a 2 minute cap between requests when 429 status codes are
 		// not going to be counted as an attempt and when the cap is 0.
-		// this should only happen in the absense of a retry-after header.
+		// this should only happen in the absence of a retry-after header.
 		if !count429 && cap == 0 {
 			cap = 2 * time.Minute
 		}

--- a/autorest/sender.go
+++ b/autorest/sender.go
@@ -295,6 +295,11 @@ func doRetryForStatusCodesImpl(s Sender, r *http.Request, count429 bool, attempt
 			return resp, err
 		}
 		delayed := DelayWithRetryAfter(resp, r.Context().Done())
+		// enforce a 2 minute cap when not counting 429 if there isn't one.
+		// this should only happen in the absense of a retry-after header.
+		if !count429 && cap == 0 {
+			cap = 2 * time.Minute
+		}
 		if !delayed && !DelayForBackoffWithCap(backoff, cap, delayCount, r.Context().Done()) {
 			return resp, r.Context().Err()
 		}


### PR DESCRIPTION
Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.