### PR TITLE
Handle other ServiceError corner-cases

### DIFF
--- a/autorest/azure/azure.go
+++ b/autorest/azure/azure.go
@@ -92,54 +92,85 @@ func (se ServiceError) Error() string {
 
 // UnmarshalJSON implements the json.Unmarshaler interface for the ServiceError type.
 func (se *ServiceError) UnmarshalJSON(b []byte) error {
-	// per the OData v4 spec the details field must be an array of JSON objects.
-	// unfortunately not all services adhear to the spec and just return a single
-	// object instead of an array with one object.  so we have to perform some
-	// shenanigans to accommodate both cases.
 	// http://docs.oasis-open.org/odata/odata-json-format/v4.0/os/odata-json-format-v4.0-os.html#_Toc372793091
 
-	type serviceError1 struct {
+	type serviceErrorInternal struct {
 		Code           string                   `json:"code"`
 		Message        string                   `json:"message"`
-		Target         *string                  `json:"target"`
-		Details        []map[string]interface{} `json:"details"`
-		InnerError     map[string]interface{}   `json:"innererror"`
-		AdditionalInfo []map[string]interface{} `json:"additionalInfo"`
+		Target         *string                  `json:"target,omitempty"`
+		AdditionalInfo []map[string]interface{} `json:"additionalInfo,omitempty"`
+		// not all services conform to the OData v4 spec.
+		// the following fields are where we've seen discrepancies
+
+		// spec calls for []map[string]interface{} but have seen map[string]interface{}
+		Details interface{} `json:"details,omitempty"`
+
+		// spec calls for map[string]interface{} but have seen []map[string]interface{} and string
+		InnerError interface{} `json:"innererror,omitempty"`
 	}
 
-	type serviceError2 struct {
-		Code           string                   `json:"code"`
-		Message        string                   `json:"message"`
-		Target         *string                  `json:"target"`
-		Details        map[string]interface{}   `json:"details"`
-		InnerError     map[string]interface{}   `json:"innererror"`
-		AdditionalInfo []map[string]interface{} `json:"additionalInfo"`
+	sei := serviceErrorInternal{}
+	if err := json.Unmarshal(b, &sei); err != nil {
+		return err
 	}
 
-	se1 := serviceError1{}
-	err := json.Unmarshal(b, &se1)
-	if err == nil {
-		se.populate(se1.Code, se1.Message, se1.Target, se1.Details, se1.InnerError, se1.AdditionalInfo)
-		return nil
+	// copy the fields we know to be correct
+	se.AdditionalInfo = sei.AdditionalInfo
+	se.Code = sei.Code
+	se.Message = sei.Message
+	se.Target = sei.Target
+
+	// converts an []interface{} to []map[string]interface{}
+	arrayOfObjs := func(v interface{}) ([]map[string]interface{}, bool) {
+		arrayOf, ok := v.([]interface{})
+		if !ok {
+			return nil, false
+		}
+		final := []map[string]interface{}{}
+		for _, item := range arrayOf {
+			as, ok := item.(map[string]interface{})
+			if !ok {
+				return nil, false
+			}
+			final = append(final, as)
+		}
+		return final, true
 	}
 
-	se2 := serviceError2{}
-	err = json.Unmarshal(b, &se2)
-	if err == nil {
-		se.populate(se2.Code, se2.Message, se2.Target, nil, se2.InnerError, se2.AdditionalInfo)
-		se.Details = append(se.Details, se2.Details)
-		return nil
-	}
-	return err
-}
+	// convert the remaining fields, falling back to raw JSON if necessary
 
-func (se *ServiceError) populate(code, message string, target *string, details []map[string]interface{}, inner map[string]interface{}, additional []map[string]interface{}) {
-	se.Code = code
-	se.Message = message
-	se.Target = target
-	se.Details = details
-	se.InnerError = inner
-	se.AdditionalInfo = additional
+	if c, ok := arrayOfObjs(sei.Details); ok {
+		se.Details = c
+	} else if c, ok := sei.Details.(map[string]interface{}); ok {
+		se.Details = []map[string]interface{}{c}
+	} else if sei.Details != nil {
+		// stuff into Details
+		se.Details = []map[string]interface{}{
+			{"raw": sei.Details},
+		}
+	}
+
+	if c, ok := sei.InnerError.(map[string]interface{}); ok {
+		se.InnerError = c
+	} else if c, ok := arrayOfObjs(sei.InnerError); ok {
+		// if there's only one error extract it
+		if len(c) == 1 {
+			se.InnerError = c[0]
+		} else {
+			// multiple errors, stuff them into the value
+			se.InnerError = map[string]interface{}{
+				"multi": c,
+			}
+		}
+	} else if c, ok := sei.InnerError.(string); ok {
+		se.InnerError = map[string]interface{}{c: ""}
+	} else if sei.InnerError != nil {
+		// stuff into InnerError
+		se.InnerError = map[string]interface{}{
+			"raw": sei.InnerError,
+		}
+	}
+	return nil
 }
 
 // RequestError describes an error response returned by Azure service.
@@ -310,7 +341,7 @@ func WithErrorUnlessStatusCode(codes ...int) autorest.RespondDecorator {
 					// Check if error is unwrapped ServiceError
 					decoder := autorest.NewDecoder(encodedAs, bytes.NewReader(b.Bytes()))
 					if err := decoder.Decode(&e.ServiceError); err != nil {
-						return err
+						return fmt.Errorf("autorest/azure: error response cannot be parsed: %q error: %v", b.String(), err)
 					}
 
 					// for example, should the API return the literal value `null` as the response
@@ -333,7 +364,7 @@ func WithErrorUnlessStatusCode(codes ...int) autorest.RespondDecorator {
 					rawBody := map[string]interface{}{}
 					decoder := autorest.NewDecoder(encodedAs, bytes.NewReader(b.Bytes()))
 					if err := decoder.Decode(&rawBody); err != nil {
-						return err
+						return fmt.Errorf("autorest/azure: error response cannot be parsed: %q error: %v", b.String(), err)
 					}
 
 					e.ServiceError = &ServiceError{

--- a/autorest/azure/azure.go
+++ b/autorest/azure/azure.go
@@ -163,7 +163,7 @@ func (se *ServiceError) UnmarshalJSON(b []byte) error {
 			}
 		}
 	} else if c, ok := sei.InnerError.(string); ok {
-		se.InnerError = map[string]interface{}{c: ""}
+		se.InnerError = map[string]interface{}{"error": c}
 	} else if sei.InnerError != nil {
 		// stuff into InnerError
 		se.InnerError = map[string]interface{}{

--- a/autorest/azure/azure_test.go
+++ b/autorest/azure/azure_test.go
@@ -587,7 +587,7 @@ func TestRequestErrorString_WithErrorNonConforming2(t *testing.T) {
 		t.Fatalf("azure: returned nil error for proper error response")
 	}
 	azErr, _ := err.(*RequestError)
-	expected := "autorest/azure: Service returned an error. Status=500 Code=\"InternalError\" Message=\"Conflict\" Details=[{\"code\":\"conflict1\",\"message\":\"error message1\"}] InnerError={\"something bad happened\":\"\"}"
+	expected := "autorest/azure: Service returned an error. Status=500 Code=\"InternalError\" Message=\"Conflict\" Details=[{\"code\":\"conflict1\",\"message\":\"error message1\"}] InnerError={\"error\":\"something bad happened\"}"
 	if expected != azErr.Error() {
 		t.Fatalf("azure: send wrong RequestError.\nexpected=%v\ngot=%v", expected, azErr.Error())
 	}

--- a/autorest/azure/azure_test.go
+++ b/autorest/azure/azure_test.go
@@ -531,11 +531,14 @@ func TestRequestErrorString_WithError(t *testing.T) {
 }
 
 func TestRequestErrorString_WithErrorNonConforming(t *testing.T) {
+	// here details is an object, it should be an array of objects
+	// and innererror is an array of objects (should be one object)
 	j := `{
 		"error": {
 			"code": "InternalError",
 			"message": "Conflict",
-			"details": {"code": "conflict1", "message":"error message1"}
+			"details": {"code": "conflict1", "message":"error message1"},
+			"innererror": [{ "customKey": "customValue" }]
 		}
 	}`
 	uuid := "71FDB9F4-5E49-4C12-B266-DE7B4FD999A6"
@@ -553,9 +556,159 @@ func TestRequestErrorString_WithErrorNonConforming(t *testing.T) {
 		t.Fatalf("azure: returned nil error for proper error response")
 	}
 	azErr, _ := err.(*RequestError)
-	expected := "autorest/azure: Service returned an error. Status=500 Code=\"InternalError\" Message=\"Conflict\" Details=[{\"code\":\"conflict1\",\"message\":\"error message1\"}]"
+	expected := "autorest/azure: Service returned an error. Status=500 Code=\"InternalError\" Message=\"Conflict\" Details=[{\"code\":\"conflict1\",\"message\":\"error message1\"}] InnerError={\"customKey\":\"customValue\"}"
 	if expected != azErr.Error() {
 		t.Fatalf("azure: send wrong RequestError.\nexpected=%v\ngot=%v", expected, azErr.Error())
+	}
+}
+
+func TestRequestErrorString_WithErrorNonConforming2(t *testing.T) {
+	// here innererror is a string (it should be a JSON object)
+	j := `{
+		"error": {
+			"code": "InternalError",
+			"message": "Conflict",
+			"details": {"code": "conflict1", "message":"error message1"},
+			"innererror": "something bad happened"
+		}
+	}`
+	uuid := "71FDB9F4-5E49-4C12-B266-DE7B4FD999A6"
+	r := mocks.NewResponseWithContent(j)
+	mocks.SetResponseHeader(r, HeaderRequestID, uuid)
+	r.Request = mocks.NewRequest()
+	r.StatusCode = http.StatusInternalServerError
+	r.Status = http.StatusText(r.StatusCode)
+
+	err := autorest.Respond(r,
+		WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByClosing())
+
+	if err == nil {
+		t.Fatalf("azure: returned nil error for proper error response")
+	}
+	azErr, _ := err.(*RequestError)
+	expected := "autorest/azure: Service returned an error. Status=500 Code=\"InternalError\" Message=\"Conflict\" Details=[{\"code\":\"conflict1\",\"message\":\"error message1\"}] InnerError={\"something bad happened\":\"\"}"
+	if expected != azErr.Error() {
+		t.Fatalf("azure: send wrong RequestError.\nexpected=%v\ngot=%v", expected, azErr.Error())
+	}
+}
+
+func TestRequestErrorString_WithErrorNonConforming3(t *testing.T) {
+	// here details is an object, it should be an array of objects
+	// and innererror is an array of objects (should be one object)
+	j := `{
+		"error": {
+			"code": "InternalError",
+			"message": "Conflict",
+			"details": {"code": "conflict1", "message":"error message1"},
+			"innererror": [{ "customKey": "customValue" }, { "customKey2": "customValue2" }]
+		}
+	}`
+	uuid := "71FDB9F4-5E49-4C12-B266-DE7B4FD999A6"
+	r := mocks.NewResponseWithContent(j)
+	mocks.SetResponseHeader(r, HeaderRequestID, uuid)
+	r.Request = mocks.NewRequest()
+	r.StatusCode = http.StatusInternalServerError
+	r.Status = http.StatusText(r.StatusCode)
+
+	err := autorest.Respond(r,
+		WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByClosing())
+
+	if err == nil {
+		t.Fatalf("azure: returned nil error for proper error response")
+	}
+	azErr, _ := err.(*RequestError)
+	expected := "autorest/azure: Service returned an error. Status=500 Code=\"InternalError\" Message=\"Conflict\" Details=[{\"code\":\"conflict1\",\"message\":\"error message1\"}] InnerError={\"multi\":[{\"customKey\":\"customValue\"},{\"customKey2\":\"customValue2\"}]}"
+	if expected != azErr.Error() {
+		t.Fatalf("azure: send wrong RequestError.\nexpected=%v\ngot=%v", expected, azErr.Error())
+	}
+}
+
+func TestRequestErrorString_WithErrorNonConforming4(t *testing.T) {
+	// here details is a string, it should be an array of objects
+	j := `{
+		"error": {
+			"code": "InternalError",
+			"message": "Conflict",
+			"details": "something bad happened"
+		}
+	}`
+	uuid := "71FDB9F4-5E49-4C12-B266-DE7B4FD999A6"
+	r := mocks.NewResponseWithContent(j)
+	mocks.SetResponseHeader(r, HeaderRequestID, uuid)
+	r.Request = mocks.NewRequest()
+	r.StatusCode = http.StatusInternalServerError
+	r.Status = http.StatusText(r.StatusCode)
+
+	err := autorest.Respond(r,
+		WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByClosing())
+
+	if err == nil {
+		t.Fatalf("azure: returned nil error for proper error response")
+	}
+	azErr, _ := err.(*RequestError)
+	expected := "autorest/azure: Service returned an error. Status=500 Code=\"InternalError\" Message=\"Conflict\" Details=[{\"raw\":\"something bad happened\"}]"
+	if expected != azErr.Error() {
+		t.Fatalf("azure: send wrong RequestError.\nexpected=%v\ngot=%v", expected, azErr.Error())
+	}
+}
+
+func TestRequestErrorString_WithErrorNonConforming5(t *testing.T) {
+	// here innererror is a number (it should be a JSON object)
+	j := `{
+		"error": {
+			"code": "InternalError",
+			"message": "Conflict",
+			"details": {"code": "conflict1", "message":"error message1"},
+			"innererror": 500
+		}
+	}`
+	uuid := "71FDB9F4-5E49-4C12-B266-DE7B4FD999A6"
+	r := mocks.NewResponseWithContent(j)
+	mocks.SetResponseHeader(r, HeaderRequestID, uuid)
+	r.Request = mocks.NewRequest()
+	r.StatusCode = http.StatusInternalServerError
+	r.Status = http.StatusText(r.StatusCode)
+
+	err := autorest.Respond(r,
+		WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByClosing())
+
+	if err == nil {
+		t.Fatalf("azure: returned nil error for proper error response")
+	}
+	azErr, _ := err.(*RequestError)
+	expected := "autorest/azure: Service returned an error. Status=500 Code=\"InternalError\" Message=\"Conflict\" Details=[{\"code\":\"conflict1\",\"message\":\"error message1\"}] InnerError={\"raw\":500}"
+	if expected != azErr.Error() {
+		t.Fatalf("azure: send wrong RequestError.\nexpected=%v\ngot=%v", expected, azErr.Error())
+	}
+}
+
+func TestRequestErrorString_WithErrorNonConforming6(t *testing.T) {
+	// here code is a number, it should be a string
+	j := `{
+			"code": 409,
+			"message": "Conflict",
+			"details": "something bad happened"
+		}`
+	uuid := "71FDB9F4-5E49-4C12-B266-DE7B4FD999A6"
+	r := mocks.NewResponseWithContent(j)
+	mocks.SetResponseHeader(r, HeaderRequestID, uuid)
+	r.Request = mocks.NewRequest()
+	r.StatusCode = http.StatusInternalServerError
+	r.Status = http.StatusText(r.StatusCode)
+
+	err := autorest.Respond(r,
+		WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByClosing())
+
+	if err == nil {
+		t.Fatalf("azure: returned nil error for proper error response")
+	}
+	if _, ok := err.(*RequestError); ok {
+		t.Fatal("unexpected RequestError when unmarshalling fails")
 	}
 }
 


### PR DESCRIPTION
Improve unmarshalling support for errors that are not OData v4
compliant.
Include raw JSON body when failing to unmarshall into ServiceError.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
