### PR TITLE
Allow to use OAuth token for authorization outside autorest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## v14.0.0
+
+## Breaking Changes
+
+- By default, the `DoRetryForStatusCodes` functions will no longer infinitely retry a request when the response returns an HTTP status code of 429 (StatusTooManyRequests).  To opt in to the old behavior set `autorest.Count429AsRetry` to `false`.
+
+## New Features
+
+- Variable `autorest.Max429Delay` can be used to control the maximum delay between retries when a 429 is received with no `Retry-After` header.  The default is zero which means there is no cap.
+
 ## v13.4.0
 
 ## New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## v14.0.1
+
+### Bug Fixes
+
+- Fix race condition when refreshing token.
+- Fixed some tests to work with Go 1.14.
+
 ## v14.0.0
 
 ## Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v14.1.0
+
+### New Features
+
+- Added `azure.SetEnvironment()` that will update the global environments map with the specified values.
+
 ## v14.0.1
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## v13.4.0
+
+## New Features
+
+- Added field `SendDecorators` to the `Client` type.  This can be used to specify a custom chain of SendDecorators per client.
+- Added method `Client.Send()` which includes logic for selecting the preferred chain of SendDecorators.
+
 ## v13.3.3
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## v13.3.3
+
+### Bug Fixes
+
+- Fixed connection leak when retrying requests.
+- Enabled exponential back-off with a 2-minute cap when retrying on 429.
+- Fixed some cases where errors were inadvertently dropped.
+
 ## v13.3.2
 
 ### Bug Fixes

