### PR TITLE
Implementation of factory pattern for create http transports (senders)

### DIFF
--- a/autorest/preparer.go
+++ b/autorest/preparer.go
@@ -127,7 +127,7 @@ func WithHeader(header string, value string) PrepareDecorator {
 		return PreparerFunc(func(r *http.Request) (*http.Request, error) {
 			r, err := p.Prepare(r)
 			if err == nil {
-				setHeader(r, http.CanonicalHeaderKey(header), value)
+				SetHeader(r, http.CanonicalHeaderKey(header), value)
 			}
 			return r, err
 		})
@@ -292,7 +292,7 @@ func WithFormData(v url.Values) PrepareDecorator {
 			if err == nil {
 				s := v.Encode()
 
-				setHeader(r, http.CanonicalHeaderKey(headerContentType), mimeTypeFormPost)
+				SetHeader(r, http.CanonicalHeaderKey(headerContentType), mimeTypeFormPost)
 				r.ContentLength = int64(len(s))
 				r.Body = ioutil.NopCloser(strings.NewReader(s))
 			}
@@ -328,7 +328,7 @@ func WithMultiPartFormData(formDataParameters map[string]interface{}) PrepareDec
 				if err = writer.Close(); err != nil {
 					return r, err
 				}
-				setHeader(r, http.CanonicalHeaderKey(headerContentType), writer.FormDataContentType())
+				SetHeader(r, http.CanonicalHeaderKey(headerContentType), writer.FormDataContentType())
 				r.Body = ioutil.NopCloser(bytes.NewReader(body.Bytes()))
 				r.ContentLength = int64(body.Len())
 				return r, err
@@ -433,7 +433,7 @@ func WithXML(v interface{}) PrepareDecorator {
 					bytesWithHeader := []byte(withHeader)
 
 					r.ContentLength = int64(len(bytesWithHeader))
-					setHeader(r, headerContentLength, fmt.Sprintf("%d", len(bytesWithHeader)))
+					SetHeader(r, headerContentLength, fmt.Sprintf("%d", len(bytesWithHeader)))
 					r.Body = ioutil.NopCloser(bytes.NewReader(bytesWithHeader))
 				}
 			}

--- a/autorest/sender.go
+++ b/autorest/sender.go
@@ -124,30 +124,49 @@ func SendWithSender(s Sender, r *http.Request, decorators ...SendDecorator) (*ht
 	return DecorateSender(s, decorators...).Do(r)
 }
 
+// SenderFactory creates a sender instance
+type SenderFactory func(renengotiation tls.RenegotiationSupport) (*http.Client, error)
+
+// DefaultSenderFactory creates a sender instance suitable for Azure
+func DefaultSenderFactory(renengotiation tls.RenegotiationSupport) (*http.Client, error) {
+	// Use behaviour compatible with DefaultTransport, but require TLS minimum version.
+	defaultTransport := http.DefaultTransport.(*http.Transport)
+	transport := &http.Transport{
+		Proxy:                 defaultTransport.Proxy,
+		DialContext:           defaultTransport.DialContext,
+		MaxIdleConns:          defaultTransport.MaxIdleConns,
+		IdleConnTimeout:       defaultTransport.IdleConnTimeout,
+		TLSHandshakeTimeout:   defaultTransport.TLSHandshakeTimeout,
+		ExpectContinueTimeout: defaultTransport.ExpectContinueTimeout,
+		TLSClientConfig: &tls.Config{
+			MinVersion:    tls.VersionTLS12,
+			Renegotiation: renengotiation,
+		},
+	}
+	var roundTripper http.RoundTripper = transport
+	if tracing.IsEnabled() {
+		roundTripper = tracing.NewTransport(transport)
+	}
+	j, err := cookiejar.New(nil)
+	if err != nil {
+		return nil, err
+	}
+	return &http.Client{Jar: j, Transport: roundTripper}, nil
+}
+
+// SenderFactoryInstance used to a create a sender instance
+var SenderFactoryInstance SenderFactory = DefaultSenderFactory
+
 func sender(renengotiation tls.RenegotiationSupport) Sender {
 	// note that we can't init defaultSenders in init() since it will
 	// execute before calling code has had a chance to enable tracing
 	defaultSenders[renengotiation].init.Do(func() {
 		// Use behaviour compatible with DefaultTransport, but require TLS minimum version.
-		defaultTransport := http.DefaultTransport.(*http.Transport)
-		transport := &http.Transport{
-			Proxy:                 defaultTransport.Proxy,
-			DialContext:           defaultTransport.DialContext,
-			MaxIdleConns:          defaultTransport.MaxIdleConns,
-			IdleConnTimeout:       defaultTransport.IdleConnTimeout,
-			TLSHandshakeTimeout:   defaultTransport.TLSHandshakeTimeout,
-			ExpectContinueTimeout: defaultTransport.ExpectContinueTimeout,
-			TLSClientConfig: &tls.Config{
-				MinVersion:    tls.VersionTLS12,
-				Renegotiation: renengotiation,
-			},
+		sender, err := SenderFactoryInstance(renengotiation)
+		if err != nil {
+			panic(fmt.Errorf("Failed to initialize sender instance: %v", err))
 		}
-		var roundTripper http.RoundTripper = transport
-		if tracing.IsEnabled() {
-			roundTripper = tracing.NewTransport(transport)
-		}
-		j, _ := cookiejar.New(nil)
-		defaultSenders[renengotiation].sender = &http.Client{Jar: j, Transport: roundTripper}
+		defaultSenders[renengotiation].sender = sender
 	})
 	return defaultSenders[renengotiation].sender
 }

--- a/autorest/utility.go
+++ b/autorest/utility.go
@@ -224,7 +224,8 @@ func DrainResponseBody(resp *http.Response) error {
 	return nil
 }
 
-func setHeader(r *http.Request, key, value string) {
+// SetHeader safely sets a header value for a HTTP request
+func SetHeader(r *http.Request, key, value string) {
 	if r.Header == nil {
 		r.Header = make(http.Header)
 	}


### PR DESCRIPTION
## Assertions

 - [ ] ~~I've tested my changes, adding unit tests if applicable.~~ (No new functionality to test)
 - [ ] ~~I've added Apache 2.0 Headers to the top of any new source files.~~  (New new files added)

## Description

This PR implements the factory pattern to create senders (Go http clients) based on a factory. Users can override the variable `SenderFactoryInstance` to set an own implementation of the factory type `type SenderFactory func(renengotiation tls.RenegotiationSupport) (*http.Client, error)`. 

The original implementation is preserved as `DefaultSenderFactory` which is set as the default implementation of the sender factory.

## Reasoning

While generating a [GO SDK für the REST API of QNAP Virtualization Station (QVS)](https://github.com/tmeckel/qnap-qvs-sdk-for-go) using `autorest` and creating initial [samples](https://github.com/tmeckel/qnap-qvs-sdk-for-go-samples), how to use the SDK and to verify the generated Go API, I faced  three issues which made it hard to get the samples running with `go-autorest`:

1. Most QNAP installations are run with a self-signed certificate
2. QVS uses a dated (legacy) authentication mechanism which returns a session cookie after successful login
3. The CSRF implementation of django (QVS is implemented in Python) requires the `X-CSRFToken` HTTP header to be set on subsequent requests following a login (session start). The value (token) for this header is passed back to the caller after successful login as cookie with name `csrftoken`. (https://docs.djangoproject.com/en/1.11/ref/csrf/)

Whereas the issues around the CSRF issue could be solved (by copying the `csrftoken` to an own cookie jar and setting the header value) using send and respond decorators I found no alternative to circumvent the issue with the self-signed certificate without changing the code in function `sender` in `go-autorest/autorest/sender.go` because there's no way to set `InsecureSkipVerify: true` to skip TLS certificate validation because the current implementation always creates a new `TLSClientConfig: &tls.Config{}` and thus overriding the settings from the `http.DefaultTransport`.

By introducing the factory pattern, so that people can change the way a `http.Client` is created, I was able to provide my own HTTP transports settings that fit the requirements of my local QNAP installation. I addition it reduced the amount of code I had to provide to fulfill the CSRF requirements because I can now use my own (shared) cookieJar.

One question for my own interest: why is the code in `sender.go`, which creates a "duplicate" of the default settings for the http.Transport not using `http.DefaultTransport.(*http.Transport).Clone()` for duplicating the settings but explicitly only copies the settings for selected properties?