### PR TITLE
Walk error chain when checking for TokenRefreshError

### DIFF
--- a/autorest/adal/token.go
+++ b/autorest/adal/token.go
@@ -1165,46 +1165,6 @@ func (mt *MultiTenantServicePrincipalToken) AuxiliaryOAuthTokens() []string {
 	return tokens
 }
 
-// EnsureFreshWithContext will refresh the token if it will expire within the refresh window (as set by
-// RefreshWithin) and autoRefresh flag is on.  This method is safe for concurrent use.
-func (mt *MultiTenantServicePrincipalToken) EnsureFreshWithContext(ctx context.Context) error {
-	if err := mt.PrimaryToken.EnsureFreshWithContext(ctx); err != nil {
-		return fmt.Errorf("failed to refresh primary token: %v", err)
-	}
-	for _, aux := range mt.AuxiliaryTokens {
-		if err := aux.EnsureFreshWithContext(ctx); err != nil {
-			return fmt.Errorf("failed to refresh auxiliary token: %v", err)
-		}
-	}
-	return nil
-}
-
-// RefreshWithContext obtains a fresh token for the Service Principal.
-func (mt *MultiTenantServicePrincipalToken) RefreshWithContext(ctx context.Context) error {
-	if err := mt.PrimaryToken.RefreshWithContext(ctx); err != nil {
-		return fmt.Errorf("failed to refresh primary token: %v", err)
-	}
-	for _, aux := range mt.AuxiliaryTokens {
-		if err := aux.RefreshWithContext(ctx); err != nil {
-			return fmt.Errorf("failed to refresh auxiliary token: %v", err)
-		}
-	}
-	return nil
-}
-
-// RefreshExchangeWithContext refreshes the token, but for a different resource.
-func (mt *MultiTenantServicePrincipalToken) RefreshExchangeWithContext(ctx context.Context, resource string) error {
-	if err := mt.PrimaryToken.RefreshExchangeWithContext(ctx, resource); err != nil {
-		return fmt.Errorf("failed to refresh primary token: %v", err)
-	}
-	for _, aux := range mt.AuxiliaryTokens {
-		if err := aux.RefreshExchangeWithContext(ctx, resource); err != nil {
-			return fmt.Errorf("failed to refresh auxiliary token: %v", err)
-		}
-	}
-	return nil
-}
-
 // NewMultiTenantServicePrincipalToken creates a new MultiTenantServicePrincipalToken with the specified credentials and resource.
 func NewMultiTenantServicePrincipalToken(multiTenantCfg MultiTenantOAuthConfig, clientID string, secret string, resource string) (*MultiTenantServicePrincipalToken, error) {
 	if err := validateStringParam(clientID, "clientID"); err != nil {

--- a/autorest/adal/token_1.13.go
+++ b/autorest/adal/token_1.13.go
@@ -18,6 +18,7 @@ package adal
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"time"
 )
@@ -33,4 +34,44 @@ func getMSIEndpoint(ctx context.Context, sender Sender) (*http.Response, error) 
 	q.Add("api-version", msiAPIVersion)
 	req.URL.RawQuery = q.Encode()
 	return sender.Do(req)
+}
+
+// EnsureFreshWithContext will refresh the token if it will expire within the refresh window (as set by
+// RefreshWithin) and autoRefresh flag is on.  This method is safe for concurrent use.
+func (mt *MultiTenantServicePrincipalToken) EnsureFreshWithContext(ctx context.Context) error {
+	if err := mt.PrimaryToken.EnsureFreshWithContext(ctx); err != nil {
+		return fmt.Errorf("failed to refresh primary token: %w", err)
+	}
+	for _, aux := range mt.AuxiliaryTokens {
+		if err := aux.EnsureFreshWithContext(ctx); err != nil {
+			return fmt.Errorf("failed to refresh auxiliary token: %w", err)
+		}
+	}
+	return nil
+}
+
+// RefreshWithContext obtains a fresh token for the Service Principal.
+func (mt *MultiTenantServicePrincipalToken) RefreshWithContext(ctx context.Context) error {
+	if err := mt.PrimaryToken.RefreshWithContext(ctx); err != nil {
+		return fmt.Errorf("failed to refresh primary token: %w", err)
+	}
+	for _, aux := range mt.AuxiliaryTokens {
+		if err := aux.RefreshWithContext(ctx); err != nil {
+			return fmt.Errorf("failed to refresh auxiliary token: %w", err)
+		}
+	}
+	return nil
+}
+
+// RefreshExchangeWithContext refreshes the token, but for a different resource.
+func (mt *MultiTenantServicePrincipalToken) RefreshExchangeWithContext(ctx context.Context, resource string) error {
+	if err := mt.PrimaryToken.RefreshExchangeWithContext(ctx, resource); err != nil {
+		return fmt.Errorf("failed to refresh primary token: %w", err)
+	}
+	for _, aux := range mt.AuxiliaryTokens {
+		if err := aux.RefreshExchangeWithContext(ctx, resource); err != nil {
+			return fmt.Errorf("failed to refresh auxiliary token: %w", err)
+		}
+	}
+	return nil
 }