--- a/autorest/adal/token.go
+++ b/autorest/adal/token.go
@@ -771,8 +771,9 @@ func (spt *ServicePrincipalToken) EnsureFresh() error {
 // EnsureFreshWithContext will refresh the token if it will expire within the refresh window (as set by
 // RefreshWithin) and autoRefresh flag is on.  This method is safe for concurrent use.
 func (spt *ServicePrincipalToken) EnsureFreshWithContext(ctx context.Context) error {
-	if spt.inner.AutoRefresh && spt.inner.Token.WillExpireIn(spt.inner.RefreshWithin) {
-		// take the write lock then check to see if the token was already refreshed
+	// must take the read lock when initially checking the token's expiration
+	if spt.inner.AutoRefresh && spt.Token().WillExpireIn(spt.inner.RefreshWithin) {
+		// take the write lock then check again to see if the token was already refreshed
 		spt.refreshLock.Lock()
 		defer spt.refreshLock.Unlock()
 		if spt.inner.Token.WillExpireIn(spt.inner.RefreshWithin) {

--- a/autorest/adal/token.go
+++ b/autorest/adal/token.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"math"
 	"net/http"
@@ -248,7 +249,7 @@ func (secret *ServicePrincipalCertificateSecret) SignJwt(spt *ServicePrincipalTo
 		"sub": spt.inner.ClientID,
 		"jti": base64.URLEncoding.EncodeToString(jti),
 		"nbf": time.Now().Unix(),
-		"exp": time.Now().Add(time.Hour * 24).Unix(),
+		"exp": time.Now().Add(24 * time.Hour).Unix(),
 	}
 
 	signedString, err := token.SignedString(secret.PrivateKey)
@@ -972,6 +973,10 @@ func retryForIMDS(sender Sender, req *http.Request, maxAttempts int) (resp *http
 	delay := time.Duration(0)
 
 	for attempt < maxAttempts {
+		if resp != nil && resp.Body != nil {
+			io.Copy(ioutil.Discard, resp.Body)
+			resp.Body.Close()
+		}
 		resp, err = sender.Do(req)
 		// we want to retry if err is not nil or the status code is in the list of retry codes
 		if err == nil && !responseHasStatusCode(resp, retries...) {

--- a/autorest/adal/token_test.go
+++ b/autorest/adal/token_test.go
@@ -164,7 +164,7 @@ func TestServicePrincipalTokenRefreshUsesCustomRefreshFunc(t *testing.T) {
 func TestServicePrincipalTokenRefreshUsesPOST(t *testing.T) {
 	spt := newServicePrincipalToken()
 
-	body := mocks.NewBody(newTokenJSON("test", "test"))
+	body := mocks.NewBody(newTokenJSON("12345", "test"))
 	resp := mocks.NewResponseWithBodyAndStatus(body, http.StatusOK, "OK")
 
 	c := mocks.NewSender()
@@ -199,7 +199,7 @@ func TestServicePrincipalTokenFromMSIRefreshUsesGET(t *testing.T) {
 		t.Fatalf("Failed to get MSI SPT: %v", err)
 	}
 
-	body := mocks.NewBody(newTokenJSON("test", "test"))
+	body := mocks.NewBody(newTokenJSON("12345", "test"))
 	resp := mocks.NewResponseWithBodyAndStatus(body, http.StatusOK, "OK")
 
 	c := mocks.NewSender()
@@ -264,7 +264,7 @@ func TestServicePrincipalTokenFromMSIRefreshCancel(t *testing.T) {
 func TestServicePrincipalTokenRefreshSetsMimeType(t *testing.T) {
 	spt := newServicePrincipalToken()
 
-	body := mocks.NewBody(newTokenJSON("test", "test"))
+	body := mocks.NewBody(newTokenJSON("12345", "test"))
 	resp := mocks.NewResponseWithBodyAndStatus(body, http.StatusOK, "OK")
 
 	c := mocks.NewSender()
@@ -291,7 +291,7 @@ func TestServicePrincipalTokenRefreshSetsMimeType(t *testing.T) {
 func TestServicePrincipalTokenRefreshSetsURL(t *testing.T) {
 	spt := newServicePrincipalToken()
 
-	body := mocks.NewBody(newTokenJSON("test", "test"))
+	body := mocks.NewBody(newTokenJSON("12345", "test"))
 	resp := mocks.NewResponseWithBodyAndStatus(body, http.StatusOK, "OK")
 
 	c := mocks.NewSender()
@@ -315,7 +315,7 @@ func TestServicePrincipalTokenRefreshSetsURL(t *testing.T) {
 }
 
 func testServicePrincipalTokenRefreshSetsBody(t *testing.T, spt *ServicePrincipalToken, f func(*testing.T, []byte)) {
-	body := mocks.NewBody(newTokenJSON("test", "test"))
+	body := mocks.NewBody(newTokenJSON("12345", "test"))
 	resp := mocks.NewResponseWithBodyAndStatus(body, http.StatusOK, "OK")
 
 	c := mocks.NewSender()
@@ -435,7 +435,7 @@ func TestServicePrincipalTokenSecretRefreshSetsBody(t *testing.T) {
 func TestServicePrincipalTokenRefreshClosesRequestBody(t *testing.T) {
 	spt := newServicePrincipalToken()
 
-	body := mocks.NewBody(newTokenJSON("test", "test"))
+	body := mocks.NewBody(newTokenJSON("12345", "test"))
 	resp := mocks.NewResponseWithBodyAndStatus(body, http.StatusOK, "OK")
 
 	c := mocks.NewSender()
@@ -460,7 +460,7 @@ func TestServicePrincipalTokenRefreshClosesRequestBody(t *testing.T) {
 func TestServicePrincipalTokenRefreshRejectsResponsesWithStatusNotOK(t *testing.T) {
 	spt := newServicePrincipalToken()
 
-	body := mocks.NewBody(newTokenJSON("test", "test"))
+	body := mocks.NewBody(newTokenJSON("12345", "test"))
 	resp := mocks.NewResponseWithBodyAndStatus(body, http.StatusUnauthorized, "Unauthorized")
 
 	c := mocks.NewSender()
@@ -559,7 +559,7 @@ func TestServicePrincipalTokenEnsureFreshRefreshes(t *testing.T) {
 	spt := newServicePrincipalToken()
 	expireToken(&spt.inner.Token)
 
-	body := mocks.NewBody(newTokenJSON("test", "test"))
+	body := mocks.NewBody(newTokenJSON("12345", "test"))
 	resp := mocks.NewResponseWithBodyAndStatus(body, http.StatusOK, "OK")
 
 	f := false

--- a/autorest/adal/token_test.go
+++ b/autorest/adal/token_test.go
@@ -978,6 +978,9 @@ func TestNewMultiTenantServicePrincipalToken(t *testing.T) {
 		t.Fatalf("autorest/adal: unexpected error while creating multitenant config: %v", err)
 	}
 	mt, err := NewMultiTenantServicePrincipalToken(cfg, "clientID", "superSecret", "resource")
+	if err != nil {
+		t.Fatalf("autorest/adal: unexpected error while creating multitenant service principal token: %v", err)
+	}
 	if !strings.Contains(mt.PrimaryToken.inner.OauthConfig.AuthorizeEndpoint.String(), TestTenantID) {
 		t.Fatal("didn't find primary tenant ID in primary SPT")
 	}

--- a/autorest/authorization.go
+++ b/autorest/authorization.go
@@ -138,6 +138,11 @@ func (ba *BearerAuthorizer) WithAuthorization() PrepareDecorator {
 	}
 }
 
+// TokenProvider returns OAuthTokenProvider so that it can be used for authorization outside the REST.
+func (ba *BearerAuthorizer) TokenProvider() adal.OAuthTokenProvider {
+	return ba.tokenProvider
+}
+
 // BearerAuthorizerCallbackFunc is the authentication callback signature.
 type BearerAuthorizerCallbackFunc func(tenantID, resource string) (*BearerAuthorizer, error)
 

--- a/autorest/authorization_storage.go
+++ b/autorest/authorization_storage.go
@@ -104,6 +104,9 @@ func (sk *SharedKeyAuthorizer) WithAuthorization() PrepareDecorator {
 			}
 
 			sk, err := buildSharedKey(sk.accountName, sk.accountKey, r, sk.keyType)
+			if err != nil {
+				return r, err
+			}
 			return Prepare(r, WithHeader(headerAuthorization, sk))
 		})
 	}

--- a/autorest/authorization_test.go
+++ b/autorest/authorization_test.go
@@ -102,8 +102,8 @@ func TestServicePrincipalTokenWithAuthorizationRefresh(t *testing.T) {
 	jwt := `{
 		"access_token" : "accessToken",
 		"expires_in"   : "3600",
-		"expires_on"   : "test",
-		"not_before"   : "test",
+		"expires_on"   : "12345",
+		"not_before"   : "67890",
 		"resource"     : "test",
 		"token_type"   : "Bearer"
 	}`
@@ -317,8 +317,8 @@ func TestMultiTenantServicePrincipalTokenWithAuthorizationRefresh(t *testing.T) 
 	primaryToken := `{
 		"access_token" : "primary token refreshed",
 		"expires_in"   : "3600",
-		"expires_on"   : "test",
-		"not_before"   : "test",
+		"expires_on"   : "12345",
+		"not_before"   : "67890",
 		"resource"     : "test",
 		"token_type"   : "Bearer"
 	}`
@@ -326,8 +326,8 @@ func TestMultiTenantServicePrincipalTokenWithAuthorizationRefresh(t *testing.T) 
 	auxToken1 := `{
 		"access_token" : "aux token 1 refreshed",
 		"expires_in"   : "3600",
-		"expires_on"   : "test",
-		"not_before"   : "test",
+		"expires_on"   : "12345",
+		"not_before"   : "67890",
 		"resource"     : "test",
 		"token_type"   : "Bearer"
 	}`
@@ -335,8 +335,8 @@ func TestMultiTenantServicePrincipalTokenWithAuthorizationRefresh(t *testing.T) 
 	auxToken2 := `{
 		"access_token" : "aux token 2 refreshed",
 		"expires_in"   : "3600",
-		"expires_on"   : "test",
-		"not_before"   : "test",
+		"expires_on"   : "12345",
+		"not_before"   : "67890",
 		"resource"     : "test",
 		"token_type"   : "Bearer"
 	}`
@@ -344,8 +344,8 @@ func TestMultiTenantServicePrincipalTokenWithAuthorizationRefresh(t *testing.T) 
 	auxToken3 := `{
 		"access_token" : "aux token 3 refreshed",
 		"expires_in"   : "3600",
-		"expires_on"   : "test",
-		"not_before"   : "test",
+		"expires_on"   : "12345",
+		"not_before"   : "67890",
 		"resource"     : "test",
 		"token_type"   : "Bearer"
 	}`

--- a/autorest/azure/async.go
+++ b/autorest/azure/async.go
@@ -258,7 +258,17 @@ func (f Future) GetResult(sender autorest.Sender) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	return sender.Do(req)
+	resp, err := sender.Do(req)
+	if err == nil && resp.Body != nil {
+		// copy the body and close it so callers don't have to
+		defer resp.Body.Close()
+		b, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return resp, err
+		}
+		resp.Body = ioutil.NopCloser(bytes.NewReader(b))
+	}
+	return resp, err
 }
 
 type pollingTracker interface {

--- a/autorest/azure/auth/auth.go
+++ b/autorest/azure/auth/auth.go
@@ -713,8 +713,8 @@ type MSIConfig struct {
 	ClientID string
 }
 
-// Authorizer gets the authorizer from MSI.
-func (mc MSIConfig) Authorizer() (autorest.Authorizer, error) {
+// ServicePrincipalToken creates a ServicePrincipalToken from MSI.
+func (mc MSIConfig) ServicePrincipalToken() (*adal.ServicePrincipalToken, error) {
 	msiEndpoint, err := adal.GetMSIEndpoint()
 	if err != nil {
 		return nil, err
@@ -731,6 +731,16 @@ func (mc MSIConfig) Authorizer() (autorest.Authorizer, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to get oauth token from MSI for user assigned identity: %v", err)
 		}
+	}
+
+	return spToken, nil
+}
+
+// Authorizer gets the authorizer from MSI.
+func (mc MSIConfig) Authorizer() (autorest.Authorizer, error) {
+	spToken, err := mc.ServicePrincipalToken()
+	if err != nil {
+		return nil, err
 	}
 
 	return autorest.NewBearerAuthorizer(spToken), nil

--- a/autorest/azure/environments.go
+++ b/autorest/azure/environments.go
@@ -242,3 +242,8 @@ func EnvironmentFromFile(location string) (unmarshaled Environment, err error) {
 
 	return
 }
+
+// SetEnvironment updates the environment map with the specified values.
+func SetEnvironment(name string, env Environment) {
+	environments[strings.ToUpper(name)] = env
+}

--- a/autorest/azure/environments_test.go
+++ b/autorest/azure/environments_test.go
@@ -405,3 +405,19 @@ func TestRoundTripSerialization(t *testing.T) {
 		t.Errorf("Expected ResourceIdentifiers.OperationalInsights to be %q, but got %q", env.ResourceIdentifiers.OperationalInsights, testSubject.ResourceIdentifiers.OperationalInsights)
 	}
 }
+
+func TestSetEnvironment(t *testing.T) {
+	const testEnvName = "testenvironment"
+	if _, err := EnvironmentFromName(testEnvName); err == nil {
+		t.Fatal("expected non-nil error")
+	}
+	testEnv := Environment{Name: testEnvName}
+	SetEnvironment(testEnvName, testEnv)
+	result, err := EnvironmentFromName(testEnvName)
+	if err != nil {
+		t.Fatalf("failed to get custom environment: %v", err)
+	}
+	if testEnv != result {
+		t.Fatalf("expected %v, got %v", testEnv, result)
+	}
+}

--- a/autorest/go.mod
+++ b/autorest/go.mod
@@ -3,7 +3,7 @@ module github.com/Azure/go-autorest/autorest
 go 1.12
 
 require (
-	github.com/Azure/go-autorest/autorest/adal v0.8.0
+	github.com/Azure/go-autorest/autorest/adal v0.8.2
 	github.com/Azure/go-autorest/autorest/mocks v0.3.0
 	github.com/Azure/go-autorest/logger v0.1.0
 	github.com/Azure/go-autorest/tracing v0.5.0

--- a/autorest/go.sum
+++ b/autorest/go.sum
@@ -1,8 +1,8 @@
 github.com/Azure/go-autorest/autorest v0.9.0/go.mod h1:xyHB1BMZT0cuDHU7I0+g046+BFDTQ8rEZB0s4Yfa6bI=
 github.com/Azure/go-autorest/autorest/adal v0.5.0 h1:q2gDruN08/guU9vAjuPWff0+QIrpH6ediguzdAzXAUU=
 github.com/Azure/go-autorest/autorest/adal v0.5.0/go.mod h1:8Z9fGy2MpX0PvDjB1pEgQTmVqjGhiHBW7RJJEciWzS0=
-github.com/Azure/go-autorest/autorest/adal v0.8.0 h1:CxTzQrySOxDnKpLjFJeZAS5Qrv/qFPkgLjx5bOAi//I=
-github.com/Azure/go-autorest/autorest/adal v0.8.0/go.mod h1:Z6vX6WXXuyieHAXwMj0S6HY6e6wcHn37qQMBQlvY3lc=
+github.com/Azure/go-autorest/autorest/adal v0.8.2 h1:O1X4oexUxnZCaEUGsvMnr8ZGj8HI37tNezwY4npRqA0=
+github.com/Azure/go-autorest/autorest/adal v0.8.2/go.mod h1:ZjhuQClTqx435SRJ2iMlOxPYt3d2C/T/7TiQCVZSn3Q=
 github.com/Azure/go-autorest/autorest/date v0.1.0 h1:YGrhWfrgtFs84+h0o46rJrlmsZtyZRg470CqAXTZaGM=
 github.com/Azure/go-autorest/autorest/date v0.1.0/go.mod h1:plvfp3oPSKwf2DNjlBjWF/7vwR+cUD/ELuzDCXwHUVA=
 github.com/Azure/go-autorest/autorest/date v0.2.0 h1:yW+Zlqf26583pE43KhfnhFcdmSWlm5Ew6bxipnr/tbM=

--- a/autorest/preparer_test.go
+++ b/autorest/preparer_test.go
@@ -158,10 +158,11 @@ func ExampleWithBaseURL() {
 	// Output: https://microsoft.com/a/b/c/
 }
 
-func ExampleWithBaseURL_second() {
+func TestWithBaseURL_second(t *testing.T) {
 	_, err := Prepare(&http.Request{}, WithBaseURL(":"))
-	fmt.Println(err)
-	// Output: parse :: missing protocol scheme
+	if err == nil {
+		t.Fatal("unexpected nil error")
+	}
 }
 
 // Create a request whose Body is a byte array
@@ -203,11 +204,12 @@ func ExampleWithCustomBaseURL() {
 	// Output: https://myaccount.blob.core.windows.net/
 }
 
-func ExampleWithCustomBaseURL_second() {
+func TestWithCustomBaseURL_second(t *testing.T) {
 	_, err := Prepare(&http.Request{},
 		WithCustomBaseURL(":", map[string]interface{}{}))
-	fmt.Println(err)
-	// Output: parse :: missing protocol scheme
+	if err == nil {
+		t.Fatal("unexpected nil error")
+	}
 }
 
 // Create a request with a custom HTTP header

--- a/autorest/sender.go
+++ b/autorest/sender.go
@@ -243,6 +243,7 @@ func DoRetryForAttempts(attempts int, backoff time.Duration) SendDecorator {
 				if err != nil {
 					return resp, err
 				}
+				DrainResponseBody(resp)
 				resp, err = s.Do(rr.Request())
 				if err == nil {
 					return resp, err
@@ -283,11 +284,12 @@ func DoRetryForStatusCodesWithCap(attempts int, backoff, cap time.Duration, code
 func doRetryForStatusCodesImpl(s Sender, r *http.Request, count429 bool, attempts int, backoff, cap time.Duration, codes ...int) (resp *http.Response, err error) {
 	rr := NewRetriableRequest(r)
 	// Increment to add the first call (attempts denotes number of retries)
-	for attempt := 0; attempt < attempts+1; {
+	for attempt, delayCount := 0, 0; attempt < attempts+1; {
 		err = rr.Prepare()
 		if err != nil {
 			return
 		}
+		DrainResponseBody(resp)
 		resp, err = s.Do(rr.Request())
 		// we want to retry if err is not nil (e.g. transient network failure).  note that for failed authentication
 		// resp and err will both have a value, so in this case we don't want to retry as it will never succeed.
@@ -295,7 +297,13 @@ func doRetryForStatusCodesImpl(s Sender, r *http.Request, count429 bool, attempt
 			return resp, err
 		}
 		delayed := DelayWithRetryAfter(resp, r.Context().Done())
-		if !delayed && !DelayForBackoffWithCap(backoff, cap, attempt, r.Context().Done()) {
+		// enforce a 2 minute cap between requests when 429 status codes are
+		// not going to be counted as an attempt and when the cap is 0.
+		// this should only happen in the absence of a retry-after header.
+		if !count429 && cap == 0 {
+			cap = 2 * time.Minute
+		}
+		if !delayed && !DelayForBackoffWithCap(backoff, cap, delayCount, r.Context().Done()) {
 			return resp, r.Context().Err()
 		}
 		// when count429 == false don't count a 429 against the number
@@ -303,6 +311,9 @@ func doRetryForStatusCodesImpl(s Sender, r *http.Request, count429 bool, attempt
 		if count429 || (resp == nil || resp.StatusCode != http.StatusTooManyRequests) {
 			attempt++
 		}
+		// delay count is tracked separately from attempts to
+		// ensure that 429 participates in exponential back-off
+		delayCount++
 	}
 	return resp, err
 }
@@ -347,6 +358,7 @@ func DoRetryForDuration(d time.Duration, backoff time.Duration) SendDecorator {
 				if err != nil {
 					return resp, err
 				}
+				DrainResponseBody(resp)
 				resp, err = s.Do(rr.Request())
 				if err == nil {
 					return resp, err

--- a/autorest/utility.go
+++ b/autorest/utility.go
@@ -20,6 +20,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -225,4 +226,14 @@ func IsTemporaryNetworkError(err error) bool {
 		return true
 	}
 	return false
+}
+
+// DrainResponseBody reads the response body then closes it.
+func DrainResponseBody(resp *http.Response) error {
+	if resp != nil && resp.Body != nil {
+		_, err := io.Copy(ioutil.Discard, resp.Body)
+		resp.Body.Close()
+		return err
+	}
+	return nil
 }

--- a/autorest/version.go
+++ b/autorest/version.go
@@ -19,7 +19,7 @@ import (
 	"runtime"
 )
 
-const number = "v13.4.0"
+const number = "v14.0.0"
 
 var (
 	userAgent = fmt.Sprintf("Go/%s (%s-%s) go-autorest/%s",

--- a/autorest/version.go
+++ b/autorest/version.go
@@ -19,7 +19,7 @@ import (
 	"runtime"
 )
 
-const number = "v13.3.2"
+const number = "v13.3.3"
 
 var (
 	userAgent = fmt.Sprintf("Go/%s (%s-%s) go-autorest/%s",

--- a/autorest/version.go
+++ b/autorest/version.go
@@ -19,7 +19,7 @@ import (
 	"runtime"
 )
 
-const number = "v14.0.1"
+const number = "v14.1.0"
 
 var (
 	userAgent = fmt.Sprintf("Go/%s (%s-%s) go-autorest/%s",

--- a/autorest/version.go
+++ b/autorest/version.go
@@ -19,7 +19,7 @@ import (
 	"runtime"
 )
 
-const number = "v14.0.0"
+const number = "v14.0.1"
 
 var (
 	userAgent = fmt.Sprintf("Go/%s (%s-%s) go-autorest/%s",

--- a/autorest/version.go
+++ b/autorest/version.go
@@ -19,7 +19,7 @@ import (
 	"runtime"
 )
 
-const number = "v13.3.3"
+const number = "v13.4.0"
 
 var (
 	userAgent = fmt.Sprintf("Go/%s (%s-%s) go-autorest/%s",

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,82 +1,103 @@
-pool:
-  vmImage: 'Ubuntu 16.04'
-
 variables:
-  GOROOT: '/usr/local/go1.12'
   GOPATH: '$(system.defaultWorkingDirectory)/work'
   sdkPath: '$(GOPATH)/src/github.com/$(build.repository.name)'
 
-steps:
-- script: |
-    set -e
-    mkdir -p '$(GOPATH)/bin'
-    mkdir -p '$(sdkPath)'
-    shopt -s extglob
-    mv !(work) '$(sdkPath)'
-    echo '##vso[task.prependpath]$(GOROOT)/bin'
-    echo '##vso[task.prependpath]$(GOPATH)/bin'
-  displayName: 'Create Go Workspace'
-- script: |
-    set -e
-    curl -sSL https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-    dep ensure -v
-    go install ./vendor/golang.org/x/lint/golint
-    go get github.com/jstemmer/go-junit-report
-    go get github.com/axw/gocov/gocov
-    go get github.com/AlekSi/gocov-xml
-    go get -u github.com/matm/gocov-html
-  workingDirectory: '$(sdkPath)'
-  displayName: 'Install Dependencies'
-- script: |
-    go vet ./autorest/...
-    go vet ./logger/...
-    go vet ./tracing/...
-  workingDirectory: '$(sdkPath)'
-  displayName: 'Vet'
-- script: |
-    go build -v ./autorest/...
-    go build -v ./logger/...
-    go build -v ./tracing/...
-  workingDirectory: '$(sdkPath)'
-  displayName: 'Build'
-- script: |
-    set -e
-    go test -race -v -coverprofile=coverage.txt -covermode atomic ./autorest/... ./logger/... ./tracing/... 2>&1 | go-junit-report > report.xml
-    gocov convert coverage.txt > coverage.json
-    gocov-xml < coverage.json > coverage.xml
-    gocov-html < coverage.json > coverage.html
-  workingDirectory: '$(sdkPath)'
-  displayName: 'Run Tests'
-- script: grep -L -r --include *.go --exclude-dir vendor -P "Copyright (\d{4}|\(c\)) Microsoft" ./ | tee >&2
-  workingDirectory: '$(sdkPath)'
-  displayName: 'Copyright Header Check'
-  failOnStderr: true
-  condition: succeededOrFailed()
-- script: |
-    gofmt -s -l -w ./autorest/. >&2
-    gofmt -s -l -w ./logger/. >&2
-    gofmt -s -l -w ./tracing/. >&2
-  workingDirectory: '$(sdkPath)'
-  displayName: 'Format Check'
-  failOnStderr: true
-  condition: succeededOrFailed()
-- script: |
-    golint ./autorest/... >&2
-    golint ./logger/... >&2
-    golint ./tracing/... >&2
-  workingDirectory: '$(sdkPath)'
-  displayName: 'Linter Check'
-  failOnStderr: true
-  condition: succeededOrFailed()
+jobs:
+  - job: 'goautorest'
+    displayName: 'Run go-autorest CI Checks'
 
-- task: PublishTestResults@2
-  inputs:
-    testRunner: JUnit
-    testResultsFiles: $(sdkPath)/report.xml
-    failTaskOnFailedTests: true
+    strategy:
+      matrix:
+        Linux_Go113:
+          vm.image: 'ubuntu-18.04'
+          go.version: '1.13'
+          GOROOT: '/usr/local/go$(go.version)'
+        Linux_Go114:
+          vm.image: 'ubuntu-18.04'
+          go.version: '1.14'
+          GOROOT: '/usr/local/go$(go.version)'
 
-- task: PublishCodeCoverageResults@1
-  inputs:
-    codeCoverageTool: Cobertura 
-    summaryFileLocation: $(sdkPath)/coverage.xml
-    additionalCodeCoverageFiles: $(sdkPath)/coverage.html
+    pool:
+      vmImage: '$(vm.image)'
+
+    steps:
+      - script: |
+          set -e
+          mkdir -p '$(GOPATH)/bin'
+          mkdir -p '$(sdkPath)'
+          shopt -s extglob
+          mv !(work) '$(sdkPath)'
+          echo '##vso[task.prependpath]$(GOROOT)/bin'
+          echo '##vso[task.prependpath]$(GOPATH)/bin'
+        displayName: 'Create Go Workspace'
+
+      - script: |
+          set -e
+          curl -sSL https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+          dep ensure -v
+          go install ./vendor/golang.org/x/lint/golint
+          go get github.com/jstemmer/go-junit-report
+          go get github.com/axw/gocov/gocov
+          go get github.com/AlekSi/gocov-xml
+          go get -u github.com/matm/gocov-html
+        workingDirectory: '$(sdkPath)'
+        displayName: 'Install Dependencies'
+
+      - script: |
+          go vet ./autorest/...
+          go vet ./logger/...
+          go vet ./tracing/...
+        workingDirectory: '$(sdkPath)'
+        displayName: 'Vet'
+
+      - script: |
+          go build -v ./autorest/...
+          go build -v ./logger/...
+          go build -v ./tracing/...
+        workingDirectory: '$(sdkPath)'
+        displayName: 'Build'
+
+      - script: |
+          set -e
+          go test -race -v -coverprofile=coverage.txt -covermode atomic ./autorest/... ./logger/... ./tracing/... 2>&1 | go-junit-report > report.xml
+          gocov convert coverage.txt > coverage.json
+          gocov-xml < coverage.json > coverage.xml
+          gocov-html < coverage.json > coverage.html
+        workingDirectory: '$(sdkPath)'
+        displayName: 'Run Tests'
+
+      - script: grep -L -r --include *.go --exclude-dir vendor -P "Copyright (\d{4}|\(c\)) Microsoft" ./ | tee >&2
+        workingDirectory: '$(sdkPath)'
+        displayName: 'Copyright Header Check'
+        failOnStderr: true
+        condition: succeededOrFailed()
+
+      - script: |
+          gofmt -s -l -w ./autorest/. >&2
+          gofmt -s -l -w ./logger/. >&2
+          gofmt -s -l -w ./tracing/. >&2
+        workingDirectory: '$(sdkPath)'
+        displayName: 'Format Check'
+        failOnStderr: true
+        condition: succeededOrFailed()
+
+      - script: |
+          golint ./autorest/... >&2
+          golint ./logger/... >&2
+          golint ./tracing/... >&2
+        workingDirectory: '$(sdkPath)'
+        displayName: 'Linter Check'
+        failOnStderr: true
+        condition: succeededOrFailed()
+
+      - task: PublishTestResults@2
+        inputs:
+          testRunner: JUnit
+          testResultsFiles: $(sdkPath)/report.xml
+          failTaskOnFailedTests: true
+
+      - task: PublishCodeCoverageResults@1
+        inputs:
+          codeCoverageTool: Cobertura 
+          summaryFileLocation: $(sdkPath)/coverage.xml
+          additionalCodeCoverageFiles: $(sdkPath)/coverage.html


### PR DESCRIPTION
This tiny PR 
- extracts creation of ServicePrincipalToken for MSI to a public method. The new method can then be in `denisenkom/go-mssqldb` driver when using Azure authentication, like in case of  `ClientCredentialsConfig` or `UsernamePasswordConfig`. 
- adds getter for token provider on `BearerAuthorizer` so the token can be used for authorization outside the REST.

---

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [X] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [X] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.