### PR TITLE
Expose OAuth token provider for use outside autorest

### DIFF
--- a/autorest/authorization.go
+++ b/autorest/authorization.go
@@ -138,6 +138,11 @@ func (ba *BearerAuthorizer) WithAuthorization() PrepareDecorator {
 	}
 }
 
+// TokenProvider returns OAuthTokenProvider so that it can be used for authorization outside the REST.
+func (ba *BearerAuthorizer) TokenProvider() adal.OAuthTokenProvider {
+	return ba.tokenProvider
+}
+
 // BearerAuthorizerCallbackFunc is the authentication callback signature.
 type BearerAuthorizerCallbackFunc func(tenantID, resource string) (*BearerAuthorizer, error)
 

--- a/autorest/azure/auth/auth.go
+++ b/autorest/azure/auth/auth.go
@@ -713,8 +713,8 @@ type MSIConfig struct {
 	ClientID string
 }
 
-// Authorizer gets the authorizer from MSI.
-func (mc MSIConfig) Authorizer() (autorest.Authorizer, error) {
+// ServicePrincipalToken creates a ServicePrincipalToken from MSI.
+func (mc MSIConfig) ServicePrincipalToken() (*adal.ServicePrincipalToken, error) {
 	msiEndpoint, err := adal.GetMSIEndpoint()
 	if err != nil {
 		return nil, err
@@ -731,6 +731,16 @@ func (mc MSIConfig) Authorizer() (autorest.Authorizer, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to get oauth token from MSI for user assigned identity: %v", err)
 		}
+	}
+
+	return spToken, nil
+}
+
+// Authorizer gets the authorizer from MSI.
+func (mc MSIConfig) Authorizer() (autorest.Authorizer, error) {
+	spToken, err := mc.ServicePrincipalToken()
+	if err != nil {
+		return nil, err
 	}
 
 	return autorest.NewBearerAuthorizer(spToken), nil


### PR DESCRIPTION
This PR

- extracts creation of ServicePrincipalToken for MSI to a public method. The new method can then be used with eg. `denisenkom/go-mssqldb` driver when using Azure authentication to SQL server, like in case of ClientCredentialsConfig or UsernamePasswordConfig.
- adds getter for token provider on BearerAuthorizer so the token can be used for authorization outside the REST in a generic way like, again, together with `denisenkom/go-mssqldb`.

---

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [X] I've tested my changes, adding unit tests if applicable.
 - [x] I've added Apache 2.0 Headers to the top of any new source files.
 - [X] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [x] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.