### PR TITLE
Remove runtime dependency on jwt-go

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -33,20 +33,20 @@
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:76dc72490af7174349349838f2fe118996381b31ea83243812a97e5a0fd5ed55"
-  name = "github.com/dgrijalva/jwt-go"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "06ea1031745cb8b3dab3f6a236daf2b0aa468b7e"
-  version = "v3.2.0"
-
-[[projects]]
   digest = "1:cf0d2e435fd4ce45b789e93ef24b5f08e86be0e9807a16beb3694e2d8c9af965"
   name = "github.com/dimchansky/utfbom"
   packages = ["."]
   pruneopts = "UT"
   revision = "d2133a1ce379ef6fa992b0514a77146c60db9d1c"
   version = "v1.1.0"
+
+[[projects]]
+  digest = "1:3be7b7206a3fd8686175fd974eb33a1c9dd109c149bdf19801e32b8f48733530"
+  name = "github.com/form3tech-oss/jwt-go"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "9162a5abdbc046b7c8b03ee90052cee67e25caa7"
+  version = "v3.2.2"
 
 [[projects]]
   branch = "master"
@@ -309,8 +309,8 @@
   analyzer-version = 1
   input-imports = [
     "contrib.go.opencensus.io/exporter/ocagent",
-    "github.com/dgrijalva/jwt-go",
     "github.com/dimchansky/utfbom",
+    "github.com/form3tech-oss/jwt-go",
     "github.com/mitchellh/go-homedir",
     "github.com/stretchr/testify/require",
     "go.opencensus.io/plugin/ochttp",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -35,10 +35,6 @@ required = ["golang.org/x/lint/golint"]
   version = "0.6.0"
 
 [[constraint]]
-  name = "github.com/dgrijalva/jwt-go"
-  version = "3.2.0"
-
-[[constraint]]
   name = "github.com/dimchansky/utfbom"
   version = "1.1.0"
 
@@ -57,3 +53,7 @@ required = ["golang.org/x/lint/golint"]
 [[constraint]]
   branch = "master"
   name = "golang.org/x/crypto"
+
+[[constraint]]
+  name = "github.com/form3tech-oss/jwt-go"
+  version = "3.2.2"

--- a/autorest/adal/go.mod
+++ b/autorest/adal/go.mod
@@ -8,5 +8,5 @@ require (
 	github.com/Azure/go-autorest/autorest/mocks v0.4.1
 	github.com/Azure/go-autorest/tracing v0.6.0
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
-	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+	golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0
 )

--- a/autorest/adal/go.mod
+++ b/autorest/adal/go.mod
@@ -7,6 +7,6 @@ require (
 	github.com/Azure/go-autorest/autorest/date v0.3.0
 	github.com/Azure/go-autorest/autorest/mocks v0.4.1
 	github.com/Azure/go-autorest/tracing v0.6.0
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/form3tech-oss/jwt-go v3.2.2+incompatible
 	golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0
 )

--- a/autorest/adal/go.sum
+++ b/autorest/adal/go.sum
@@ -6,8 +6,8 @@ github.com/Azure/go-autorest/autorest/mocks v0.4.1 h1:K0laFcLE6VLTOwNgSxaGbUcLPu
 github.com/Azure/go-autorest/autorest/mocks v0.4.1/go.mod h1:LTp+uSrOhSkaKrUy935gNZuuIPPVsHlr9DSOxSayd+k=
 github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUMfuitfgcfuo=
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/form3tech-oss/jwt-go v3.2.2+incompatible h1:TcekIExNqud5crz4xD2pavyTgWiPvpYe4Xau31I0PRk=
+github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0 h1:hb9wdF1z5waM+dSIICn1l0DkLVDT3hqhhQsDNUmHPRE=

--- a/autorest/adal/go.sum
+++ b/autorest/adal/go.sum
@@ -10,8 +10,8 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumC
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
-golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
-golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0 h1:hb9wdF1z5waM+dSIICn1l0DkLVDT3hqhhQsDNUmHPRE=
+golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv3hCI0z56oJR5vAMgBU=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/autorest/adal/token.go
+++ b/autorest/adal/token.go
@@ -16,9 +16,11 @@ package adal
 
 import (
 	"context"
+	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha1"
+	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
@@ -35,7 +37,6 @@ import (
 	"time"
 
 	"github.com/Azure/go-autorest/autorest/date"
-	"github.com/dgrijalva/jwt-go"
 )
 
 const (
@@ -245,11 +246,20 @@ func (secret *ServicePrincipalCertificateSecret) SignJwt(spt *ServicePrincipalTo
 		return "", err
 	}
 
-	token := jwt.New(jwt.SigningMethodRS256)
-	token.Header["x5t"] = thumbprint
-	x5c := []string{base64.StdEncoding.EncodeToString(secret.Certificate.Raw)}
-	token.Header["x5c"] = x5c
-	token.Claims = jwt.MapClaims{
+	tokenHeader := map[string]interface{}{
+		"typ": "JWT",
+		"alg": "RS256",
+		"x5t": thumbprint,
+		"x5c": []string{base64.StdEncoding.EncodeToString(secret.Certificate.Raw)},
+	}
+
+	headerJSON, err := json.Marshal(tokenHeader)
+	if err != nil {
+		return "", fmt.Errorf("marshal header: %v", err)
+	}
+	header := base64.RawURLEncoding.EncodeToString(headerJSON)
+
+	tokenClaims := map[string]interface{}{
 		"aud": spt.inner.OauthConfig.TokenEndpoint.String(),
 		"iss": spt.inner.ClientID,
 		"sub": spt.inner.ClientID,
@@ -258,8 +268,21 @@ func (secret *ServicePrincipalCertificateSecret) SignJwt(spt *ServicePrincipalTo
 		"exp": time.Now().Add(24 * time.Hour).Unix(),
 	}
 
-	signedString, err := token.SignedString(secret.PrivateKey)
-	return signedString, err
+	claimsJSON, err := json.Marshal(tokenClaims)
+	if err != nil {
+		return "", fmt.Errorf("marshal claims: %v", err)
+	}
+	claims := base64.RawURLEncoding.EncodeToString(claimsJSON)
+	result := header + "." + claims
+	hashedSum := sha256.Sum256([]byte(result))
+
+	signed, err := rsa.SignPKCS1v15(rand.Reader, secret.PrivateKey, crypto.SHA256, hashedSum[:])
+	if err != nil {
+		return "", fmt.Errorf("signing: %v", err)
+	}
+	signature := base64.RawURLEncoding.EncodeToString(signed)
+
+	return result + "." + signature, nil
 }
 
 // SetAuthenticationValues is a method of the interface ServicePrincipalSecret.

--- a/autorest/adal/token_test.go
+++ b/autorest/adal/token_test.go
@@ -420,6 +420,22 @@ func TestServicePrincipalTokenCertficateRefreshSetsBody(t *testing.T) {
 		if _, ok := tok.Header["x5c"]; !ok {
 			t.Fatalf("adal: ServicePrincipalTokenCertificate#Expected client_assertion to have an x5c header")
 		}
+		claims, ok := tok.Claims.(jwt.MapClaims)
+		if !ok {
+			t.Fatalf("expected MapClaims, got %T", tok.Claims)
+		}
+		if err := claims.Valid(); err != nil {
+			t.Fatalf("invalid claim: %v", err)
+		}
+		if aud := claims["aud"]; aud != "https://login.test.com/SomeTenantID/oauth2/token?api-version=1.0" {
+			t.Fatalf("unexpected aud: %s", aud)
+		}
+		if iss := claims["iss"]; iss != "id" {
+			t.Fatalf("unexpected iss: %s", iss)
+		}
+		if sub := claims["sub"]; sub != "id" {
+			t.Fatalf("unexpected sub: %s", sub)
+		}
 	})
 }
 

--- a/autorest/adal/token_test.go
+++ b/autorest/adal/token_test.go
@@ -36,7 +36,7 @@ import (
 
 	"github.com/Azure/go-autorest/autorest/date"
 	"github.com/Azure/go-autorest/autorest/mocks"
-	jwt "github.com/dgrijalva/jwt-go"
+	jwt "github.com/form3tech-oss/jwt-go"
 )
 
 const (


### PR DESCRIPTION
There's a security issue in jwt-go and the project appears to be
abandoned.  While we don't use the vulnerable functionality, it's easier
to simply remove our dependency.
Note that jwt-go is still used as part of tests.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.