### PR TITLE
Add SetEnvironment method to azure package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v14.1.0
+
+### New Features
+
+- Added `azure.SetEnvironment()` that will update the global environments map with the specified values.
+
 ## v14.0.1
 
 ### Bug Fixes

--- a/autorest/azure/environments.go
+++ b/autorest/azure/environments.go
@@ -242,3 +242,8 @@ func EnvironmentFromFile(location string) (unmarshaled Environment, err error) {
 
 	return
 }
+
+// SetEnvironment updates the environment map with the specified values.
+func SetEnvironment(name string, env Environment) {
+	environments[strings.ToUpper(name)] = env
+}

--- a/autorest/azure/environments_test.go
+++ b/autorest/azure/environments_test.go
@@ -405,3 +405,19 @@ func TestRoundTripSerialization(t *testing.T) {
 		t.Errorf("Expected ResourceIdentifiers.OperationalInsights to be %q, but got %q", env.ResourceIdentifiers.OperationalInsights, testSubject.ResourceIdentifiers.OperationalInsights)
 	}
 }
+
+func TestSetEnvironment(t *testing.T) {
+	const testEnvName = "testenvironment"
+	if _, err := EnvironmentFromName(testEnvName); err == nil {
+		t.Fatal("expected non-nil error")
+	}
+	testEnv := Environment{Name: testEnvName}
+	SetEnvironment(testEnvName, testEnv)
+	result, err := EnvironmentFromName(testEnvName)
+	if err != nil {
+		t.Fatalf("failed to get custom environment: %v", err)
+	}
+	if testEnv != result {
+		t.Fatalf("expected %v, got %v", testEnv, result)
+	}
+}

--- a/autorest/version.go
+++ b/autorest/version.go
@@ -19,7 +19,7 @@ import (
 	"runtime"
 )
 
-const number = "v14.0.1"
+const number = "v14.1.0"
 
 var (
 	userAgent = fmt.Sprintf("Go/%s (%s-%s) go-autorest/%s",


### PR DESCRIPTION
Allows modification of the global environments map.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.