### PR TITLE
Ensure query parameters are properly encoded

### DIFF
--- a/autorest/preparer_test.go
+++ b/autorest/preparer_test.go
@@ -404,6 +404,18 @@ func TestCreatePreparerRunsDecoratorsInOrder(t *testing.T) {
 	}
 }
 
+func TestWithBaseURLEncodeQueryParams(t *testing.T) {
+	p := CreatePreparer(WithBaseURL("https://contoso.com/path?$qp1=something/else&$qp2=do/this"))
+	r, err := p.Prepare(&http.Request{})
+	if err != nil {
+		t.Fatalf("autorest: CreatePreparer failed (%v)", err)
+	}
+	want := "https://contoso.com/path?%24qp1=something%2Felse&%24qp2=do%2Fthis"
+	if u := r.URL.String(); u != want {
+		t.Fatalf("unexpected URL, got %s, want %s", u, want)
+	}
+}
+
 func TestAsContentType(t *testing.T) {
 	r, err := Prepare(mocks.NewRequest(), AsContentType("application/text"))
 	if err != nil {


### PR DESCRIPTION
In autorest.WithBaseURL(), encode any query parameters.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.