### PR TITLE
Fix `x-ms-authorization-auxiliary` header sperator to comma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## v14.1.1
 
 ### Bug Fixes
-- Fix `x-ms-authorization-auxiliary` header sperator to comma.
+
+- Change `x-ms-authorization-auxiliary` header value separator to comma.
 
 ## v14.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## v14.1.1
+
+### Bug Fixes
+- Fix `x-ms-authorization-auxiliary` header sperator to comma.
+
 ## v14.1.0
 
 ### New Features

--- a/autorest/authorization.go
+++ b/autorest/authorization.go
@@ -331,7 +331,7 @@ func (mt multiTenantSPTAuthorizer) WithAuthorization() PrepareDecorator {
 			for i := range auxTokens {
 				auxTokens[i] = fmt.Sprintf("Bearer %s", auxTokens[i])
 			}
-			return Prepare(r, WithHeader(headerAuxAuthorization, strings.Join(auxTokens, "; ")))
+			return Prepare(r, WithHeader(headerAuxAuthorization, strings.Join(auxTokens, ", ")))
 		})
 	}
 }

--- a/autorest/authorization_test.go
+++ b/autorest/authorization_test.go
@@ -299,7 +299,7 @@ func TestMultitenantAuthorizationThree(t *testing.T) {
 	if primary := req.Header.Get(headerAuthorization); primary != "Bearer primary" {
 		t.Fatalf("bad primary authorization header %s", primary)
 	}
-	if aux := req.Header.Get(headerAuxAuthorization); aux != "Bearer aux1; Bearer aux2; Bearer aux3" {
+	if aux := req.Header.Get(headerAuxAuthorization); aux != "Bearer aux1, Bearer aux2, Bearer aux3" {
 		t.Fatalf("bad auxiliary authorization header %s", aux)
 	}
 }
@@ -376,7 +376,7 @@ func TestMultiTenantServicePrincipalTokenWithAuthorizationRefresh(t *testing.T) 
 		auxTokens[i] = fmt.Sprintf("Bearer %s", auxTokens[i])
 	}
 	auxHeader := req.Header.Get(http.CanonicalHeaderKey(headerAuxAuthorization))
-	if auxHeader != strings.Join(auxTokens, "; ") {
+	if auxHeader != strings.Join(auxTokens, ", ") {
 		t.Fatal("azure: multiTenantSPTAuthorizer#WithAuthorization failed to set Authorization header for auxiliary tokens")
 	}
 	for i := range auxTokens {

--- a/autorest/version.go
+++ b/autorest/version.go
@@ -19,7 +19,7 @@ import (
 	"runtime"
 )
 
-const number = "v14.1.0"
+const number = "v14.1.1"
 
 var (
 	userAgent = fmt.Sprintf("Go/%s (%s-%s) go-autorest/%s",

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,23 +11,25 @@ jobs:
         Linux_Go113:
           vm.image: 'ubuntu-18.04'
           go.version: '1.13'
-          GOROOT: '/usr/local/go$(go.version)'
         Linux_Go114:
           vm.image: 'ubuntu-18.04'
           go.version: '1.14'
-          GOROOT: '/usr/local/go$(go.version)'
 
     pool:
       vmImage: '$(vm.image)'
 
     steps:
+      - task: GoTool@0
+        inputs:
+          version: '$(go.version)'
+        displayName: "Select Go Version"
+
       - script: |
           set -e
           mkdir -p '$(GOPATH)/bin'
           mkdir -p '$(sdkPath)'
           shopt -s extglob
           mv !(work) '$(sdkPath)'
-          echo '##vso[task.prependpath]$(GOROOT)/bin'
           echo '##vso[task.prependpath]$(GOPATH)/bin'
         displayName: 'Create Go Workspace'
 


### PR DESCRIPTION
When authenticating across tenants, ARM is using `,` as delimiter of aux tokens as the [docs](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/authenticate-multi-tenant#header-values-for-authentication) said.
Currently go-sdk uses `;` as delimiter, all requestes send to ARM for more than 2 tenants, will get 401 response.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [X] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.