### PR TITLE
Add `ApiManagementHostManagementSuffix` in environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v14.2.1
 
 - In `Future.WaitForCompletionRef()`, if the initial async response includes a `Retry-After` header, sleep for the specified amount of time before starting to poll.
+- Added `APIManagementHostManagementSuffix` field in Azure environment map.
 
 ## v14.2.0
 
@@ -1006,4 +1007,3 @@ and `azure.DoPollForAsynchronous` for examples.
 ## v1.1.1
 
 - Introduce godeps and vendor dependencies introduced in v1.1.1
-- Added `APIManagementHostManagementSuffix` field in environment 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1002,3 +1002,4 @@ and `azure.DoPollForAsynchronous` for examples.
 ## v1.1.1
 
 - Introduce godeps and vendor dependencies introduced in v1.1.1
+- Added `APIManagementHostManagementSuffix` field in environment 

--- a/autorest/azure/environments.go
+++ b/autorest/azure/environments.go
@@ -71,7 +71,7 @@ type Environment struct {
 	ContainerRegistryDNSSuffix        string             `json:"containerRegistryDNSSuffix"`
 	CosmosDBDNSSuffix                 string             `json:"cosmosDBDNSSuffix"`
 	TokenAudience                     string             `json:"tokenAudience"`
-	ApiManagementHostManagementSuffix string             `json:"apiManagementHostManagementSuffix"`
+	APIManagementHostManagementSuffix string             `json:"apiManagementHostManagementSuffix"`
 	ResourceIdentifiers               ResourceIdentifier `json:"resourceIdentifiers"`
 }
 
