### PR TITLE
Handle empty expires_on

### DIFF
--- a/autorest/adal/token_test.go
+++ b/autorest/adal/token_test.go
@@ -114,12 +114,21 @@ func TestParseExpiresOn(t *testing.T) {
 			String: fmt.Sprintf("%d/%d/%d %d:%02d:%02d +00:00", n.Month(), n.Day(), n.Year(), n.Hour(), n.Minute(), n.Second()),
 			Value:  3600,
 		},
+		{
+			Name:   "empty",
+			String: "",
+			Value:  0,
+		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(subT *testing.T) {
 			jn, err := parseExpiresOn(tc.String)
 			if err != nil {
 				subT.Error(err)
+			}
+			if jn.String() == "" && tc.String == "" {
+				// empty case, exit early
+				return
 			}
 			i, err := jn.Int64()
 			if err != nil {

--- a/autorest/adal/token_test.go
+++ b/autorest/adal/token_test.go
@@ -114,21 +114,12 @@ func TestParseExpiresOn(t *testing.T) {
 			String: fmt.Sprintf("%d/%d/%d %d:%02d:%02d +00:00", n.Month(), n.Day(), n.Year(), n.Hour(), n.Minute(), n.Second()),
 			Value:  3600,
 		},
-		{
-			Name:   "empty",
-			String: "",
-			Value:  0,
-		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(subT *testing.T) {
 			jn, err := parseExpiresOn(tc.String)
 			if err != nil {
 				subT.Error(err)
-			}
-			if jn.String() == "" && tc.String == "" {
-				// empty case, exit early
-				return
 			}
 			i, err := jn.Int64()
 			if err != nil {
@@ -389,6 +380,69 @@ func TestServicePrincipalTokenFromASE(t *testing.T) {
 	const hourInSeconds = int64(time.Hour / time.Second)
 	if v > hourInSeconds || v < hourInSeconds-1 {
 		t.Fatalf("adal: expected %v, got %v", int64(time.Hour/time.Second), v)
+	}
+	if body.IsOpen() {
+		t.Fatalf("the response was not closed!")
+	}
+}
+
+func TestServicePrincipalTokenFromADFS(t *testing.T) {
+	os.Setenv("MSI_ENDPOINT", "http://localhost")
+	os.Setenv("MSI_SECRET", "super")
+	defer func() {
+		os.Unsetenv("MSI_ENDPOINT")
+		os.Unsetenv("MSI_SECRET")
+	}()
+	resource := "https://resource"
+	endpoint, _ := GetMSIEndpoint()
+	spt, err := NewServicePrincipalTokenFromMSI(endpoint, resource)
+	if err != nil {
+		t.Fatalf("Failed to get MSI SPT: %v", err)
+	}
+	spt.MaxMSIRefreshAttempts = 1
+	const expiresIn = 3600
+	body := mocks.NewBody(newADFSTokenJSON(expiresIn))
+	resp := mocks.NewResponseWithBodyAndStatus(body, http.StatusOK, "OK")
+
+	c := mocks.NewSender()
+	s := DecorateSender(c,
+		(func() SendDecorator {
+			return func(s Sender) Sender {
+				return SenderFunc(func(r *http.Request) (*http.Response, error) {
+					if r.Method != "GET" {
+						t.Fatalf("adal: ServicePrincipalToken#Refresh did not correctly set HTTP method -- expected %v, received %v", "GET", r.Method)
+					}
+					if h := r.Header.Get(metadataHeader); h != "" {
+						t.Fatalf("adal: ServicePrincipalToken#Refresh incorrectly set Metadata header for ASE")
+					}
+					if s := r.Header.Get(secretHeader); s != "super" {
+						t.Fatalf("adal: unexpected secret header value %s", s)
+					}
+					if r.URL.Host != "localhost" {
+						t.Fatalf("adal: unexpected host %s", r.URL.Host)
+					}
+					qp := r.URL.Query()
+					if api := qp.Get("api-version"); api != appServiceAPIVersion {
+						t.Fatalf("adal: unexpected api-version %s", api)
+					}
+					return resp, nil
+				})
+			}
+		})())
+	spt.SetSender(s)
+	err = spt.Refresh()
+	if err != nil {
+		t.Fatalf("adal: ServicePrincipalToken#Refresh returned an unexpected error (%v)", err)
+	}
+	i, err := spt.inner.Token.ExpiresIn.Int64()
+	if err != nil {
+		t.Fatalf("unexpected parsing of expires_in: %v", err)
+	}
+	if i != expiresIn {
+		t.Fatalf("unexpected expires_in %d", i)
+	}
+	if spt.inner.Token.ExpiresOn.String() != "" {
+		t.Fatal("expected empty expires_on")
 	}
 	if body.IsOpen() {
 		t.Fatalf("the response was not closed!")
@@ -1291,6 +1345,15 @@ func newTokenJSON(expiresIn, expiresOn, resource string) string {
 		"refresh_token": "ABC123"
 		}`,
 		expiresIn, expiresOn, nb, resource)
+}
+
+func newADFSTokenJSON(expiresIn int) string {
+	return fmt.Sprintf(`{
+		"access_token" : "accessToken",
+		"expires_in"   : %d,
+		"token_type"   : "Bearer"
+		}`,
+		expiresIn)
 }
 
 func newTokenExpiresIn(expireIn time.Duration) *Token {


### PR DESCRIPTION
ADFS can return an empty expires_on, handle it.
Return a TokenRefreshError when failing to parse a token response.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
 - [ ] I'm submitting this PR to the `dev` branch, except in the case of urgent bug fixes warranting their own release.
 - [ ] If I'm targeting `master`, I've updated [CHANGELOG.md](https://github.com/Azure/go-autorest/blob/master/CHANGELOG.md) to address the changes I'm making.