### PR TITLE
Fix check for App Service Environment

### DIFF
--- a/autorest/adal/token.go
+++ b/autorest/adal/token.go
@@ -354,6 +354,7 @@ type ServicePrincipalToken struct {
 	customRefreshFunc TokenRefresh
 	refreshCallbacks  []TokenRefreshCallback
 	// MaxMSIRefreshAttempts is the maximum number of attempts to refresh an MSI token.
+	// Settings this to a value less than 1 will use the default value.
 	MaxMSIRefreshAttempts int
 }
 
@@ -1005,6 +1006,11 @@ func retryForIMDS(sender Sender, req *http.Request, maxAttempts int) (resp *http
 
 	attempt := 0
 	delay := time.Duration(0)
+
+	// maxAttempts is user-specified, ensure that its value is greater than zero else no request will be made
+	if maxAttempts < 1 {
+		maxAttempts = defaultMaxMSIRefreshAttempts
+	}
 
 	for attempt < maxAttempts {
 		if resp != nil && resp.Body != nil {

--- a/autorest/adal/token_test.go
+++ b/autorest/adal/token_test.go
@@ -884,6 +884,23 @@ func TestGetMSIEndpoint(t *testing.T) {
 	}
 }
 
+func TestClientSecretWithASESet(t *testing.T) {
+	if err := os.Setenv(asMSIEndpointEnv, "http://172.16.1.2:8081/msi/token"); err != nil {
+		t.Fatalf("os.Setenv: %v", err)
+	}
+	if err := os.Setenv(asMSISecretEnv, "the_secret"); err != nil {
+		t.Fatalf("os.Setenv: %v", err)
+	}
+	defer func() {
+		os.Unsetenv(asMSIEndpointEnv)
+		os.Unsetenv(asMSISecretEnv)
+	}()
+	spt := newServicePrincipalToken()
+	if isIMDS(spt.inner.OauthConfig.TokenEndpoint) {
+		t.Fatal("isIMDS should return false for client secret token even when ASE is enabled")
+	}
+}
+
 func TestMarshalServicePrincipalNoSecret(t *testing.T) {
 	spt := newServicePrincipalTokenManual()
 	b, err := json.Marshal(spt)

--- a/autorest/adal/token_test.go
+++ b/autorest/adal/token_test.go
@@ -228,6 +228,46 @@ func TestServicePrincipalTokenFromMSIRefreshUsesGET(t *testing.T) {
 	}
 }
 
+func TestServicePrincipalTokenFromMSIRefreshZeroRetry(t *testing.T) {
+	resource := "https://resource"
+	cb := func(token Token) error { return nil }
+
+	endpoint, _ := GetMSIVMEndpoint()
+	spt, err := NewServicePrincipalTokenFromMSI(endpoint, resource, cb)
+	if err != nil {
+		t.Fatalf("Failed to get MSI SPT: %v", err)
+	}
+	spt.MaxMSIRefreshAttempts = 0
+
+	body := mocks.NewBody(newTokenJSON("12345", "test"))
+	resp := mocks.NewResponseWithBodyAndStatus(body, http.StatusOK, "OK")
+
+	c := mocks.NewSender()
+	s := DecorateSender(c,
+		(func() SendDecorator {
+			return func(s Sender) Sender {
+				return SenderFunc(func(r *http.Request) (*http.Response, error) {
+					if r.Method != "GET" {
+						t.Fatalf("adal: ServicePrincipalToken#Refresh did not correctly set HTTP method -- expected %v, received %v", "GET", r.Method)
+					}
+					if h := r.Header.Get("Metadata"); h != "true" {
+						t.Fatalf("adal: ServicePrincipalToken#Refresh did not correctly set Metadata header for MSI")
+					}
+					return resp, nil
+				})
+			}
+		})())
+	spt.SetSender(s)
+	err = spt.Refresh()
+	if err != nil {
+		t.Fatalf("adal: ServicePrincipalToken#Refresh returned an unexpected error (%v)", err)
+	}
+
+	if body.IsOpen() {
+		t.Fatalf("the response was not closed!")
+	}
+}
+
 func TestServicePrincipalTokenFromMSIRefreshCancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	endpoint, _ := GetMSIVMEndpoint()


### PR DESCRIPTION
The presence of the ASE envrionment vars does not indicate that the
caller is actually authenticating in this way.  Instead, look at the
token endpoint URL to see if it matches the ASE endpoint.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.