@@ -99,7 +99,7 @@ var (
 		ContainerRegistryDNSSuffix:        "azurecr.io",
 		CosmosDBDNSSuffix:                 "documents.azure.com",
 		TokenAudience:                     "https://management.azure.com/",
-		ApiManagementHostManagementSuffix: "azure-api.net",
+		APIManagementHostManagementSuffix: "azure-api.net",
 		ResourceIdentifiers: ResourceIdentifier{
 			Graph:               "https://graph.windows.net/",
 			KeyVault:            "https://vault.azure.net",
@@ -133,7 +133,7 @@ var (
 		ContainerRegistryDNSSuffix:        "azurecr.us",
 		CosmosDBDNSSuffix:                 "documents.azure.us",
 		TokenAudience:                     "https://management.usgovcloudapi.net/",
-		ApiManagementHostManagementSuffix: "azure-api.us",
+		APIManagementHostManagementSuffix: "azure-api.us",
 		ResourceIdentifiers: ResourceIdentifier{
 			Graph:               "https://graph.windows.net/",
 			KeyVault:            "https://vault.usgovcloudapi.net",
@@ -167,7 +167,7 @@ var (
 		ContainerRegistryDNSSuffix:        "azurecr.cn",
 		CosmosDBDNSSuffix:                 "documents.azure.cn",
 		TokenAudience:                     "https://management.chinacloudapi.cn/",
-		ApiManagementHostManagementSuffix: "azure-api.cn",
+		APIManagementHostManagementSuffix: "azure-api.cn",
 		ResourceIdentifiers: ResourceIdentifier{
 			Graph:               "https://graph.chinacloudapi.cn/",
 			KeyVault:            "https://vault.azure.cn",
@@ -201,7 +201,7 @@ var (
 		ContainerRegistryDNSSuffix:        NotAvailable,
 		CosmosDBDNSSuffix:                 "documents.microsoftazure.de",
 		TokenAudience:                     "https://management.microsoftazure.de/",
-		ApiManagementHostManagementSuffix: NotAvailable,
+		APIManagementHostManagementSuffix: NotAvailable,
 		ResourceIdentifiers: ResourceIdentifier{
 			Graph:               "https://graph.cloudapi.de/",
 			KeyVault:            "https://vault.microsoftazure.de",

--- a/autorest/azure/environments.go
+++ b/autorest/azure/environments.go
@@ -50,56 +50,56 @@ type ResourceIdentifier struct {
 
 // Environment represents a set of endpoints for each of Azure's Clouds.
 type Environment struct {
-	Name                              string             `json:"name"`
-	ManagementPortalURL               string             `json:"managementPortalURL"`
-	PublishSettingsURL                string             `json:"publishSettingsURL"`
-	ServiceManagementEndpoint         string             `json:"serviceManagementEndpoint"`
-	ResourceManagerEndpoint           string             `json:"resourceManagerEndpoint"`
-	ActiveDirectoryEndpoint           string             `json:"activeDirectoryEndpoint"`
-	GalleryEndpoint                   string             `json:"galleryEndpoint"`
-	KeyVaultEndpoint                  string             `json:"keyVaultEndpoint"`
-	GraphEndpoint                     string             `json:"graphEndpoint"`
-	ServiceBusEndpoint                string             `json:"serviceBusEndpoint"`
-	BatchManagementEndpoint           string             `json:"batchManagementEndpoint"`
-	StorageEndpointSuffix             string             `json:"storageEndpointSuffix"`
-	SQLDatabaseDNSSuffix              string             `json:"sqlDatabaseDNSSuffix"`
-	TrafficManagerDNSSuffix           string             `json:"trafficManagerDNSSuffix"`
-	KeyVaultDNSSuffix                 string             `json:"keyVaultDNSSuffix"`
-	ServiceBusEndpointSuffix          string             `json:"serviceBusEndpointSuffix"`
-	ServiceManagementVMDNSSuffix      string             `json:"serviceManagementVMDNSSuffix"`
-	ResourceManagerVMDNSSuffix        string             `json:"resourceManagerVMDNSSuffix"`
-	ContainerRegistryDNSSuffix        string             `json:"containerRegistryDNSSuffix"`
-	CosmosDBDNSSuffix                 string             `json:"cosmosDBDNSSuffix"`
-	TokenAudience                     string             `json:"tokenAudience"`
-	APIManagementHostManagementSuffix string             `json:"apiManagementHostManagementSuffix"`
-	ResourceIdentifiers               ResourceIdentifier `json:"resourceIdentifiers"`
+	Name                         string             `json:"name"`
+	ManagementPortalURL          string             `json:"managementPortalURL"`
+	PublishSettingsURL           string             `json:"publishSettingsURL"`
+	ServiceManagementEndpoint    string             `json:"serviceManagementEndpoint"`
+	ResourceManagerEndpoint      string             `json:"resourceManagerEndpoint"`
+	ActiveDirectoryEndpoint      string             `json:"activeDirectoryEndpoint"`
+	GalleryEndpoint              string             `json:"galleryEndpoint"`
+	KeyVaultEndpoint             string             `json:"keyVaultEndpoint"`
+	GraphEndpoint                string             `json:"graphEndpoint"`
+	ServiceBusEndpoint           string             `json:"serviceBusEndpoint"`
+	BatchManagementEndpoint      string             `json:"batchManagementEndpoint"`
+	StorageEndpointSuffix        string             `json:"storageEndpointSuffix"`
+	SQLDatabaseDNSSuffix         string             `json:"sqlDatabaseDNSSuffix"`
+	TrafficManagerDNSSuffix      string             `json:"trafficManagerDNSSuffix"`
+	KeyVaultDNSSuffix            string             `json:"keyVaultDNSSuffix"`
+	ServiceBusEndpointSuffix     string             `json:"serviceBusEndpointSuffix"`
+	ServiceManagementVMDNSSuffix string             `json:"serviceManagementVMDNSSuffix"`
+	ResourceManagerVMDNSSuffix   string             `json:"resourceManagerVMDNSSuffix"`
+	ContainerRegistryDNSSuffix   string             `json:"containerRegistryDNSSuffix"`
+	CosmosDBDNSSuffix            string             `json:"cosmosDBDNSSuffix"`
+	TokenAudience                string             `json:"tokenAudience"`
+	APIManagementHostNameSuffix  string             `json:"apiManagementHostNameSuffix"`
+	ResourceIdentifiers          ResourceIdentifier `json:"resourceIdentifiers"`
 }
 
 var (
 	// PublicCloud is the default public Azure cloud environment
 	PublicCloud = Environment{
-		Name:                              "AzurePublicCloud",
-		ManagementPortalURL:               "https://manage.windowsazure.com/",
-		PublishSettingsURL:                "https://manage.windowsazure.com/publishsettings/index",
-		ServiceManagementEndpoint:         "https://management.core.windows.net/",
-		ResourceManagerEndpoint:           "https://management.azure.com/",
-		ActiveDirectoryEndpoint:           "https://login.microsoftonline.com/",
-		GalleryEndpoint:                   "https://gallery.azure.com/",
-		KeyVaultEndpoint:                  "https://vault.azure.net/",
-		GraphEndpoint:                     "https://graph.windows.net/",
-		ServiceBusEndpoint:                "https://servicebus.windows.net/",
-		BatchManagementEndpoint:           "https://batch.core.windows.net/",
-		StorageEndpointSuffix:             "core.windows.net",
-		SQLDatabaseDNSSuffix:              "database.windows.net",
-		TrafficManagerDNSSuffix:           "trafficmanager.net",
-		KeyVaultDNSSuffix:                 "vault.azure.net",
-		ServiceBusEndpointSuffix:          "servicebus.windows.net",
-		ServiceManagementVMDNSSuffix:      "cloudapp.net",
-		ResourceManagerVMDNSSuffix:        "cloudapp.azure.com",
-		ContainerRegistryDNSSuffix:        "azurecr.io",
-		CosmosDBDNSSuffix:                 "documents.azure.com",
-		TokenAudience:                     "https://management.azure.com/",
-		APIManagementHostManagementSuffix: "azure-api.net",
+		Name:                         "AzurePublicCloud",
+		ManagementPortalURL:          "https://manage.windowsazure.com/",
+		PublishSettingsURL:           "https://manage.windowsazure.com/publishsettings/index",
+		ServiceManagementEndpoint:    "https://management.core.windows.net/",
+		ResourceManagerEndpoint:      "https://management.azure.com/",
+		ActiveDirectoryEndpoint:      "https://login.microsoftonline.com/",
+		GalleryEndpoint:              "https://gallery.azure.com/",
+		KeyVaultEndpoint:             "https://vault.azure.net/",
+		GraphEndpoint:                "https://graph.windows.net/",
+		ServiceBusEndpoint:           "https://servicebus.windows.net/",
+		BatchManagementEndpoint:      "https://batch.core.windows.net/",
+		StorageEndpointSuffix:        "core.windows.net",
+		SQLDatabaseDNSSuffix:         "database.windows.net",
+		TrafficManagerDNSSuffix:      "trafficmanager.net",
+		KeyVaultDNSSuffix:            "vault.azure.net",
+		ServiceBusEndpointSuffix:     "servicebus.windows.net",
+		ServiceManagementVMDNSSuffix: "cloudapp.net",
+		ResourceManagerVMDNSSuffix:   "cloudapp.azure.com",
+		ContainerRegistryDNSSuffix:   "azurecr.io",
+		CosmosDBDNSSuffix:            "documents.azure.com",
+		TokenAudience:                "https://management.azure.com/",
+		APIManagementHostNameSuffix:  "azure-api.net",
 		ResourceIdentifiers: ResourceIdentifier{
 			Graph:               "https://graph.windows.net/",
 			KeyVault:            "https://vault.azure.net",
@@ -112,28 +112,28 @@ var (
 
 	// USGovernmentCloud is the cloud environment for the US Government
 	USGovernmentCloud = Environment{
-		Name:                              "AzureUSGovernmentCloud",
-		ManagementPortalURL:               "https://manage.windowsazure.us/",
-		PublishSettingsURL:                "https://manage.windowsazure.us/publishsettings/index",
-		ServiceManagementEndpoint:         "https://management.core.usgovcloudapi.net/",
-		ResourceManagerEndpoint:           "https://management.usgovcloudapi.net/",
-		ActiveDirectoryEndpoint:           "https://login.microsoftonline.us/",
-		GalleryEndpoint:                   "https://gallery.usgovcloudapi.net/",
-		KeyVaultEndpoint:                  "https://vault.usgovcloudapi.net/",
-		GraphEndpoint:                     "https://graph.windows.net/",
-		ServiceBusEndpoint:                "https://servicebus.usgovcloudapi.net/",
-		BatchManagementEndpoint:           "https://batch.core.usgovcloudapi.net/",
-		StorageEndpointSuffix:             "core.usgovcloudapi.net",
-		SQLDatabaseDNSSuffix:              "database.usgovcloudapi.net",
-		TrafficManagerDNSSuffix:           "usgovtrafficmanager.net",
-		KeyVaultDNSSuffix:                 "vault.usgovcloudapi.net",
-		ServiceBusEndpointSuffix:          "servicebus.usgovcloudapi.net",
-		ServiceManagementVMDNSSuffix:      "usgovcloudapp.net",
-		ResourceManagerVMDNSSuffix:        "cloudapp.usgovcloudapi.net",
-		ContainerRegistryDNSSuffix:        "azurecr.us",
-		CosmosDBDNSSuffix:                 "documents.azure.us",
-		TokenAudience:                     "https://management.usgovcloudapi.net/",
-		APIManagementHostManagementSuffix: "azure-api.us",
+		Name:                         "AzureUSGovernmentCloud",
+		ManagementPortalURL:          "https://manage.windowsazure.us/",
+		PublishSettingsURL:           "https://manage.windowsazure.us/publishsettings/index",
+		ServiceManagementEndpoint:    "https://management.core.usgovcloudapi.net/",
+		ResourceManagerEndpoint:      "https://management.usgovcloudapi.net/",
+		ActiveDirectoryEndpoint:      "https://login.microsoftonline.us/",
+		GalleryEndpoint:              "https://gallery.usgovcloudapi.net/",
+		KeyVaultEndpoint:             "https://vault.usgovcloudapi.net/",
+		GraphEndpoint:                "https://graph.windows.net/",
+		ServiceBusEndpoint:           "https://servicebus.usgovcloudapi.net/",
+		BatchManagementEndpoint:      "https://batch.core.usgovcloudapi.net/",
+		StorageEndpointSuffix:        "core.usgovcloudapi.net",
+		SQLDatabaseDNSSuffix:         "database.usgovcloudapi.net",
+		TrafficManagerDNSSuffix:      "usgovtrafficmanager.net",
+		KeyVaultDNSSuffix:            "vault.usgovcloudapi.net",
+		ServiceBusEndpointSuffix:     "servicebus.usgovcloudapi.net",
+		ServiceManagementVMDNSSuffix: "usgovcloudapp.net",
+		ResourceManagerVMDNSSuffix:   "cloudapp.usgovcloudapi.net",
+		ContainerRegistryDNSSuffix:   "azurecr.us",
+		CosmosDBDNSSuffix:            "documents.azure.us",
+		TokenAudience:                "https://management.usgovcloudapi.net/",
+		APIManagementHostNameSuffix:  "azure-api.us",
 		ResourceIdentifiers: ResourceIdentifier{
 			Graph:               "https://graph.windows.net/",
 			KeyVault:            "https://vault.usgovcloudapi.net",
@@ -146,28 +146,28 @@ var (
 
 	// ChinaCloud is the cloud environment operated in China
 	ChinaCloud = Environment{
-		Name:                              "AzureChinaCloud",
-		ManagementPortalURL:               "https://manage.chinacloudapi.com/",
-		PublishSettingsURL:                "https://manage.chinacloudapi.com/publishsettings/index",
-		ServiceManagementEndpoint:         "https://management.core.chinacloudapi.cn/",
-		ResourceManagerEndpoint:           "https://management.chinacloudapi.cn/",
-		ActiveDirectoryEndpoint:           "https://login.chinacloudapi.cn/",
-		GalleryEndpoint:                   "https://gallery.chinacloudapi.cn/",
-		KeyVaultEndpoint:                  "https://vault.azure.cn/",
-		GraphEndpoint:                     "https://graph.chinacloudapi.cn/",
-		ServiceBusEndpoint:                "https://servicebus.chinacloudapi.cn/",
-		BatchManagementEndpoint:           "https://batch.chinacloudapi.cn/",
-		StorageEndpointSuffix:             "core.chinacloudapi.cn",
-		SQLDatabaseDNSSuffix:              "database.chinacloudapi.cn",
-		TrafficManagerDNSSuffix:           "trafficmanager.cn",
-		KeyVaultDNSSuffix:                 "vault.azure.cn",
-		ServiceBusEndpointSuffix:          "servicebus.chinacloudapi.cn",
-		ServiceManagementVMDNSSuffix:      "chinacloudapp.cn",
-		ResourceManagerVMDNSSuffix:        "cloudapp.chinacloudapi.cn",
-		ContainerRegistryDNSSuffix:        "azurecr.cn",
-		CosmosDBDNSSuffix:                 "documents.azure.cn",
-		TokenAudience:                     "https://management.chinacloudapi.cn/",
-		APIManagementHostManagementSuffix: "azure-api.cn",
+		Name:                         "AzureChinaCloud",
+		ManagementPortalURL:          "https://manage.chinacloudapi.com/",
+		PublishSettingsURL:           "https://manage.chinacloudapi.com/publishsettings/index",
+		ServiceManagementEndpoint:    "https://management.core.chinacloudapi.cn/",
+		ResourceManagerEndpoint:      "https://management.chinacloudapi.cn/",
+		ActiveDirectoryEndpoint:      "https://login.chinacloudapi.cn/",
+		GalleryEndpoint:              "https://gallery.chinacloudapi.cn/",
+		KeyVaultEndpoint:             "https://vault.azure.cn/",
+		GraphEndpoint:                "https://graph.chinacloudapi.cn/",
+		ServiceBusEndpoint:           "https://servicebus.chinacloudapi.cn/",
+		BatchManagementEndpoint:      "https://batch.chinacloudapi.cn/",
+		StorageEndpointSuffix:        "core.chinacloudapi.cn",
+		SQLDatabaseDNSSuffix:         "database.chinacloudapi.cn",
+		TrafficManagerDNSSuffix:      "trafficmanager.cn",
+		KeyVaultDNSSuffix:            "vault.azure.cn",
+		ServiceBusEndpointSuffix:     "servicebus.chinacloudapi.cn",
+		ServiceManagementVMDNSSuffix: "chinacloudapp.cn",
+		ResourceManagerVMDNSSuffix:   "cloudapp.chinacloudapi.cn",
+		ContainerRegistryDNSSuffix:   "azurecr.cn",
+		CosmosDBDNSSuffix:            "documents.azure.cn",
+		TokenAudience:                "https://management.chinacloudapi.cn/",
+		APIManagementHostNameSuffix:  "azure-api.cn",
 		ResourceIdentifiers: ResourceIdentifier{
 			Graph:               "https://graph.chinacloudapi.cn/",
 			KeyVault:            "https://vault.azure.cn",
@@ -180,28 +180,28 @@ var (
 
 	// GermanCloud is the cloud environment operated in Germany
 	GermanCloud = Environment{
-		Name:                              "AzureGermanCloud",
-		ManagementPortalURL:               "http://portal.microsoftazure.de/",
-		PublishSettingsURL:                "https://manage.microsoftazure.de/publishsettings/index",
-		ServiceManagementEndpoint:         "https://management.core.cloudapi.de/",
-		ResourceManagerEndpoint:           "https://management.microsoftazure.de/",
-		ActiveDirectoryEndpoint:           "https://login.microsoftonline.de/",
-		GalleryEndpoint:                   "https://gallery.cloudapi.de/",
-		KeyVaultEndpoint:                  "https://vault.microsoftazure.de/",
-		GraphEndpoint:                     "https://graph.cloudapi.de/",
-		ServiceBusEndpoint:                "https://servicebus.cloudapi.de/",
-		BatchManagementEndpoint:           "https://batch.cloudapi.de/",
-		StorageEndpointSuffix:             "core.cloudapi.de",
-		SQLDatabaseDNSSuffix:              "database.cloudapi.de",
-		TrafficManagerDNSSuffix:           "azuretrafficmanager.de",
-		KeyVaultDNSSuffix:                 "vault.microsoftazure.de",
-		ServiceBusEndpointSuffix:          "servicebus.cloudapi.de",
-		ServiceManagementVMDNSSuffix:      "azurecloudapp.de",
-		ResourceManagerVMDNSSuffix:        "cloudapp.microsoftazure.de",
-		ContainerRegistryDNSSuffix:        NotAvailable,
-		CosmosDBDNSSuffix:                 "documents.microsoftazure.de",
-		TokenAudience:                     "https://management.microsoftazure.de/",
-		APIManagementHostManagementSuffix: NotAvailable,
+		Name:                         "AzureGermanCloud",
+		ManagementPortalURL:          "http://portal.microsoftazure.de/",
+		PublishSettingsURL:           "https://manage.microsoftazure.de/publishsettings/index",
+		ServiceManagementEndpoint:    "https://management.core.cloudapi.de/",
+		ResourceManagerEndpoint:      "https://management.microsoftazure.de/",
+		ActiveDirectoryEndpoint:      "https://login.microsoftonline.de/",
+		GalleryEndpoint:              "https://gallery.cloudapi.de/",
+		KeyVaultEndpoint:             "https://vault.microsoftazure.de/",
+		GraphEndpoint:                "https://graph.cloudapi.de/",
+		ServiceBusEndpoint:           "https://servicebus.cloudapi.de/",
+		BatchManagementEndpoint:      "https://batch.cloudapi.de/",
+		StorageEndpointSuffix:        "core.cloudapi.de",
+		SQLDatabaseDNSSuffix:         "database.cloudapi.de",
+		TrafficManagerDNSSuffix:      "azuretrafficmanager.de",
+		KeyVaultDNSSuffix:            "vault.microsoftazure.de",
+		ServiceBusEndpointSuffix:     "servicebus.cloudapi.de",
+		ServiceManagementVMDNSSuffix: "azurecloudapp.de",
+		ResourceManagerVMDNSSuffix:   "cloudapp.microsoftazure.de",
+		ContainerRegistryDNSSuffix:   NotAvailable,
+		CosmosDBDNSSuffix:            "documents.microsoftazure.de",
+		TokenAudience:                "https://management.microsoftazure.de/",
+		APIManagementHostNameSuffix:  NotAvailable,
 		ResourceIdentifiers: ResourceIdentifier{
 			Graph:               "https://graph.cloudapi.de/",
 			KeyVault:            "https://vault.microsoftazure.de",

--- a/autorest/azure/environments.go
+++ b/autorest/azure/environments.go
@@ -50,54 +50,56 @@ type ResourceIdentifier struct {
 
 // Environment represents a set of endpoints for each of Azure's Clouds.
 type Environment struct {
-	Name                         string             `json:"name"`
-	ManagementPortalURL          string             `json:"managementPortalURL"`
-	PublishSettingsURL           string             `json:"publishSettingsURL"`
-	ServiceManagementEndpoint    string             `json:"serviceManagementEndpoint"`
-	ResourceManagerEndpoint      string             `json:"resourceManagerEndpoint"`
-	ActiveDirectoryEndpoint      string             `json:"activeDirectoryEndpoint"`
-	GalleryEndpoint              string             `json:"galleryEndpoint"`
-	KeyVaultEndpoint             string             `json:"keyVaultEndpoint"`
-	GraphEndpoint                string             `json:"graphEndpoint"`
-	ServiceBusEndpoint           string             `json:"serviceBusEndpoint"`
-	BatchManagementEndpoint      string             `json:"batchManagementEndpoint"`
-	StorageEndpointSuffix        string             `json:"storageEndpointSuffix"`
-	SQLDatabaseDNSSuffix         string             `json:"sqlDatabaseDNSSuffix"`
-	TrafficManagerDNSSuffix      string             `json:"trafficManagerDNSSuffix"`
-	KeyVaultDNSSuffix            string             `json:"keyVaultDNSSuffix"`
-	ServiceBusEndpointSuffix     string             `json:"serviceBusEndpointSuffix"`
-	ServiceManagementVMDNSSuffix string             `json:"serviceManagementVMDNSSuffix"`
-	ResourceManagerVMDNSSuffix   string             `json:"resourceManagerVMDNSSuffix"`
-	ContainerRegistryDNSSuffix   string             `json:"containerRegistryDNSSuffix"`
-	CosmosDBDNSSuffix            string             `json:"cosmosDBDNSSuffix"`
-	TokenAudience                string             `json:"tokenAudience"`
-	ResourceIdentifiers          ResourceIdentifier `json:"resourceIdentifiers"`
+	Name                              string             `json:"name"`
+	ManagementPortalURL               string             `json:"managementPortalURL"`
+	PublishSettingsURL                string             `json:"publishSettingsURL"`
+	ServiceManagementEndpoint         string             `json:"serviceManagementEndpoint"`
+	ResourceManagerEndpoint           string             `json:"resourceManagerEndpoint"`
+	ActiveDirectoryEndpoint           string             `json:"activeDirectoryEndpoint"`
+	GalleryEndpoint                   string             `json:"galleryEndpoint"`
+	KeyVaultEndpoint                  string             `json:"keyVaultEndpoint"`
+	GraphEndpoint                     string             `json:"graphEndpoint"`
+	ServiceBusEndpoint                string             `json:"serviceBusEndpoint"`
+	BatchManagementEndpoint           string             `json:"batchManagementEndpoint"`
+	StorageEndpointSuffix             string             `json:"storageEndpointSuffix"`
+	SQLDatabaseDNSSuffix              string             `json:"sqlDatabaseDNSSuffix"`
+	TrafficManagerDNSSuffix           string             `json:"trafficManagerDNSSuffix"`
+	KeyVaultDNSSuffix                 string             `json:"keyVaultDNSSuffix"`
+	ServiceBusEndpointSuffix          string             `json:"serviceBusEndpointSuffix"`
+	ServiceManagementVMDNSSuffix      string             `json:"serviceManagementVMDNSSuffix"`
+	ResourceManagerVMDNSSuffix        string             `json:"resourceManagerVMDNSSuffix"`
+	ContainerRegistryDNSSuffix        string             `json:"containerRegistryDNSSuffix"`
+	CosmosDBDNSSuffix                 string             `json:"cosmosDBDNSSuffix"`
+	TokenAudience                     string             `json:"tokenAudience"`
+	ApiManagementHostManagementSuffix string             `json:"apiManagementHostManagementSuffix"`
+	ResourceIdentifiers               ResourceIdentifier `json:"resourceIdentifiers"`
 }
 
 var (
 	// PublicCloud is the default public Azure cloud environment
 	PublicCloud = Environment{
-		Name:                         "AzurePublicCloud",
-		ManagementPortalURL:          "https://manage.windowsazure.com/",
-		PublishSettingsURL:           "https://manage.windowsazure.com/publishsettings/index",
-		ServiceManagementEndpoint:    "https://management.core.windows.net/",
-		ResourceManagerEndpoint:      "https://management.azure.com/",
-		ActiveDirectoryEndpoint:      "https://login.microsoftonline.com/",
-		GalleryEndpoint:              "https://gallery.azure.com/",
-		KeyVaultEndpoint:             "https://vault.azure.net/",
-		GraphEndpoint:                "https://graph.windows.net/",
-		ServiceBusEndpoint:           "https://servicebus.windows.net/",
-		BatchManagementEndpoint:      "https://batch.core.windows.net/",
-		StorageEndpointSuffix:        "core.windows.net",
-		SQLDatabaseDNSSuffix:         "database.windows.net",
-		TrafficManagerDNSSuffix:      "trafficmanager.net",
-		KeyVaultDNSSuffix:            "vault.azure.net",
-		ServiceBusEndpointSuffix:     "servicebus.windows.net",
-		ServiceManagementVMDNSSuffix: "cloudapp.net",
-		ResourceManagerVMDNSSuffix:   "cloudapp.azure.com",
-		ContainerRegistryDNSSuffix:   "azurecr.io",
-		CosmosDBDNSSuffix:            "documents.azure.com",
-		TokenAudience:                "https://management.azure.com/",
+		Name:                              "AzurePublicCloud",
+		ManagementPortalURL:               "https://manage.windowsazure.com/",
+		PublishSettingsURL:                "https://manage.windowsazure.com/publishsettings/index",
+		ServiceManagementEndpoint:         "https://management.core.windows.net/",
+		ResourceManagerEndpoint:           "https://management.azure.com/",
+		ActiveDirectoryEndpoint:           "https://login.microsoftonline.com/",
+		GalleryEndpoint:                   "https://gallery.azure.com/",
+		KeyVaultEndpoint:                  "https://vault.azure.net/",
+		GraphEndpoint:                     "https://graph.windows.net/",
+		ServiceBusEndpoint:                "https://servicebus.windows.net/",
+		BatchManagementEndpoint:           "https://batch.core.windows.net/",
+		StorageEndpointSuffix:             "core.windows.net",
+		SQLDatabaseDNSSuffix:              "database.windows.net",
+		TrafficManagerDNSSuffix:           "trafficmanager.net",
+		KeyVaultDNSSuffix:                 "vault.azure.net",
+		ServiceBusEndpointSuffix:          "servicebus.windows.net",
+		ServiceManagementVMDNSSuffix:      "cloudapp.net",
+		ResourceManagerVMDNSSuffix:        "cloudapp.azure.com",
+		ContainerRegistryDNSSuffix:        "azurecr.io",
+		CosmosDBDNSSuffix:                 "documents.azure.com",
+		TokenAudience:                     "https://management.azure.com/",
+		ApiManagementHostManagementSuffix: "azure-api.net",
 		ResourceIdentifiers: ResourceIdentifier{
 			Graph:               "https://graph.windows.net/",
 			KeyVault:            "https://vault.azure.net",
@@ -110,27 +112,28 @@ var (
 
 	// USGovernmentCloud is the cloud environment for the US Government
 	USGovernmentCloud = Environment{
-		Name:                         "AzureUSGovernmentCloud",
-		ManagementPortalURL:          "https://manage.windowsazure.us/",
-		PublishSettingsURL:           "https://manage.windowsazure.us/publishsettings/index",
-		ServiceManagementEndpoint:    "https://management.core.usgovcloudapi.net/",
-		ResourceManagerEndpoint:      "https://management.usgovcloudapi.net/",
-		ActiveDirectoryEndpoint:      "https://login.microsoftonline.us/",
-		GalleryEndpoint:              "https://gallery.usgovcloudapi.net/",
-		KeyVaultEndpoint:             "https://vault.usgovcloudapi.net/",
-		GraphEndpoint:                "https://graph.windows.net/",
-		ServiceBusEndpoint:           "https://servicebus.usgovcloudapi.net/",
-		BatchManagementEndpoint:      "https://batch.core.usgovcloudapi.net/",
-		StorageEndpointSuffix:        "core.usgovcloudapi.net",
-		SQLDatabaseDNSSuffix:         "database.usgovcloudapi.net",
-		TrafficManagerDNSSuffix:      "usgovtrafficmanager.net",
-		KeyVaultDNSSuffix:            "vault.usgovcloudapi.net",
-		ServiceBusEndpointSuffix:     "servicebus.usgovcloudapi.net",
-		ServiceManagementVMDNSSuffix: "usgovcloudapp.net",
-		ResourceManagerVMDNSSuffix:   "cloudapp.usgovcloudapi.net",
-		ContainerRegistryDNSSuffix:   "azurecr.us",
-		CosmosDBDNSSuffix:            "documents.azure.us",
-		TokenAudience:                "https://management.usgovcloudapi.net/",
+		Name:                              "AzureUSGovernmentCloud",
+		ManagementPortalURL:               "https://manage.windowsazure.us/",
+		PublishSettingsURL:                "https://manage.windowsazure.us/publishsettings/index",
+		ServiceManagementEndpoint:         "https://management.core.usgovcloudapi.net/",
+		ResourceManagerEndpoint:           "https://management.usgovcloudapi.net/",
+		ActiveDirectoryEndpoint:           "https://login.microsoftonline.us/",
+		GalleryEndpoint:                   "https://gallery.usgovcloudapi.net/",
+		KeyVaultEndpoint:                  "https://vault.usgovcloudapi.net/",
+		GraphEndpoint:                     "https://graph.windows.net/",
+		ServiceBusEndpoint:                "https://servicebus.usgovcloudapi.net/",
+		BatchManagementEndpoint:           "https://batch.core.usgovcloudapi.net/",
+		StorageEndpointSuffix:             "core.usgovcloudapi.net",
+		SQLDatabaseDNSSuffix:              "database.usgovcloudapi.net",
+		TrafficManagerDNSSuffix:           "usgovtrafficmanager.net",
+		KeyVaultDNSSuffix:                 "vault.usgovcloudapi.net",
+		ServiceBusEndpointSuffix:          "servicebus.usgovcloudapi.net",
+		ServiceManagementVMDNSSuffix:      "usgovcloudapp.net",
+		ResourceManagerVMDNSSuffix:        "cloudapp.usgovcloudapi.net",
+		ContainerRegistryDNSSuffix:        "azurecr.us",
+		CosmosDBDNSSuffix:                 "documents.azure.us",
+		TokenAudience:                     "https://management.usgovcloudapi.net/",
+		ApiManagementHostManagementSuffix: "azure-api.us",
 		ResourceIdentifiers: ResourceIdentifier{
 			Graph:               "https://graph.windows.net/",
 			KeyVault:            "https://vault.usgovcloudapi.net",
@@ -143,27 +146,28 @@ var (
 
 	// ChinaCloud is the cloud environment operated in China
 	ChinaCloud = Environment{
-		Name:                         "AzureChinaCloud",
-		ManagementPortalURL:          "https://manage.chinacloudapi.com/",
-		PublishSettingsURL:           "https://manage.chinacloudapi.com/publishsettings/index",
-		ServiceManagementEndpoint:    "https://management.core.chinacloudapi.cn/",
-		ResourceManagerEndpoint:      "https://management.chinacloudapi.cn/",
-		ActiveDirectoryEndpoint:      "https://login.chinacloudapi.cn/",
-		GalleryEndpoint:              "https://gallery.chinacloudapi.cn/",
-		KeyVaultEndpoint:             "https://vault.azure.cn/",
-		GraphEndpoint:                "https://graph.chinacloudapi.cn/",
-		ServiceBusEndpoint:           "https://servicebus.chinacloudapi.cn/",
-		BatchManagementEndpoint:      "https://batch.chinacloudapi.cn/",
-		StorageEndpointSuffix:        "core.chinacloudapi.cn",
-		SQLDatabaseDNSSuffix:         "database.chinacloudapi.cn",
-		TrafficManagerDNSSuffix:      "trafficmanager.cn",
-		KeyVaultDNSSuffix:            "vault.azure.cn",
-		ServiceBusEndpointSuffix:     "servicebus.chinacloudapi.cn",
-		ServiceManagementVMDNSSuffix: "chinacloudapp.cn",
-		ResourceManagerVMDNSSuffix:   "cloudapp.chinacloudapi.cn",
-		ContainerRegistryDNSSuffix:   "azurecr.cn",
-		CosmosDBDNSSuffix:            "documents.azure.cn",
-		TokenAudience:                "https://management.chinacloudapi.cn/",
+		Name:                              "AzureChinaCloud",
+		ManagementPortalURL:               "https://manage.chinacloudapi.com/",
+		PublishSettingsURL:                "https://manage.chinacloudapi.com/publishsettings/index",
+		ServiceManagementEndpoint:         "https://management.core.chinacloudapi.cn/",
+		ResourceManagerEndpoint:           "https://management.chinacloudapi.cn/",
+		ActiveDirectoryEndpoint:           "https://login.chinacloudapi.cn/",
+		GalleryEndpoint:                   "https://gallery.chinacloudapi.cn/",
+		KeyVaultEndpoint:                  "https://vault.azure.cn/",
+		GraphEndpoint:                     "https://graph.chinacloudapi.cn/",
+		ServiceBusEndpoint:                "https://servicebus.chinacloudapi.cn/",
+		BatchManagementEndpoint:           "https://batch.chinacloudapi.cn/",
+		StorageEndpointSuffix:             "core.chinacloudapi.cn",
+		SQLDatabaseDNSSuffix:              "database.chinacloudapi.cn",
+		TrafficManagerDNSSuffix:           "trafficmanager.cn",
+		KeyVaultDNSSuffix:                 "vault.azure.cn",
+		ServiceBusEndpointSuffix:          "servicebus.chinacloudapi.cn",
+		ServiceManagementVMDNSSuffix:      "chinacloudapp.cn",
+		ResourceManagerVMDNSSuffix:        "cloudapp.chinacloudapi.cn",
+		ContainerRegistryDNSSuffix:        "azurecr.cn",
+		CosmosDBDNSSuffix:                 "documents.azure.cn",
+		TokenAudience:                     "https://management.chinacloudapi.cn/",
+		ApiManagementHostManagementSuffix: "azure-api.cn",
 		ResourceIdentifiers: ResourceIdentifier{
 			Graph:               "https://graph.chinacloudapi.cn/",
 			KeyVault:            "https://vault.azure.cn",
@@ -176,27 +180,28 @@ var (
 
 	// GermanCloud is the cloud environment operated in Germany
 	GermanCloud = Environment{
-		Name:                         "AzureGermanCloud",
-		ManagementPortalURL:          "http://portal.microsoftazure.de/",
-		PublishSettingsURL:           "https://manage.microsoftazure.de/publishsettings/index",
-		ServiceManagementEndpoint:    "https://management.core.cloudapi.de/",
-		ResourceManagerEndpoint:      "https://management.microsoftazure.de/",
-		ActiveDirectoryEndpoint:      "https://login.microsoftonline.de/",
-		GalleryEndpoint:              "https://gallery.cloudapi.de/",
-		KeyVaultEndpoint:             "https://vault.microsoftazure.de/",
-		GraphEndpoint:                "https://graph.cloudapi.de/",
-		ServiceBusEndpoint:           "https://servicebus.cloudapi.de/",
-		BatchManagementEndpoint:      "https://batch.cloudapi.de/",
-		StorageEndpointSuffix:        "core.cloudapi.de",
-		SQLDatabaseDNSSuffix:         "database.cloudapi.de",
-		TrafficManagerDNSSuffix:      "azuretrafficmanager.de",
-		KeyVaultDNSSuffix:            "vault.microsoftazure.de",
-		ServiceBusEndpointSuffix:     "servicebus.cloudapi.de",
-		ServiceManagementVMDNSSuffix: "azurecloudapp.de",
-		ResourceManagerVMDNSSuffix:   "cloudapp.microsoftazure.de",
-		ContainerRegistryDNSSuffix:   NotAvailable,
-		CosmosDBDNSSuffix:            "documents.microsoftazure.de",
-		TokenAudience:                "https://management.microsoftazure.de/",
+		Name:                              "AzureGermanCloud",
+		ManagementPortalURL:               "http://portal.microsoftazure.de/",
+		PublishSettingsURL:                "https://manage.microsoftazure.de/publishsettings/index",
+		ServiceManagementEndpoint:         "https://management.core.cloudapi.de/",
+		ResourceManagerEndpoint:           "https://management.microsoftazure.de/",
+		ActiveDirectoryEndpoint:           "https://login.microsoftonline.de/",
+		GalleryEndpoint:                   "https://gallery.cloudapi.de/",
+		KeyVaultEndpoint:                  "https://vault.microsoftazure.de/",
+		GraphEndpoint:                     "https://graph.cloudapi.de/",
+		ServiceBusEndpoint:                "https://servicebus.cloudapi.de/",
+		BatchManagementEndpoint:           "https://batch.cloudapi.de/",
+		StorageEndpointSuffix:             "core.cloudapi.de",
+		SQLDatabaseDNSSuffix:              "database.cloudapi.de",
+		TrafficManagerDNSSuffix:           "azuretrafficmanager.de",
+		KeyVaultDNSSuffix:                 "vault.microsoftazure.de",
+		ServiceBusEndpointSuffix:          "servicebus.cloudapi.de",
+		ServiceManagementVMDNSSuffix:      "azurecloudapp.de",
+		ResourceManagerVMDNSSuffix:        "cloudapp.microsoftazure.de",
+		ContainerRegistryDNSSuffix:        NotAvailable,
+		CosmosDBDNSSuffix:                 "documents.microsoftazure.de",
+		TokenAudience:                     "https://management.microsoftazure.de/",
+		ApiManagementHostManagementSuffix: NotAvailable,
 		ResourceIdentifiers: ResourceIdentifier{
 			Graph:               "https://graph.cloudapi.de/",
 			KeyVault:            "https://vault.microsoftazure.de",


### PR DESCRIPTION
To fix acctests in `azurerm_api_management` related to https://github.com/terraform-providers/terraform-provider-azurerm/pull/7603.

Environment variables got from service team : https://github.com/Azure/azure-rest-api-specs/issues/10065

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.