### PR TITLE
Fix parsing of expires_on

### DIFF
--- a/autorest/adal/token_test.go
+++ b/autorest/adal/token_test.go
@@ -87,6 +87,52 @@ func TestTokenWillExpireIn(t *testing.T) {
 	}
 }
 
+func TestParseExpiresOn(t *testing.T) {
+	// get current time, round to nearest second, and add one hour
+	n := time.Now().UTC().Round(time.Second).Add(time.Hour)
+	amPM := "AM"
+	if n.Hour() > 12 {
+		amPM = "PM"
+	}
+	testcases := []struct {
+		Name   string
+		String string
+		Value  int64
+	}{
+		{
+			Name:   "integer",
+			String: "3600",
+			Value:  3600,
+		},
+		{
+			Name:   "timestamp with AM/PM",
+			String: fmt.Sprintf("%d/%d/%d %d:%02d:%02d %s +00:00", n.Month(), n.Day(), n.Year(), n.Hour(), n.Minute(), n.Second(), amPM),
+			Value:  3600,
+		},
+		{
+			Name:   "timestamp without AM/PM",
+			String: fmt.Sprintf("%d/%d/%d %d:%02d:%02d +00:00", n.Month(), n.Day(), n.Year(), n.Hour(), n.Minute(), n.Second()),
+			Value:  3600,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.Name, func(subT *testing.T) {
+			jn, err := parseExpiresOn(tc.String)
+			if err != nil {
+				subT.Error(err)
+			}
+			i, err := jn.Int64()
+			if err != nil {
+				subT.Error(err)
+			}
+			if i != tc.Value {
+				subT.Logf("expected %d, got %d", tc.Value, i)
+				subT.Fail()
+			}
+		})
+	}
+}
+
 func TestServicePrincipalTokenSetAutoRefresh(t *testing.T) {
 	spt := newServicePrincipalToken()
 


### PR DESCRIPTION
Handle expires_on time stamps that omit an AM/PM designation.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.