### PR TITLE
Enable specifying SendDecorators on a client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## v13.4.0
+
+## New Features
+
+- Added field `SendDecorators` to the `Client` type.  This can be used to specify a custom chain of SendDecorators per client.
+- Added method `Client.Send()` which includes logic for selecting the preferred chain of SendDecorators.
+
 ## v13.3.3
 
 ### Bug Fixes

--- a/autorest/client_test.go
+++ b/autorest/client_test.go
@@ -16,6 +16,7 @@ package autorest
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"fmt"
 	"io/ioutil"
@@ -460,4 +461,92 @@ func randomString(n int) string {
 		s[i] = chars[r.Intn(len(chars))]
 	}
 	return string(s)
+}
+
+func TestClientSendMethod(t *testing.T) {
+	sender := mocks.NewSender()
+	sender.AppendResponse(newAcceptedResponse())
+	client := Client{
+		Sender: sender,
+	}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, mocks.TestURL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// no SendDecorators
+	resp, err := client.Send(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("expected status code %d, got %d", http.StatusAccepted, resp.StatusCode)
+	}
+	// default SendDecorators
+	sender.AppendResponse(newAcceptedResponse())
+	resp, err = client.Send(req, DefaultSendDecorator())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v := resp.Header.Get("default-decorator"); v != "true" {
+		t.Fatal("didn't find default-decorator header in response")
+	}
+	// using client SendDecorators
+	sender.AppendResponse(newAcceptedResponse())
+	client.SendDecorators = []SendDecorator{ClientSendDecorator()}
+	resp, err = client.Send(req, DefaultSendDecorator())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v := resp.Header.Get("client-decorator"); v != "true" {
+		t.Fatal("didn't find client-decorator header in response")
+	}
+	if v := resp.Header.Get("default-decorator"); v == "true" {
+		t.Fatal("unexpected default-decorator header in response")
+	}
+	// using context SendDecorators
+	sender.AppendResponse(newAcceptedResponse())
+	req = req.WithContext(WithSendDecorators(req.Context(), []SendDecorator{ContextSendDecorator()}))
+	resp, err = client.Send(req, DefaultSendDecorator())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v := resp.Header.Get("context-decorator"); v != "true" {
+		t.Fatal("didn't find context-decorator header in response")
+	}
+	if v := resp.Header.Get("client-decorator"); v == "true" {
+		t.Fatal("unexpected client-decorator header in response")
+	}
+	if v := resp.Header.Get("default-decorator"); v == "true" {
+		t.Fatal("unexpected default-decorator header in response")
+	}
+}
+
+func DefaultSendDecorator() SendDecorator {
+	return func(s Sender) Sender {
+		return SenderFunc(func(r *http.Request) (*http.Response, error) {
+			resp, err := s.Do(r)
+			resp.Header.Set("default-decorator", "true")
+			return resp, err
+		})
+	}
+}
+
+func ClientSendDecorator() SendDecorator {
+	return func(s Sender) Sender {
+		return SenderFunc(func(r *http.Request) (*http.Response, error) {
+			resp, err := s.Do(r)
+			resp.Header.Set("client-decorator", "true")
+			return resp, err
+		})
+	}
+}
+
+func ContextSendDecorator() SendDecorator {
+	return func(s Sender) Sender {
+		return SenderFunc(func(r *http.Request) (*http.Response, error) {
+			resp, err := s.Do(r)
+			resp.Header.Set("context-decorator", "true")
+			return resp, err
+		})
+	}
 }

--- a/autorest/client_test.go
+++ b/autorest/client_test.go
@@ -469,7 +469,8 @@ func TestClientSendMethod(t *testing.T) {
 	client := Client{
 		Sender: sender,
 	}
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, mocks.TestURL, nil)
+	req, err := http.NewRequest(http.MethodGet, mocks.TestURL, nil)
+	req = req.WithContext(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/autorest/version.go
+++ b/autorest/version.go
@@ -19,7 +19,7 @@ import (
 	"runtime"
 )
 
-const number = "v13.3.3"
+const number = "v13.4.0"
 
 var (
 	userAgent = fmt.Sprintf("Go/%s (%s-%s) go-autorest/%s",


### PR DESCRIPTION
Added field SendDecorators to autorest.Client; this value will be
preferred over the default SendDecorators.
Added method Client.Send() which includes logic for using custom
SendDecorator chains.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.