### PR TITLE
authorization_sas fixes

### DIFF
--- a/autorest/authorization_sas.go
+++ b/autorest/authorization_sas.go
@@ -54,13 +54,10 @@ func (sas *SASTokenAuthorizer) WithAuthorization() PrepareDecorator {
 				return r, err
 			}
 
-			if r.URL.RawQuery != "" {
-				// When retrying the request we need to ensure the sasToken isn't present
-				if !strings.Contains(r.URL.RawQuery, sas.sasToken) {
-					r.URL.RawQuery = fmt.Sprintf("%s&%s", r.URL.RawQuery, sas.sasToken)
-				}
-			} else {
+			if r.URL.RawQuery == "" {
 				r.URL.RawQuery = sas.sasToken
+			} else if !strings.Contains(r.URL.RawQuery, sas.sasToken) {
+				r.URL.RawQuery = fmt.Sprintf("%s&%s", r.URL.RawQuery, sas.sasToken)
 			}
 
 			return Prepare(r)

--- a/autorest/authorization_sas.go
+++ b/autorest/authorization_sas.go
@@ -55,12 +55,14 @@ func (sas *SASTokenAuthorizer) WithAuthorization() PrepareDecorator {
 			}
 
 			if r.URL.RawQuery != "" {
-				r.URL.RawQuery = fmt.Sprintf("%s&%s", r.URL.RawQuery, sas.sasToken)
+				// When retrying the request we need to ensure the sasToken isn't present
+				if !strings.Contains(r.URL.RawQuery, sas.sasToken) {
+					r.URL.RawQuery = fmt.Sprintf("%s&%s", r.URL.RawQuery, sas.sasToken)
+				}
 			} else {
 				r.URL.RawQuery = sas.sasToken
 			}
 
-			r.RequestURI = r.URL.String()
 			return Prepare(r)
 		})
 	}

--- a/autorest/authorization_sas_test.go
+++ b/autorest/authorization_sas_test.go
@@ -102,8 +102,8 @@ func TestSasAuthorizerRequest(t *testing.T) {
 			t.Fatalf("azure: SASTokenAuthorizer#WithAuthorization returned an error (%v)", err)
 		}
 
-		if req.RequestURI != v.expected {
-			t.Fatalf("azure: SASTokenAuthorizer#WithAuthorization failed to set QueryString header - got %q but expected %q", req.RequestURI, v.expected)
+		if req.URL.String() != v.expected {
+			t.Fatalf("azure: SASTokenAuthorizer#WithAuthorization failed to set QueryString header - got %q but expected %q", req.URL.String(), v.expected)
 		}
 
 		if req.Header.Get(http.CanonicalHeaderKey("Authorization")) != "" {


### PR DESCRIPTION
There is a bug preventing requests from being sent when using SAS token authentication because you can't modify the RequestURI.
```
Failure sending request: StatusCode=0
Request.RequestURI can't be set in client requests.
```

Also, when retrying requests, the SAS Token was repeatedly being appended to the query string. 