### PR TITLE
auth/storage: support for the SharedKey implementation used by the Storage Accounts Data Plane API

### DIFF
--- a/autorest/authorization_storage.go
+++ b/autorest/authorization_storage.go
@@ -35,9 +35,6 @@ const (
 	// SharedKey is used to authorize against blobs, files and queues services.
 	SharedKey SharedKeyType = "sharedKey"
 
-	// SharedKey is used to authorize against the account.
-	SharedKeyForAccount SharedKeyType = "sharedKeyAccount"
-
 	// SharedKeyForTable is used to authorize against the table service.
 	SharedKeyForTable SharedKeyType = "sharedKeyTable"
 
@@ -130,14 +127,6 @@ func buildSharedKey(accName string, accKey []byte, req *http.Request, keyType Sh
 		date := time.Now().UTC().Format(http.TimeFormat)
 		req.Header.Set(headerXMSDate, date)
 	}
-
-	if keyType == SharedKeyForAccount {
-		// ensure a content length is set if appropriate
-		if req.Header.Get(headerContentLength) == "" {
-			req.Header.Set("Content-Length", fmt.Sprintf("%d", int(req.ContentLength)))
-		}
-	}
-
 	canString, err := buildCanonicalizedString(req.Method, req.Header, canRes, keyType)
 	if err != nil {
 		return "", err
@@ -156,9 +145,6 @@ func buildCanonicalizedResource(accountName, uri string, keyType SharedKeyType) 
 	if accountName != storageEmulatorAccountName {
 		cr.WriteString("/")
 		cr.WriteString(getCanonicalizedAccountName(accountName))
-		if keyType == SharedKeyForAccount {
-			cr.WriteString("/")
-		}
 	}
 
 	if len(u.Path) > 0 {
@@ -166,6 +152,9 @@ func buildCanonicalizedResource(accountName, uri string, keyType SharedKeyType) 
 		// the resource's URI should be encoded exactly as it is in the URI.
 		// -- https://msdn.microsoft.com/en-gb/library/azure/dd179428.aspx
 		cr.WriteString(u.EscapedPath())
+	} else {
+		// a slash is required to indicate the root path
+		cr.WriteString("/")
 	}
 
 	params, err := url.ParseQuery(u.RawQuery)
@@ -174,7 +163,7 @@ func buildCanonicalizedResource(accountName, uri string, keyType SharedKeyType) 
 	}
 
 	// See https://github.com/Azure/azure-storage-net/blob/master/Lib/Common/Core/Util/AuthenticationUtility.cs#L277
-	if keyType == SharedKey || keyType == SharedKeyForAccount {
+	if keyType == SharedKey {
 		if len(params) > 0 {
 			cr.WriteString("\n")
 
@@ -217,7 +206,7 @@ func buildCanonicalizedString(verb string, headers http.Header, canonicalizedRes
 	}
 	date := headers.Get(headerDate)
 	if v := headers.Get(headerXMSDate); v != "" {
-		if keyType == SharedKey || keyType == SharedKeyForAccount || keyType == SharedKeyLite {
+		if keyType == SharedKey || keyType == SharedKeyLite {
 			date = ""
 		} else {
 			date = v
@@ -225,7 +214,7 @@ func buildCanonicalizedString(verb string, headers http.Header, canonicalizedRes
 	}
 	var canString string
 	switch keyType {
-	case SharedKey, SharedKeyForAccount:
+	case SharedKey:
 		canString = strings.Join([]string{
 			verb,
 			headers.Get(headerContentEncoding),
@@ -309,7 +298,7 @@ func createAuthorizationHeader(accountName string, accountKey []byte, canonicali
 	signature := base64.StdEncoding.EncodeToString(h.Sum(nil))
 	var key string
 	switch keyType {
-	case SharedKey, SharedKeyForAccount, SharedKeyForTable:
+	case SharedKey, SharedKeyForTable:
 		key = "SharedKey"
 	case SharedKeyLite, SharedKeyLiteForTable:
 		key = "SharedKeyLite"

--- a/autorest/authorization_storage.go
+++ b/autorest/authorization_storage.go
@@ -35,6 +35,9 @@ const (
 	// SharedKey is used to authorize against blobs, files and queues services.
 	SharedKey SharedKeyType = "sharedKey"
 
+	// SharedKey is used to authorize against the account.
+	SharedKeyForAccount SharedKeyType = "sharedKeyAccount"
+
 	// SharedKeyForTable is used to authorize against the table service.
 	SharedKeyForTable SharedKeyType = "sharedKeyTable"
 
@@ -127,6 +130,14 @@ func buildSharedKey(accName string, accKey []byte, req *http.Request, keyType Sh
 		date := time.Now().UTC().Format(http.TimeFormat)
 		req.Header.Set(headerXMSDate, date)
 	}
+
+	if keyType == SharedKeyForAccount {
+		// ensure a content length is set if appropriate
+		if req.Header.Get(headerContentLength) == "" {
+			req.Header.Set("Content-Length", fmt.Sprintf("%d", int(req.ContentLength)))
+		}
+	}
+
 	canString, err := buildCanonicalizedString(req.Method, req.Header, canRes, keyType)
 	if err != nil {
 		return "", err
@@ -145,6 +156,9 @@ func buildCanonicalizedResource(accountName, uri string, keyType SharedKeyType) 
 	if accountName != storageEmulatorAccountName {
 		cr.WriteString("/")
 		cr.WriteString(getCanonicalizedAccountName(accountName))
+		if keyType == SharedKeyForAccount {
+			cr.WriteString("/")
+		}
 	}
 
 	if len(u.Path) > 0 {
@@ -160,7 +174,7 @@ func buildCanonicalizedResource(accountName, uri string, keyType SharedKeyType) 
 	}
 
 	// See https://github.com/Azure/azure-storage-net/blob/master/Lib/Common/Core/Util/AuthenticationUtility.cs#L277
-	if keyType == SharedKey {
+	if keyType == SharedKey || keyType == SharedKeyForAccount {
 		if len(params) > 0 {
 			cr.WriteString("\n")
 
@@ -203,7 +217,7 @@ func buildCanonicalizedString(verb string, headers http.Header, canonicalizedRes
 	}
 	date := headers.Get(headerDate)
 	if v := headers.Get(headerXMSDate); v != "" {
-		if keyType == SharedKey || keyType == SharedKeyLite {
+		if keyType == SharedKey || keyType == SharedKeyForAccount || keyType == SharedKeyLite {
 			date = ""
 		} else {
 			date = v
@@ -211,7 +225,7 @@ func buildCanonicalizedString(verb string, headers http.Header, canonicalizedRes
 	}
 	var canString string
 	switch keyType {
-	case SharedKey:
+	case SharedKey, SharedKeyForAccount:
 		canString = strings.Join([]string{
 			verb,
 			headers.Get(headerContentEncoding),
@@ -295,7 +309,7 @@ func createAuthorizationHeader(accountName string, accountKey []byte, canonicali
 	signature := base64.StdEncoding.EncodeToString(h.Sum(nil))
 	var key string
 	switch keyType {
-	case SharedKey, SharedKeyForTable:
+	case SharedKey, SharedKeyForAccount, SharedKeyForTable:
 		key = "SharedKey"
 	case SharedKeyLite, SharedKeyLiteForTable:
 		key = "SharedKeyLite"

--- a/autorest/authorization_storage_test.go
+++ b/autorest/authorization_storage_test.go
@@ -44,6 +44,31 @@ func TestNewSharedKeyAuthorizer(t *testing.T) {
 	}
 }
 
+func TestNewSharedKeyForAccountAuthorizer(t *testing.T) {
+	auth, err := NewSharedKeyAuthorizer("golangrocksonazure", "YmFy", SharedKeyForAccount)
+	if err != nil {
+		t.Fatalf("create shared key authorizer: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodGet, "https://golangrocksonazure.blob.core.windows.net/?comp=properties&restype=service", nil)
+	if err != nil {
+		t.Fatalf("create HTTP request: %v", err)
+	}
+	req.Header.Add(headerAcceptCharset, "UTF-8")
+	req.Header.Add(headerContentType, "application/json")
+	req.Header.Add(headerXMSDate, "Tue, 10 Mar 2020 10:04:41 GMT")
+	req.Header.Add(headerContentLength, "0")
+	req.Header.Add(headerXMSVersion, "2018-11-09")
+	req.Header.Add(headerAccept, "application/json;odata=nometadata")
+	req, err = Prepare(req, auth.WithAuthorization())
+	if err != nil {
+		t.Fatalf("prepare HTTP request: %v", err)
+	}
+	const expected = "SharedKey golangrocksonazure:YxaPt5rsKrfBl973jnvCq5VBfrB76FRbL+M1ZuvIGSw="
+	if auth := req.Header.Get(headerAuthorization); auth != expected {
+		t.Fatalf("expected: %s, go %s", expected, auth)
+	}
+}
+
 func TestNewSharedKeyForTableAuthorizer(t *testing.T) {
 	auth, err := NewSharedKeyAuthorizer("golangrocksonazure", "YmFy", SharedKeyForTable)
 	if err != nil {

--- a/autorest/authorization_storage_test.go
+++ b/autorest/authorization_storage_test.go
@@ -44,8 +44,8 @@ func TestNewSharedKeyAuthorizer(t *testing.T) {
 	}
 }
 
-func TestNewSharedKeyForAccountAuthorizer(t *testing.T) {
-	auth, err := NewSharedKeyAuthorizer("golangrocksonazure", "YmFy", SharedKeyForAccount)
+func TestNewSharedKeyAuthorizerWithRoot(t *testing.T) {
+	auth, err := NewSharedKeyAuthorizer("golangrocksonazure", "YmFy", SharedKey)
 	if err != nil {
 		t.Fatalf("create shared key authorizer: %v", err)
 	}
@@ -63,7 +63,32 @@ func TestNewSharedKeyForAccountAuthorizer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("prepare HTTP request: %v", err)
 	}
-	const expected = "SharedKey golangrocksonazure:YxaPt5rsKrfBl973jnvCq5VBfrB76FRbL+M1ZuvIGSw="
+	const expected = "SharedKey golangrocksonazure:BfdIC0K5OwkRbZjewqRXgjQJ2PBMZDoaBCCL3qhrEIs="
+	if auth := req.Header.Get(headerAuthorization); auth != expected {
+		t.Fatalf("expected: %s, go %s", expected, auth)
+	}
+}
+
+func TestNewSharedKeyAuthorizerWithoutRoot(t *testing.T) {
+	auth, err := NewSharedKeyAuthorizer("golangrocksonazure", "YmFy", SharedKey)
+	if err != nil {
+		t.Fatalf("create shared key authorizer: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodGet, "https://golangrocksonazure.blob.core.windows.net?comp=properties&restype=service", nil)
+	if err != nil {
+		t.Fatalf("create HTTP request: %v", err)
+	}
+	req.Header.Add(headerAcceptCharset, "UTF-8")
+	req.Header.Add(headerContentType, "application/json")
+	req.Header.Add(headerXMSDate, "Tue, 10 Mar 2020 10:04:41 GMT")
+	req.Header.Add(headerContentLength, "0")
+	req.Header.Add(headerXMSVersion, "2018-11-09")
+	req.Header.Add(headerAccept, "application/json;odata=nometadata")
+	req, err = Prepare(req, auth.WithAuthorization())
+	if err != nil {
+		t.Fatalf("prepare HTTP request: %v", err)
+	}
+	const expected = "SharedKey golangrocksonazure:BfdIC0K5OwkRbZjewqRXgjQJ2PBMZDoaBCCL3qhrEIs="
 	if auth := req.Header.Get(headerAuthorization); auth != expected {
 		t.Fatalf("expected: %s, go %s", expected, auth)
 	}


### PR DESCRIPTION
Well this is a fun one.

After a bunch of debugging it turns out API's in the root of a Storage Data Plane API use a slightly different, undocumented implementation of SharedKey authorization. Specifically [this API](https://docs.microsoft.com/en-us/rest/api/storageservices/set-blob-service-properties) and [this API](https://docs.microsoft.com/en-us/rest/api/storageservices/get-blob-service-properties) - but presumably the others in the root too.

Whilst this is unfortunate - attempting to update this API to [match the definition](https://docs.microsoft.com/en-us/rest/api/storageservices/authorize-with-shared-key) at this point in time would be a breaking change and thus is a less ideal solution.

Instead this PR introduces a new mode to the SharedKey Authorizer which supports the varied authorization method used by this endpoint.

---

Before this PR, when attempting to hit the Account Endpoint using a SharedKey or SharedKeyLite authorizer with this Request using the SharedKey authorizer:

```
GET /?comp=properties&restype=service HTTP/1.1
Host: unlikely23exst2acctazcnp.blob.core.windows.net
User-Agent: Go/go1.13.5 (amd64-darwin) go-autorest/v13.3.0 tombuildsstuff/giovanni/v0.8.0 storage/2018-11-09
Authorization: SharedKey unlikely23exst2acctazcnp:{removed}
X-Ms-Date: Tue, 10 Mar 2020 10:04:41 GMT
X-Ms-Version: 2018-11-09
Accept-Encoding: gzip
```

returns the following Response..

```
HTTP/1.1 403 Server failed to authenticate the request. Make sure the value of Authorization header is formed correctly including the signature.
Content-Length: 687
Content-Type: application/xml
Server: Microsoft-HTTPAPI/2.0
x-ms-request-id: a3addf0a-b01e-002e-09c3-f6cf21000000
x-ms-error-code: AuthenticationFailed
Date: Tue, 10 Mar 2020 10:04:40 GMT
Connection: keep-alive

<?xml version="1.0" encoding="utf-8"?><Error><Code>AuthenticationFailed</Code><Message>Server failed to authenticate the request. Make sure the value of Authorization header is formed correctly including the signature.
RequestId:a3addf0a-b01e-002e-09c3-f6cf21000000
Time:2020-03-10T10:04:41.2097467Z</Message><AuthenticationErrorDetail>The MAC signature found in the HTTP request '{removed}' is not the same as any computed signature. Server used following string to sign: 'GET











x-ms-date:Tue, 10 Mar 2020 10:04:41 GMT
x-ms-version:2018-11-09
/unlikely23exst2acctazcnp/
comp:properties
restype:service'.</AuthenticationErrorDetail></Error>
```

---

With these changes, and this new Authorizer - the following Request:

```
PUT /?comp=properties&restype=service HTTP/1.1
Host: unlikely23exst2acctggtll.blob.core.windows.net
User-Agent: Go/go1.13.5 (amd64-darwin) go-autorest/v13.3.0 tombuildsstuff/giovanni/v0.8.0 storage/2018-11-09
Content-Length: 146
Authorization: SharedKey unlikely23exst2acctggtll:{removed}
X-Ms-Date: Tue, 10 Mar 2020 10:17:00 GMT
X-Ms-Version: 2018-11-09
Accept-Encoding: gzip

<?xml version="1.0" encoding="UTF-8"?>
<StorageServiceProperties><StaticWebsite><Enabled>true</Enabled></StaticWebsite></StorageServiceProperties>
```

.. returns the following Response:

```
HTTP/1.1 202 Accepted
Content-Length: 0
Server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
x-ms-request-id: aca9eb77-301e-007a-67c5-f6b5af000000
x-ms-version: 2018-11-09
Date: Tue, 10 Mar 2020 10:17:02 GMT
Connection: keep-alive
```