### PR TITLE
Add support for MSIAvailable on older versions of Go

### DIFF
--- a/autorest/adal/token.go
+++ b/autorest/adal/token.go
@@ -1183,17 +1183,3 @@ func NewMultiTenantServicePrincipalToken(multiTenantCfg MultiTenantOAuthConfig, 
 	}
 	return &m, nil
 }
-
-// MSIAvailable returns true if the MSI endpoint is available for authentication.
-func MSIAvailable(ctx context.Context, sender Sender) bool {
-	// this cannot fail, the return sig is due to legacy reasons
-	msiEndpoint, _ := GetMSIVMEndpoint()
-	tempCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
-	defer cancel()
-	req, _ := http.NewRequestWithContext(tempCtx, http.MethodGet, msiEndpoint, nil)
-	q := req.URL.Query()
-	q.Add("api-version", msiAPIVersion)
-	req.URL.RawQuery = q.Encode()
-	_, err := sender.Do(req)
-	return err == nil
-}

--- a/autorest/adal/token_1.13.go
+++ b/autorest/adal/token_1.13.go
@@ -1,0 +1,38 @@
+// +build go1.13
+
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package adal
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+// MSIAvailable returns true if the MSI endpoint is available for authentication.
+func MSIAvailable(ctx context.Context, sender Sender) bool {
+	// this cannot fail, the return sig is due to legacy reasons
+	msiEndpoint, _ := GetMSIVMEndpoint()
+	tempCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	defer cancel()
+	// http.NewRequestWithContext() was added in Go 1.13
+	req, _ := http.NewRequestWithContext(tempCtx, http.MethodGet, msiEndpoint, nil)
+	q := req.URL.Query()
+	q.Add("api-version", msiAPIVersion)
+	req.URL.RawQuery = q.Encode()
+	_, err := sender.Do(req)
+	return err == nil
+}

--- a/autorest/adal/token_legacy.go
+++ b/autorest/adal/token_legacy.go
@@ -1,0 +1,32 @@
+// +build !go1.13
+
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package adal
+
+// MSIAvailable returns true if the MSI endpoint is available for authentication.
+func MSIAvailable(ctx context.Context, sender Sender) bool {
+	// this cannot fail, the return sig is due to legacy reasons
+	msiEndpoint, _ := GetMSIVMEndpoint()
+	tempCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	defer cancel()
+	req, _ := http.NewRequest(http.MethodGet, msiEndpoint, nil)
+	req = req.WithContext(ctx)
+	q := req.URL.Query()
+	q.Add("api-version", msiAPIVersion)
+	req.URL.RawQuery = q.Encode()
+	_, err := sender.Do(req)
+	return err == nil
+}


### PR DESCRIPTION
http.NewRequestWithContext() was added in Go 1.13.  This change uses
build constraints to support older versions.
Note that Go 1.7 is the minimum version due to reliance on the context
package.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.