### PR TITLE
Fix decoding of certificates with intermediate CAs

### DIFF
--- a/autorest/adal/cmd/adal.go
+++ b/autorest/adal/cmd/adal.go
@@ -27,7 +27,6 @@ import (
 	"os/user"
 
 	"github.com/Azure/go-autorest/autorest/adal"
-	"golang.org/x/crypto/pkcs12"
 )
 
 const (
@@ -159,17 +158,7 @@ func acquireTokenClientSecretFlow(oauthConfig adal.OAuthConfig,
 }
 
 func decodePkcs12(pkcs []byte, password string) (*x509.Certificate, *rsa.PrivateKey, error) {
-	privateKey, certificate, err := pkcs12.Decode(pkcs, password)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	rsaPrivateKey, isRsaKey := privateKey.(*rsa.PrivateKey)
-	if !isRsaKey {
-		return nil, nil, fmt.Errorf("PKCS#12 certificate must contain an RSA private key")
-	}
-
-	return certificate, rsaPrivateKey, nil
+	return adal.DecodePfxCertificateData(pkcs, password)
 }
 
 func acquireTokenMSIFlow(applicationID string,

--- a/autorest/adal/devicetoken.go
+++ b/autorest/adal/devicetoken.go
@@ -222,6 +222,10 @@ func CheckForUserCompletionWithContext(ctx context.Context, sender Sender, code 
 	case "code_expired":
 		return nil, ErrDeviceCodeExpired
 	default:
+		// return a more meaningful error message if available
+		if token.ErrorDescription != nil {
+			return nil, fmt.Errorf("%s %s: %s", logPrefix, *token.Error, *token.ErrorDescription)
+		}
 		return nil, ErrDeviceGeneric
 	}
 }

--- a/autorest/adal/persist.go
+++ b/autorest/adal/persist.go
@@ -86,8 +86,9 @@ func SaveToken(path string, mode os.FileMode, token Token) error {
 }
 
 // DecodePfxCertificateData extracts the x509 certificate and RSA private key from the provided PFX data.
-// The PFX data must contain a local certificate along with a private key or an error is returned.
-// If the certificate is not password protected pass the empty string for password.
+// The PFX data must contain a private key along with a certificate whose public key matches that of the
+// private key or an error is returned.
+// If the private key is not password protected pass the empty string for password.
 func DecodePfxCertificateData(pfxData []byte, password string) (*x509.Certificate, *rsa.PrivateKey, error) {
 	blocks, err := pkcs12.ToPEM(pfxData, password)
 	if err != nil {

--- a/autorest/adal/persist.go
+++ b/autorest/adal/persist.go
@@ -15,11 +15,24 @@ package adal
 //  limitations under the License.
 
 import (
+	"crypto/rsa"
+	"crypto/x509"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"golang.org/x/crypto/pkcs12"
+)
+
+var (
+	// ErrMissingCertificate is returned when no local certificate is found in the provided PFX data.
+	ErrMissingCertificate = errors.New("adal: certificate missing")
+
+	// ErrMissingPrivateKey is returned when no private key is found in the provided PFX data.
+	ErrMissingPrivateKey = errors.New("adal: private key missing")
 )
 
 // LoadToken restores a Token object from a file located at 'path'.
@@ -70,4 +83,42 @@ func SaveToken(path string, mode os.FileMode, token Token) error {
 		return fmt.Errorf("failed to chmod the token file %s: %v", path, err)
 	}
 	return nil
+}
+
+// DecodePfxCertificateData extracts the x509 certificate and RSA private key from the provided PFX data.
+// The PFX data must contain a local certificate along with a private key or an error is returned.
+// If the certificate is not password protected pass the empty string for password.
+func DecodePfxCertificateData(pfxData []byte, password string) (*x509.Certificate, *rsa.PrivateKey, error) {
+	blocks, err := pkcs12.ToPEM(pfxData, password)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var (
+		cert *x509.Certificate
+		priv *rsa.PrivateKey
+	)
+
+	for _, block := range blocks {
+		if block.Type == "CERTIFICATE" {
+			if _, ok := block.Headers["localKeyId"]; ok {
+				cert, err = x509.ParseCertificate(block.Bytes)
+				if err != nil {
+					return nil, nil, err
+				}
+			}
+		} else if block.Type == "PRIVATE KEY" {
+			priv, err = x509.ParsePKCS1PrivateKey(block.Bytes)
+			if err != nil {
+				return nil, nil, err
+			}
+		}
+	}
+
+	if cert == nil {
+		return nil, nil, ErrMissingCertificate
+	} else if priv == nil {
+		return nil, nil, ErrMissingPrivateKey
+	}
+	return cert, priv, nil
 }


### PR DESCRIPTION
pkcs12.Decode will fail if a certificate contains more than two safe
bags which is the case for certificates with intermediate authorities.
Switch to using pkcs12.ToPEM, then manually decoding the certificate and
private key blocks.
In CheckForUserCompletionWithContext, return a better error message when
available, falling back to ErrDeviceGeneric.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.