### PR TITLE
fix: return error for failed MSI endpoint check

### DIFF
--- a/autorest/adal/token.go
+++ b/autorest/adal/token.go
@@ -947,6 +947,7 @@ func (spt *ServicePrincipalToken) refreshInternal(ctx context.Context, resource 
 			// return a TokenRefreshError here so that we don't keep retrying
 			return newTokenRefreshError(fmt.Sprintf("the MSI endpoint is not available. Failed HTTP request to MSI endpoint: %v", err), nil)
 		}
+		resp.Body.Close()
 	}
 	if isIMDS(spt.inner.OauthConfig.TokenEndpoint) {
 		resp, err = retryForIMDS(spt.sender, req, spt.MaxMSIRefreshAttempts)

--- a/autorest/adal/token.go
+++ b/autorest/adal/token.go
@@ -945,7 +945,11 @@ func (spt *ServicePrincipalToken) refreshInternal(ctx context.Context, resource 
 		resp, err = getMSIEndpoint(ctx, spt.sender)
 		if err != nil {
 			// return a TokenRefreshError here so that we don't keep retrying
-			return newTokenRefreshError(fmt.Sprintf("the MSI endpoint is not available. Status Code = '%d'. Failed HTTP request to MSI endpoint: %v", resp.StatusCode, err), resp)
+			if resp != nil {
+				return newTokenRefreshError(fmt.Sprintf("the MSI endpoint is not available. Status Code = '%d'. Failed HTTP request to MSI endpoint: %v", resp.StatusCode, err), resp)
+			}
+			return newTokenRefreshError(fmt.Sprintf("the MSI endpoint is not available. Failed HTTP request to MSI endpoint: %v", err), resp)
+
 		}
 	}
 	if isIMDS(spt.inner.OauthConfig.TokenEndpoint) {

--- a/autorest/adal/token.go
+++ b/autorest/adal/token.go
@@ -945,11 +945,7 @@ func (spt *ServicePrincipalToken) refreshInternal(ctx context.Context, resource 
 		resp, err = getMSIEndpoint(ctx, spt.sender)
 		if err != nil {
 			// return a TokenRefreshError here so that we don't keep retrying
-			if resp != nil {
-				return newTokenRefreshError(fmt.Sprintf("the MSI endpoint is not available. Status Code = '%d'. Failed HTTP request to MSI endpoint: %v", resp.StatusCode, err), resp)
-			}
-			return newTokenRefreshError(fmt.Sprintf("the MSI endpoint is not available. Failed HTTP request to MSI endpoint: %v", err), resp)
-
+			return newTokenRefreshError(fmt.Sprintf("the MSI endpoint is not available. Failed HTTP request to MSI endpoint: %v", err), nil)
 		}
 	}
 	if isIMDS(spt.inner.OauthConfig.TokenEndpoint) {

--- a/autorest/adal/token_1.13.go
+++ b/autorest/adal/token_1.13.go
@@ -22,8 +22,7 @@ import (
 	"time"
 )
 
-// MSIAvailable returns true if the MSI endpoint is available for authentication.
-func MSIAvailable(ctx context.Context, sender Sender) bool {
+func getMSIEndpoint(ctx context.Context, sender Sender) (*http.Response, error) {
 	// this cannot fail, the return sig is due to legacy reasons
 	msiEndpoint, _ := GetMSIVMEndpoint()
 	tempCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
@@ -33,6 +32,11 @@ func MSIAvailable(ctx context.Context, sender Sender) bool {
 	q := req.URL.Query()
 	q.Add("api-version", msiAPIVersion)
 	req.URL.RawQuery = q.Encode()
-	_, err := sender.Do(req)
+	return sender.Do(req)
+}
+
+// MSIAvailable returns true if the MSI endpoint is available for authentication.
+func MSIAvailable(ctx context.Context, sender Sender) bool {
+	_, err := getMSIEndpoint(ctx, sender)
 	return err == nil
 }

--- a/autorest/adal/token_legacy.go
+++ b/autorest/adal/token_legacy.go
@@ -16,8 +16,13 @@
 
 package adal
 
-// MSIAvailable returns true if the MSI endpoint is available for authentication.
-func MSIAvailable(ctx context.Context, sender Sender) bool {
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+func getMSIEndpoint(ctx context.Context, sender Sender) (*http.Response, error) {
 	// this cannot fail, the return sig is due to legacy reasons
 	msiEndpoint, _ := GetMSIVMEndpoint()
 	tempCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
@@ -27,6 +32,11 @@ func MSIAvailable(ctx context.Context, sender Sender) bool {
 	q := req.URL.Query()
 	q.Add("api-version", msiAPIVersion)
 	req.URL.RawQuery = q.Encode()
-	_, err := sender.Do(req)
+	return sender.Do(req)
+}
+
+// MSIAvailable returns true if the MSI endpoint is available for authentication.
+func MSIAvailable(ctx context.Context, sender Sender) bool {
+	_, err := getMSIEndpoint(ctx, sender)
 	return err == nil
 }

--- a/autorest/adal/token_test.go
+++ b/autorest/adal/token_test.go
@@ -1099,10 +1099,19 @@ func TestMSIAvailableSuccess(t *testing.T) {
 	}
 }
 
-func TestMSIAvailableFail(t *testing.T) {
+func TestMSIAvailableSlow(t *testing.T) {
 	c := mocks.NewSender()
 	// introduce a long response delay to simulate the endpoint not being available
 	c.AppendResponseWithDelay(mocks.NewResponse(), 5*time.Second)
+	if MSIAvailable(context.Background(), c) {
+		t.Fatal("unexpected true")
+	}
+}
+
+func TestMSIAvailableFail(t *testing.T) {
+	c := mocks.NewSender()
+	// introduce a long response delay to simulate the endpoint not being available
+	c.AppendError(fmt.Errorf("failed to make msi http request"))
 	if MSIAvailable(context.Background(), c) {
 		t.Fatal("unexpected true")
 	}

--- a/autorest/adal/token_test.go
+++ b/autorest/adal/token_test.go
@@ -1109,10 +1109,15 @@ func TestMSIAvailableSlow(t *testing.T) {
 }
 
 func TestMSIAvailableFail(t *testing.T) {
+	expectErr := "failed to make msi http request"
 	c := mocks.NewSender()
-	c.AppendError(fmt.Errorf("failed to make msi http request"))
+	c.AppendAndRepeatError(fmt.Errorf(expectErr), 2)
 	if MSIAvailable(context.Background(), c) {
 		t.Fatal("unexpected true")
+	}
+	_, err := getMSIEndpoint(context.Background(), c)
+	if !strings.Contains(err.Error(), "") {
+		t.Fatalf("expected error: '%s', but got error '%s'", expectErr, err)
 	}
 }
 

--- a/autorest/adal/token_test.go
+++ b/autorest/adal/token_test.go
@@ -1110,7 +1110,6 @@ func TestMSIAvailableSlow(t *testing.T) {
 
 func TestMSIAvailableFail(t *testing.T) {
 	c := mocks.NewSender()
-	// introduce a long response delay to simulate the endpoint not being available
 	c.AppendError(fmt.Errorf("failed to make msi http request"))
 	if MSIAvailable(context.Background(), c) {
 		t.Fatal("unexpected true")


### PR DESCRIPTION
[This commit](https://github.com/Azure/go-autorest/commit/cbf46deb11b50a1bc9ac059f430c647493829459) allows MSI token acquisition to fail fast. However this flow [swallows the real error](https://github.com/Azure/go-autorest/commit/cbf46deb11b50a1bc9ac059f430c647493829459#diff-104007a705afedbaf9fd03870136bd96R946) unlike the other code paths. This PR bubbles the error up for users.

As `MSIAvailable` is publicly exported, I've avoided changing the external signature and relied on the existing tests. Happy to add some unit tests if you like.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [x] I've tested my changes, adding unit tests if applicable.
 - [x] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.

