### PR TITLE
Honor the request context in mock sender

### DIFF
--- a/autorest/mocks/mocks.go
+++ b/autorest/mocks/mocks.go
@@ -131,7 +131,13 @@ func (c *Sender) Do(r *http.Request) (resp *http.Response, err error) {
 		} else {
 			err = c.responses[0].e
 		}
-		time.Sleep(c.responses[0].d)
+		select {
+		case <-time.After(c.responses[0].d):
+			// do nothing
+		case <-r.Context().Done():
+			err = r.Context().Err()
+			return
+		}
 		c.repeatResponse[0]--
 		if c.repeatResponse[0] == 0 {
 			c.responses = c.responses[1:]


### PR DESCRIPTION
If the request's context has expired return the error.  This allows
mocking of requests that take too long, triggering deadline exceeded.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.