### PR TITLE
Fail-fast if the MSI endpoint is not available

### DIFF
--- a/autorest/adal/go.mod
+++ b/autorest/adal/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/Azure/go-autorest v14.2.0+incompatible
 	github.com/Azure/go-autorest/autorest/date v0.3.0
-	github.com/Azure/go-autorest/autorest/mocks v0.4.0
+	github.com/Azure/go-autorest/autorest/mocks v0.4.1
 	github.com/Azure/go-autorest/tracing v0.6.0
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9

--- a/autorest/adal/go.sum
+++ b/autorest/adal/go.sum
@@ -2,8 +2,8 @@ github.com/Azure/go-autorest v14.2.0+incompatible h1:V5VMDjClD3GiElqLWO7mz2MxNAK
 github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-autorest/autorest/date v0.3.0 h1:7gUk1U5M/CQbp9WoqinNzJar+8KY+LPI6wiWrP/myHw=
 github.com/Azure/go-autorest/autorest/date v0.3.0/go.mod h1:BI0uouVdmngYNUzGWeSYnokU+TrmwEsOqdt8Y6sso74=
-github.com/Azure/go-autorest/autorest/mocks v0.4.0 h1:z20OWOSG5aCye0HEkDp6TPmP17ZcfeMxPi6HnSALa8c=
-github.com/Azure/go-autorest/autorest/mocks v0.4.0/go.mod h1:LTp+uSrOhSkaKrUy935gNZuuIPPVsHlr9DSOxSayd+k=
+github.com/Azure/go-autorest/autorest/mocks v0.4.1 h1:K0laFcLE6VLTOwNgSxaGbUcLPuGXlNkbVvq4cW4nIHk=
+github.com/Azure/go-autorest/autorest/mocks v0.4.1/go.mod h1:LTp+uSrOhSkaKrUy935gNZuuIPPVsHlr9DSOxSayd+k=
 github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUMfuitfgcfuo=
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=

--- a/autorest/adal/token_test.go
+++ b/autorest/adal/token_test.go
@@ -1091,9 +1091,20 @@ func TestNewMultiTenantServicePrincipalToken(t *testing.T) {
 	}
 }
 
-func TestMSIAvailable(t *testing.T) {
-	if MSIAvailable(context.Background(), http.DefaultClient) {
-		t.Fatal("didn't expect MSI to be available, is the test running on an Azure VM?")
+func TestMSIAvailableSuccess(t *testing.T) {
+	c := mocks.NewSender()
+	c.AppendResponse(mocks.NewResponse())
+	if !MSIAvailable(context.Background(), c) {
+		t.Fatal("unexpected false")
+	}
+}
+
+func TestMSIAvailableFail(t *testing.T) {
+	c := mocks.NewSender()
+	// introduce a long response delay to simulate the endpoint not being available
+	c.AppendResponseWithDelay(mocks.NewResponse(), 5*time.Second)
+	if MSIAvailable(context.Background(), c) {
+		t.Fatal("unexpected true")
 	}
 }
 

--- a/autorest/adal/token_test.go
+++ b/autorest/adal/token_test.go
@@ -1083,6 +1083,12 @@ func TestNewMultiTenantServicePrincipalToken(t *testing.T) {
 	}
 }
 
+func TestMSIAvailable(t *testing.T) {
+	if MSIAvailable(context.Background(), http.DefaultClient) {
+		t.Fatal("didn't expect MSI to be available, is the test running on an Azure VM?")
+	}
+}
+
 func newTokenJSON(expiresOn string, resource string) string {
 	return fmt.Sprintf(`{
 		"access_token" : "accessToken",


### PR DESCRIPTION
Added adal.MSIAvailable to probe if the MSI endpoint is available.
Return a TokenRefreshError when attempting to authenticate via MSI when
the endpoint isn't available, this will prevent retries from happening.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.