### PR TITLE
Export multi-tenant bearer authorizer

### DIFF
--- a/autorest/authorization.go
+++ b/autorest/authorization.go
@@ -299,18 +299,24 @@ type MultiTenantServicePrincipalTokenAuthorizer interface {
 
 // NewMultiTenantServicePrincipalTokenAuthorizer crates a BearerAuthorizer using the given token provider
 func NewMultiTenantServicePrincipalTokenAuthorizer(tp adal.MultitenantOAuthTokenProvider) MultiTenantServicePrincipalTokenAuthorizer {
-	return &multiTenantSPTAuthorizer{tp: tp}
+	return NewMultiTenantBearerAuthorizer(tp)
 }
 
-type multiTenantSPTAuthorizer struct {
+// MultiTenantBearerAuthorizer implements bearer authorization across multiple tenants.
+type MultiTenantBearerAuthorizer struct {
 	tp adal.MultitenantOAuthTokenProvider
+}
+
+// NewMultiTenantBearerAuthorizer creates a MultiTenantBearerAuthorizer using the given token provider.
+func NewMultiTenantBearerAuthorizer(tp adal.MultitenantOAuthTokenProvider) *MultiTenantBearerAuthorizer {
+	return &MultiTenantBearerAuthorizer{tp: tp}
 }
 
 // WithAuthorization returns a PrepareDecorator that adds an HTTP Authorization header using the
 // primary token along with the auxiliary authorization header using the auxiliary tokens.
 //
 // By default, the token will be automatically refreshed through the Refresher interface.
-func (mt multiTenantSPTAuthorizer) WithAuthorization() PrepareDecorator {
+func (mt *MultiTenantBearerAuthorizer) WithAuthorization() PrepareDecorator {
 	return func(p Preparer) Preparer {
 		return PreparerFunc(func(r *http.Request) (*http.Request, error) {
 			r, err := p.Prepare(r)
@@ -339,4 +345,9 @@ func (mt multiTenantSPTAuthorizer) WithAuthorization() PrepareDecorator {
 			return Prepare(r, WithHeader(headerAuxAuthorization, strings.Join(auxTokens, ", ")))
 		})
 	}
+}
+
+// TokenProvider returns the underlying MultitenantOAuthTokenProvider for this authorizer.
+func (mt *MultiTenantBearerAuthorizer) TokenProvider() adal.MultitenantOAuthTokenProvider {
+	return mt.tp
 }

--- a/autorest/authorization_test.go
+++ b/autorest/authorization_test.go
@@ -291,10 +291,16 @@ func TestMultitenantAuthorizationThree(t *testing.T) {
 		p: "primary",
 		a: []string{TestAuxTenent1, TestAuxTenent2, TestAuxTenent3},
 	}
-	mt := NewMultiTenantServicePrincipalTokenAuthorizer(mtSPTProvider)
+	mt := NewMultiTenantBearerAuthorizer(mtSPTProvider)
 	req, err := Prepare(mocks.NewRequest(), mt.WithAuthorization())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if primary := mt.TokenProvider().PrimaryOAuthToken(); primary != mtSPTProvider.p {
+		t.Fatalf("bad primary authorization token %s", primary)
+	}
+	if aux := strings.Join(mt.TokenProvider().AuxiliaryOAuthTokens(), ","); aux != strings.Join(mtSPTProvider.a, ",") {
+		t.Fatalf("bad auxiliary authorization tokens %s", aux)
 	}
 	if primary := req.Header.Get(headerAuthorization); primary != "Bearer primary" {
 		t.Fatalf("bad primary authorization header %s", primary)


### PR DESCRIPTION
Make the multi-tenant bearer authorizer publicly available for consumers
that need access to the underlying type.  This also provides symmetry
with the single-tenant bearer authorizer implementation.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.