### PR TITLE
Initial sleep on Retry-After

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v14.2.1
+
+- In `Future.WaitForCompletionRef()`, if the initial async response includes a `Retry-After` header, sleep for the specified amount of time before starting to poll.
+
 ## v14.2.0
 
 - Added package comment to make `github.com/Azure/go-autorest` importable.

--- a/autorest/azure/async.go
+++ b/autorest/azure/async.go
@@ -167,7 +167,13 @@ func (f *Future) WaitForCompletionRef(ctx context.Context, client autorest.Clien
 		cancelCtx, cancel = context.WithTimeout(ctx, d)
 		defer cancel()
 	}
-
+	// if the initial response has a Retry-After, sleep for the specified amount of time before starting to poll
+	if delay, ok := f.GetPollingDelay(); ok {
+		if delayElapsed := autorest.DelayForBackoff(delay, 0, cancelCtx.Done()); !delayElapsed {
+			err = cancelCtx.Err()
+			return
+		}
+	}
 	done, err := f.DoneWithContext(ctx, client)
 	for attempts := 0; !done; done, err = f.DoneWithContext(ctx, client) {
 		if attempts >= client.RetryAttempts {

--- a/autorest/version.go
+++ b/autorest/version.go
@@ -19,7 +19,7 @@ import (
 	"runtime"
 )
 
-const number = "v14.2.0"
+const number = "v14.2.1"
 
 var (
 	userAgent = fmt.Sprintf("Go/%s (%s-%s) go-autorest/%s",


### PR DESCRIPTION
If the initial response to an LRO contains a Retry-After header, sleep
for the specified duration before beginning to poll.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.