### PR TITLE
allow MSI login with "mi_res_id"

### DIFF
--- a/autorest/adal/cmd/adal.go
+++ b/autorest/adal/cmd/adal.go
@@ -106,7 +106,7 @@ func init() {
 		checkMandatoryOptions(msiResourceIDMode,
 			option{name: "resource", value: resource},
 			option{name: "tenantId", value: tenantID},
-			option{name: "identityResourceID", value: applicationID},
+			option{name: "identityResourceID", value: identityResourceID},
 		)
 	case clientSecretMode:
 		checkMandatoryOptions(clientSecretMode,

--- a/autorest/adal/cmd/adal.go
+++ b/autorest/adal/cmd/adal.go
@@ -31,10 +31,13 @@ import (
 )
 
 const (
-	deviceMode       = "device"
-	clientSecretMode = "secret"
-	clientCertMode   = "cert"
-	refreshMode      = "refresh"
+	deviceMode        = "device"
+	clientSecretMode  = "secret"
+	clientCertMode    = "cert"
+	refreshMode       = "refresh"
+	msiDefaultMode    = "msiDefault"
+	msiClientIDMode   = "msiClientID"
+	msiResourceIDMode = "msiResourceID"
 
 	activeDirectoryEndpoint = "https://login.microsoftonline.com/"
 )
@@ -48,8 +51,9 @@ var (
 	mode     string
 	resource string
 
-	tenantID      string
-	applicationID string
+	tenantID           string
+	applicationID      string
+	identityResourceID string
 
 	applicationSecret string
 	certificatePath   string
@@ -82,10 +86,28 @@ func init() {
 	flag.StringVar(&applicationSecret, "secret", "", "application secret")
 	flag.StringVar(&certificatePath, "certificatePath", "", "path to pk12/PFC application certificate")
 	flag.StringVar(&tokenCachePath, "tokenCachePath", defaultTokenCachePath(), "location of oath token cache")
+	flag.StringVar(&identityResourceID, "identityResourceID", "", "managedIdentity azure resource id")
 
 	flag.Parse()
 
 	switch mode = strings.TrimSpace(mode); mode {
+	case msiDefaultMode:
+		checkMandatoryOptions(clientSecretMode,
+			option{name: "resource", value: resource},
+			option{name: "tenantId", value: tenantID},
+		)
+	case msiClientIDMode:
+		checkMandatoryOptions(clientSecretMode,
+			option{name: "resource", value: resource},
+			option{name: "tenantId", value: tenantID},
+			option{name: "applicationId", value: applicationID},
+		)
+	case msiResourceIDMode:
+		checkMandatoryOptions(clientSecretMode,
+			option{name: "resource", value: resource},
+			option{name: "tenantId", value: tenantID},
+			option{name: "identityResourceID", value: applicationID},
+		)
 	case clientSecretMode:
 		checkMandatoryOptions(clientSecretMode,
 			option{name: "resource", value: resource},
@@ -148,6 +170,43 @@ func decodePkcs12(pkcs []byte, password string) (*x509.Certificate, *rsa.Private
 	}
 
 	return certificate, rsaPrivateKey, nil
+}
+
+func acquireTokenMSIFlow(oauthConfig adal.OAuthConfig,
+	applicationID string,
+	identityResourceID string,
+	resource string,
+	callbacks ...adal.TokenRefreshCallback) (*adal.ServicePrincipalToken, error) {
+
+	// only one of them can be present:
+	if applicationID != "" && identityResourceID != "" {
+		return nil, fmt.Errorf("didn't expect applicationID and identityResourceID at same time")
+	}
+
+	msiEndpoint, _ := adal.GetMSIVMEndpoint()
+	var spt *adal.ServicePrincipalToken
+	var err error
+
+	// both can be empty, systemAssignedMSI scenario
+	if applicationID == "" && identityResourceID == "" {
+		spt, err = adal.NewServicePrincipalTokenFromMSI(msiEndpoint, resource, callbacks...)
+	}
+
+	// msi login with clientID
+	if applicationID != "" {
+		spt, err = adal.NewServicePrincipalTokenFromMSIWithUserAssignedID(msiEndpoint, resource, applicationID, callbacks...)
+	}
+
+	// msi login with resourceID
+	if identityResourceID != "" {
+		spt, err = adal.NewServicePrincipalTokenFromMSIWithIdentityResourceID(msiEndpoint, resource, identityResourceID, callbacks...)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return spt, spt.Refresh()
 }
 
 func acquireTokenClientCertFlow(oauthConfig adal.OAuthConfig,

--- a/autorest/adal/cmd/adal.go
+++ b/autorest/adal/cmd/adal.go
@@ -26,7 +26,7 @@ import (
 	"net/http"
 	"os/user"
 
-	"github.com/haitch/go-autorest/autorest/adal"
+	"github.com/Azure/go-autorest/autorest/adal"
 	"golang.org/x/crypto/pkcs12"
 )
 

--- a/autorest/adal/go.mod
+++ b/autorest/adal/go.mod
@@ -1,4 +1,4 @@
-module github.com/Azure/go-autorest/autorest/adal
+module github.com/haitch/go-autorest/autorest/adal
 
 go 1.12
 

--- a/autorest/adal/go.mod
+++ b/autorest/adal/go.mod
@@ -1,4 +1,4 @@
-module github.com/haitch/go-autorest/autorest/adal
+module github.com/Azure/go-autorest/autorest/adal
 
 go 1.12
 

--- a/autorest/adal/token.go
+++ b/autorest/adal/token.go
@@ -728,7 +728,6 @@ func newServicePrincipalTokenFromMSI(msiEndpoint, resource string, userAssignedI
 		v.Set("client_id", *userAssignedID)
 	}
 	if identityResourceID != nil {
-		fmt.Println("mi_res_id set to ", *identityResourceID)
 		v.Set("mi_res_id", *identityResourceID)
 	}
 	msiEndpointURL.RawQuery = v.Encode()

--- a/autorest/adal/token.go
+++ b/autorest/adal/token.go
@@ -678,16 +678,22 @@ func GetMSIEndpoint() (string, error) {
 // NewServicePrincipalTokenFromMSI creates a ServicePrincipalToken via the MSI VM Extension.
 // It will use the system assigned identity when creating the token.
 func NewServicePrincipalTokenFromMSI(msiEndpoint, resource string, callbacks ...TokenRefreshCallback) (*ServicePrincipalToken, error) {
-	return newServicePrincipalTokenFromMSI(msiEndpoint, resource, nil, callbacks...)
+	return newServicePrincipalTokenFromMSI(msiEndpoint, resource, nil, nil, callbacks...)
 }
 
 // NewServicePrincipalTokenFromMSIWithUserAssignedID creates a ServicePrincipalToken via the MSI VM Extension.
-// It will use the specified user assigned identity when creating the token.
+// It will use the clientID of specified user assigned identity when creating the token.
 func NewServicePrincipalTokenFromMSIWithUserAssignedID(msiEndpoint, resource string, userAssignedID string, callbacks ...TokenRefreshCallback) (*ServicePrincipalToken, error) {
-	return newServicePrincipalTokenFromMSI(msiEndpoint, resource, &userAssignedID, callbacks...)
+	return newServicePrincipalTokenFromMSI(msiEndpoint, resource, &userAssignedID, nil, callbacks...)
 }
 
-func newServicePrincipalTokenFromMSI(msiEndpoint, resource string, userAssignedID *string, callbacks ...TokenRefreshCallback) (*ServicePrincipalToken, error) {
+// NewServicePrincipalTokenFromMSIWithIdentityResourceID creates a ServicePrincipalToken via the MSI VM Extension.
+// It will use the azure resource id of user assigned identity when creating the token.
+func NewServicePrincipalTokenFromMSIWithIdentityResourceID(msiEndpoint, resource string, identityResourceID string, callbacks ...TokenRefreshCallback) (*ServicePrincipalToken, error) {
+	return newServicePrincipalTokenFromMSI(msiEndpoint, resource, nil, &identityResourceID, callbacks...)
+}
+
+func newServicePrincipalTokenFromMSI(msiEndpoint, resource string, userAssignedID *string, identityResourceID *string, callbacks ...TokenRefreshCallback) (*ServicePrincipalToken, error) {
 	if err := validateStringParam(msiEndpoint, "msiEndpoint"); err != nil {
 		return nil, err
 	}
@@ -696,6 +702,11 @@ func newServicePrincipalTokenFromMSI(msiEndpoint, resource string, userAssignedI
 	}
 	if userAssignedID != nil {
 		if err := validateStringParam(*userAssignedID, "userAssignedID"); err != nil {
+			return nil, err
+		}
+	}
+	if identityResourceID != nil {
+		if err := validateStringParam(*identityResourceID, "identityResourceID"); err != nil {
 			return nil, err
 		}
 	}
@@ -715,6 +726,10 @@ func newServicePrincipalTokenFromMSI(msiEndpoint, resource string, userAssignedI
 	}
 	if userAssignedID != nil {
 		v.Set("client_id", *userAssignedID)
+	}
+	if identityResourceID != nil {
+		fmt.Println("mi_res_id set to ", *userAssignedID)
+		v.Set("mi_res_id", *userAssignedID)
 	}
 	msiEndpointURL.RawQuery = v.Encode()
 

--- a/autorest/adal/token.go
+++ b/autorest/adal/token.go
@@ -728,8 +728,8 @@ func newServicePrincipalTokenFromMSI(msiEndpoint, resource string, userAssignedI
 		v.Set("client_id", *userAssignedID)
 	}
 	if identityResourceID != nil {
-		fmt.Println("mi_res_id set to ", *userAssignedID)
-		v.Set("mi_res_id", *userAssignedID)
+		fmt.Println("mi_res_id set to ", *identityResourceID)
+		v.Set("mi_res_id", *identityResourceID)
 	}
 	msiEndpointURL.RawQuery = v.Encode()
 

--- a/autorest/adal/token_test.go
+++ b/autorest/adal/token_test.go
@@ -694,7 +694,7 @@ func TestServicePrincipalTokenManualRefreshFailsWithoutRefresh(t *testing.T) {
 }
 
 func TestNewServicePrincipalTokenFromMSI(t *testing.T) {
-	resource := "https://resource"
+	const resource = "https://resource"
 	cb := func(token Token) error { return nil }
 
 	spt, err := NewServicePrincipalTokenFromMSI("http://msiendpoint/", resource, cb)
@@ -717,8 +717,10 @@ func TestNewServicePrincipalTokenFromMSI(t *testing.T) {
 }
 
 func TestNewServicePrincipalTokenFromMSIWithUserAssignedID(t *testing.T) {
-	resource := "https://resource"
-	userID := "abc123"
+	const (
+		resource = "https://resource"
+		userID   = "abc123"
+	)
 	cb := func(token Token) error { return nil }
 
 	spt, err := NewServicePrincipalTokenFromMSIWithUserAssignedID("http://msiendpoint/", resource, userID, cb)
@@ -745,8 +747,10 @@ func TestNewServicePrincipalTokenFromMSIWithUserAssignedID(t *testing.T) {
 }
 
 func TestNewServicePrincipalTokenFromMSIWithIdentityResourceID(t *testing.T) {
-	resource := "https://resource"
-	identityResourceID := "/subscriptions/testSub/resourceGroups/testGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/test-identity"
+	const (
+		resource           = "https://resource"
+		identityResourceID = "/subscriptions/testSub/resourceGroups/testGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/test-identity"
+	)
 	cb := func(token Token) error { return nil }
 
 	spt, err := NewServicePrincipalTokenFromMSIWithIdentityResourceID("http://msiendpoint/", resource, identityResourceID, cb)
@@ -767,7 +771,10 @@ func TestNewServicePrincipalTokenFromMSIWithIdentityResourceID(t *testing.T) {
 		t.Fatal("SPT had incorrect refresh callbacks.")
 	}
 
-	if !strings.Contains(spt.inner.OauthConfig.TokenEndpoint.RawQuery, fmt.Sprintf("mi_res_id=%s", identityResourceID)) {
+	urlPathParameter := url.Values{}
+	urlPathParameter.Set("mi_res_id", identityResourceID)
+
+	if !strings.Contains(spt.inner.OauthConfig.TokenEndpoint.RawQuery, urlPathParameter.Encode()) {
 		t.Fatal("SPT tokenEndpoint should contains mi_res_id")
 	}
 }

--- a/autorest/adal/token_test.go
+++ b/autorest/adal/token_test.go
@@ -895,7 +895,7 @@ func TestMarshalServicePrincipalCertificateSecret(t *testing.T) {
 }
 
 func TestMarshalServicePrincipalMSISecret(t *testing.T) {
-	spt, err := newServicePrincipalTokenFromMSI("http://msiendpoint/", "https://resource", nil)
+	spt, err := newServicePrincipalTokenFromMSI("http://msiendpoint/", "https://resource", nil, nil)
 	if err != nil {
 		t.Fatalf("failed to get MSI SPT: %+v", err)
 	}

--- a/autorest/adal/token_test.go
+++ b/autorest/adal/token_test.go
@@ -746,10 +746,10 @@ func TestNewServicePrincipalTokenFromMSIWithUserAssignedID(t *testing.T) {
 
 func TestNewServicePrincipalTokenFromMSIWithIdentityResourceID(t *testing.T) {
 	resource := "https://resource"
-	identityResourceId := "/subscriptions/testSub/resourceGroups/testGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/test-identity"
+	identityResourceID := "/subscriptions/testSub/resourceGroups/testGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/test-identity"
 	cb := func(token Token) error { return nil }
 
-	spt, err := NewServicePrincipalTokenFromMSIWithIdentityResourceID("http://msiendpoint/", resource, identityResourceId, cb)
+	spt, err := NewServicePrincipalTokenFromMSIWithIdentityResourceID("http://msiendpoint/", resource, identityResourceID, cb)
 	if err != nil {
 		t.Fatalf("Failed to get MSI SPT: %v", err)
 	}
@@ -767,7 +767,9 @@ func TestNewServicePrincipalTokenFromMSIWithIdentityResourceID(t *testing.T) {
 		t.Fatal("SPT had incorrect refresh callbacks.")
 	}
 
-	strings.Contains(spt.inner.OauthConfig.TokenEndpoint.RawQuery, fmt.Sprintf("mi_res_id=%s", identityResourceId))
+	if !strings.Contains(spt.inner.OauthConfig.TokenEndpoint.RawQuery, fmt.Sprintf("mi_res_id=%s", identityResourceID)) {
+		t.Fatal("SPT tokenEndpoint should contains mi_res_id")
+	}
 }
 
 func TestNewServicePrincipalTokenFromManualTokenSecret(t *testing.T) {


### PR DESCRIPTION
Allowing 

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [x] I've tested my changes, adding unit tests if applicable.
 - [x] I've added Apache 2.0 Headers to the top of any new source files.
 - [x] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.

MSI login with azure resource ID of the userAssignedIdentity is now possible, see "mi_res_id" in this page: 
https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-use-vm-token#get-a-token-using-http

this PR add new login option with identityResourceID, updated the cmd as well, and I tested all 3 case.