--- a/autorest/error.go
+++ b/autorest/error.go
@@ -96,3 +96,8 @@ func (e DetailedError) Error() string {
 	}
 	return fmt.Sprintf("%s#%s: %s: StatusCode=%d -- Original Error: %v", e.PackageType, e.Method, e.Message, e.StatusCode, e.Original)
 }
+
+// Unwrap returns the original error.
+func (e DetailedError) Unwrap() error {
+	return e.Original
+}

--- a/autorest/utility.go
+++ b/autorest/utility.go
@@ -26,8 +26,6 @@ import (
 	"net/url"
 	"reflect"
 	"strings"
-
-	"github.com/Azure/go-autorest/autorest/adal"
 )
 
 // EncodedAs is a series of constants specifying various data encodings
@@ -205,18 +203,6 @@ func ChangeToGet(req *http.Request) *http.Request {
 	req.ContentLength = 0
 	req.Header.Del("Content-Length")
 	return req
-}
-
-// IsTokenRefreshError returns true if the specified error implements the TokenRefreshError
-// interface.  If err is a DetailedError it will walk the chain of Original errors.
-func IsTokenRefreshError(err error) bool {
-	if _, ok := err.(adal.TokenRefreshError); ok {
-		return true
-	}
-	if de, ok := err.(DetailedError); ok {
-		return IsTokenRefreshError(de.Original)
-	}
-	return false
 }
 
 // IsTemporaryNetworkError returns true if the specified error is a temporary network error or false

--- a/autorest/utility_1.13.go
+++ b/autorest/utility_1.13.go
@@ -1,0 +1,29 @@
+// +build go1.13
+
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package autorest
+
+import (
+	"errors"
+
+	"github.com/Azure/go-autorest/autorest/adal"
+)
+
+// IsTokenRefreshError returns true if the specified error implements the TokenRefreshError interface.
+func IsTokenRefreshError(err error) bool {
+	var tre adal.TokenRefreshError
+	return errors.As(err, &tre)
+}

--- a/autorest/utility_1.13_test.go
+++ b/autorest/utility_1.13_test.go
@@ -1,0 +1,33 @@
+// +build go1.13
+
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package autorest
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestIsTokenRefreshErrorWrapped(t *testing.T) {
+	err := fmt.Errorf("wrapped TRE %w", tokenRefreshError{})
+	if !IsTokenRefreshError(err) {
+		t.Fatal("expected a wrapped TokenRefreshError")
+	}
+	err = NewErrorWithError(fmt.Errorf("wrapped TRE %w", tokenRefreshError{}), "package", "method", nil, "failed")
+	if !IsTokenRefreshError(err) {
+		t.Fatal("expected a double-wrapped TokenRefreshError")
+	}
+}

--- a/autorest/utility_legacy.go
+++ b/autorest/utility_legacy.go
@@ -1,0 +1,31 @@
+// +build !go1.13
+
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package autorest
+
+import "github.com/Azure/go-autorest/autorest/adal"
+
+// IsTokenRefreshError returns true if the specified error implements the TokenRefreshError
+// interface.  If err is a DetailedError it will walk the chain of Original errors.
+func IsTokenRefreshError(err error) bool {
+	if _, ok := err.(adal.TokenRefreshError); ok {
+		return true
+	}
+	if de, ok := err.(DetailedError); ok {
+		return IsTokenRefreshError(de.Original)
+	}
+	return false
+}


### PR DESCRIPTION
The refresh methods on MultiTenantServicePrincipalToken didn't properly
wrap the inner error, so as a result the check for TokenRefreshError
would fail leading to retries on a credential that would always fail.
Updated the methods to use %w to wrap the error.
Added Unwrap() method to DetailedError
Updated IsTokenRefreshError() to use errors.As() to walk the error
chain.
Legacy versions for consumers on earlier versions of Go have been
provided.  In these implementations the TokenRefreshError isn't wrapped
to avoid the hang at a loss of error information.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.