### PR TITLE
Refactor managed identity detection logic

### DIFF
--- a/autorest/adal/go.mod
+++ b/autorest/adal/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Azure/go-autorest v14.2.0+incompatible
 	github.com/Azure/go-autorest/autorest/date v0.3.0
 	github.com/Azure/go-autorest/autorest/mocks v0.4.1
+	github.com/Azure/go-autorest/logger v0.2.0
 	github.com/Azure/go-autorest/tracing v0.6.0
 	github.com/form3tech-oss/jwt-go v3.2.2+incompatible
 	golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0

--- a/autorest/adal/go.sum
+++ b/autorest/adal/go.sum
@@ -4,6 +4,8 @@ github.com/Azure/go-autorest/autorest/date v0.3.0 h1:7gUk1U5M/CQbp9WoqinNzJar+8K
 github.com/Azure/go-autorest/autorest/date v0.3.0/go.mod h1:BI0uouVdmngYNUzGWeSYnokU+TrmwEsOqdt8Y6sso74=
 github.com/Azure/go-autorest/autorest/mocks v0.4.1 h1:K0laFcLE6VLTOwNgSxaGbUcLPuGXlNkbVvq4cW4nIHk=
 github.com/Azure/go-autorest/autorest/mocks v0.4.1/go.mod h1:LTp+uSrOhSkaKrUy935gNZuuIPPVsHlr9DSOxSayd+k=
+github.com/Azure/go-autorest/logger v0.2.0 h1:e4RVHVZKC5p6UANLJHkM4OfR1UKZPj8Wt8Pcx+3oqrE=
+github.com/Azure/go-autorest/logger v0.2.0/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZmbF5NWuPV8+WeEW8=
 github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUMfuitfgcfuo=
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible h1:TcekIExNqud5crz4xD2pavyTgWiPvpYe4Xau31I0PRk=

--- a/autorest/adal/sender.go
+++ b/autorest/adal/sender.go
@@ -28,6 +28,7 @@ const (
 	mimeTypeFormPost = "application/x-www-form-urlencoded"
 )
 
+// DO NOT ACCESS THIS DIRECTLY.  go through sender()
 var defaultSender Sender
 var defaultSenderInit = &sync.Once{}
 

--- a/autorest/adal/token.go
+++ b/autorest/adal/token.go
@@ -36,6 +36,7 @@ import (
 	"time"
 
 	"github.com/Azure/go-autorest/autorest/date"
+	"github.com/Azure/go-autorest/logger"
 	"github.com/form3tech-oss/jwt-go"
 )
 
@@ -799,10 +800,13 @@ func newServicePrincipalTokenFromMSI(msiEndpoint, resource, userAssignedID, iden
 	}
 	msiType, endpoint, err := getMSIType()
 	if err != nil {
+		logger.Instance.Writef(logger.LogError, "Error determining managed identity environment: %v", err)
 		return nil, err
 	}
+	logger.Instance.Writef(logger.LogInfo, "Managed identity environment is %s, endpoint is %s", msiType, endpoint)
 	if msiEndpoint != "" {
 		endpoint = msiEndpoint
+		logger.Instance.Writef(logger.LogInfo, "Managed identity custom endpoint is %s", endpoint)
 	}
 	msiEndpointURL, err := url.Parse(endpoint)
 	if err != nil {

--- a/autorest/adal/token.go
+++ b/autorest/adal/token.go
@@ -778,7 +778,11 @@ type ManagedIdentityOptions struct {
 	IdentityResourceID string
 }
 
-//NewServicePrincipalTokenFromManagedIdentity creates a ServicePrincipalToken using a managed identity.
+// NewServicePrincipalTokenFromManagedIdentity creates a ServicePrincipalToken using a managed identity.
+// It supports the following managed identity environments.
+// - App Service Environment (API version 2017-09-01 only)
+// - Cloud shell
+// - IMDS with a system or user assigned identity
 func NewServicePrincipalTokenFromManagedIdentity(resource string, options *ManagedIdentityOptions, callbacks ...TokenRefreshCallback) (*ServicePrincipalToken, error) {
 	if options == nil {
 		options = &ManagedIdentityOptions{}

--- a/autorest/adal/token.go
+++ b/autorest/adal/token.go
@@ -70,10 +70,16 @@ const (
 	defaultMaxMSIRefreshAttempts = 5
 
 	// asMSIEndpointEnv is the environment variable used to store the endpoint on App Service and Functions
-	asMSIEndpointEnv = "MSI_ENDPOINT"
+	msiEndpointEnv = "MSI_ENDPOINT"
 
 	// asMSISecretEnv is the environment variable used to store the request secret on App Service and Functions
-	asMSISecretEnv = "MSI_SECRET"
+	msiSecretEnv = "MSI_SECRET"
+
+	arcIMDSEndpointEnv = "IMDS_ENDPOINT"
+
+	identityEndpointEnv = "IDENTITY_ENDPOINT"
+
+	identityHeaderEnv = "IDENTITY_HEADER"
 
 	// the API version to use for the App Service MSI endpoint
 	appServiceAPIVersion = "2017-09-01"
@@ -670,15 +676,15 @@ func GetMSIVMEndpoint() (string, error) {
 // NOTE: this only indicates if the ASE environment credentials have been set
 // which does not necessarily mean that the caller is authenticating via ASE!
 func isAppService() bool {
-	_, asMSIEndpointEnvExists := os.LookupEnv(asMSIEndpointEnv)
-	_, asMSISecretEnvExists := os.LookupEnv(asMSISecretEnv)
+	_, asMSIEndpointEnvExists := os.LookupEnv(msiEndpointEnv)
+	_, asMSISecretEnvExists := os.LookupEnv(msiSecretEnv)
 
 	return asMSIEndpointEnvExists && asMSISecretEnvExists
 }
 
 // GetMSIAppServiceEndpoint get the MSI endpoint for App Service and Functions
 func GetMSIAppServiceEndpoint() (string, error) {
-	asMSIEndpoint, asMSIEndpointEnvExists := os.LookupEnv(asMSIEndpointEnv)
+	asMSIEndpoint, asMSIEndpointEnvExists := os.LookupEnv(msiEndpointEnv)
 
 	if asMSIEndpointEnvExists {
 		return asMSIEndpoint, nil
@@ -911,7 +917,7 @@ func (spt *ServicePrincipalToken) refreshInternal(ctx context.Context, resource 
 	req.Header.Add("User-Agent", UserAgent())
 	// Add header when runtime is on App Service or Functions
 	if isASEEndpoint(spt.inner.OauthConfig.TokenEndpoint) {
-		asMSISecret, _ := os.LookupEnv(asMSISecretEnv)
+		asMSISecret, _ := os.LookupEnv(msiSecretEnv)
 		req.Header.Add(secretHeader, asMSISecret)
 	}
 	req = req.WithContext(ctx)

--- a/autorest/adal/token.go
+++ b/autorest/adal/token.go
@@ -932,9 +932,9 @@ func (spt *ServicePrincipalToken) refreshInternal(ctx context.Context, resource 
 	req = req.WithContext(ctx)
 	var resp *http.Response
 	if msiSecret, ok := spt.inner.Secret.(*ServicePrincipalMSISecret); ok {
-		req.Method = http.MethodGet
 		switch msiSecret.msiType {
 		case msiTypeAppServiceV20170901:
+			req.Method = http.MethodGet
 			req.Header.Set("secret", os.Getenv(msiSecretEnv))
 			break
 		case msiTypeCloudShell:
@@ -947,8 +947,10 @@ func (spt *ServicePrincipalToken) refreshInternal(ctx context.Context, resource 
 				data.Set("msi_res_id", msiSecret.clientResourceID)
 			}
 			req.Body = ioutil.NopCloser(strings.NewReader(data.Encode()))
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 			break
 		case msiTypeIMDS:
+			req.Method = http.MethodGet
 			req.Header.Set("Metadata", "true")
 			break
 		}

--- a/autorest/adal/token.go
+++ b/autorest/adal/token.go
@@ -698,7 +698,7 @@ func getMSIType() (msiType, string, error) {
 		}
 		// if ONLY the env var MSI_ENDPOINT is set the msiType is CloudShell
 		return msiTypeCloudShell, endpointEnvVar, nil
-	} else if msiAvailableHook(context.Background(), defaultSender) {
+	} else if msiAvailableHook(context.Background(), sender()) {
 		// if MSI_ENDPOINT is NOT set AND the IMDS endpoint is available the msiType is IMDS. This will timeout after 500 milliseconds
 		return msiTypeIMDS, msiEndpoint, nil
 	} else {

--- a/autorest/adal/token_1.13.go
+++ b/autorest/adal/token_1.13.go
@@ -24,8 +24,6 @@ import (
 )
 
 func getMSIEndpoint(ctx context.Context, sender Sender) (*http.Response, error) {
-	// this cannot fail, the return sig is due to legacy reasons
-	msiEndpoint, _ := GetMSIVMEndpoint()
 	tempCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 	defer cancel()
 	// http.NewRequestWithContext() was added in Go 1.13

--- a/autorest/adal/token_legacy.go
+++ b/autorest/adal/token_legacy.go
@@ -23,8 +23,6 @@ import (
 )
 
 func getMSIEndpoint(ctx context.Context, sender Sender) (*http.Response, error) {
-	// this cannot fail, the return sig is due to legacy reasons
-	msiEndpoint, _ := GetMSIVMEndpoint()
 	tempCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 	defer cancel()
 	req, _ := http.NewRequest(http.MethodGet, msiEndpoint, nil)

--- a/autorest/adal/token_test.go
+++ b/autorest/adal/token_test.go
@@ -360,7 +360,7 @@ func TestServicePrincipalTokenFromASE(t *testing.T) {
 						t.Fatalf("adal: unexpected host %s", r.URL.Host)
 					}
 					qp := r.URL.Query()
-					if api := qp.Get("api-version"); api != appServiceAPIVersion {
+					if api := qp.Get("api-version"); api != appServiceAPIVersion2017 {
 						t.Fatalf("adal: unexpected api-version %s", api)
 					}
 					return resp, nil
@@ -422,7 +422,7 @@ func TestServicePrincipalTokenFromADFS(t *testing.T) {
 						t.Fatalf("adal: unexpected host %s", r.URL.Host)
 					}
 					qp := r.URL.Query()
-					if api := qp.Get("api-version"); api != appServiceAPIVersion {
+					if api := qp.Get("api-version"); api != appServiceAPIVersion2017 {
 						t.Fatalf("adal: unexpected api-version %s", api)
 					}
 					return resp, nil
@@ -1133,7 +1133,7 @@ func TestClientSecretWithASESet(t *testing.T) {
 		os.Unsetenv(msiSecretEnv)
 	}()
 	spt := newServicePrincipalToken()
-	if isIMDS(spt.inner.OauthConfig.TokenEndpoint) {
+	if spt.msi != msiTypeUnavailable {
 		t.Fatal("isIMDS should return false for client secret token even when ASE is enabled")
 	}
 }
@@ -1184,7 +1184,7 @@ func TestMarshalServicePrincipalCertificateSecret(t *testing.T) {
 }
 
 func TestMarshalServicePrincipalMSISecret(t *testing.T) {
-	spt, err := newServicePrincipalTokenFromMSI("http://msiendpoint/", "https://resource", nil, nil)
+	spt, err := newServicePrincipalTokenFromMSI("http://msiendpoint/", "https://resource", "", nil)
 	if err != nil {
 		t.Fatalf("failed to get MSI SPT: %+v", err)
 	}

--- a/autorest/adal/token_test.go
+++ b/autorest/adal/token_test.go
@@ -243,11 +243,8 @@ func TestServicePrincipalTokenRefreshUsesPOST(t *testing.T) {
 	}
 }
 
-func TestServicePrincipalTokenFromMSIRefreshUsesGET(t *testing.T) {
-	resource := "https://resource"
-	cb := func(token Token) error { return nil }
-
-	spt, err := NewServicePrincipalTokenFromMSI("http://msiendpoint/", resource, cb)
+func TestNewServicePrincipalTokenFromManagedIdentity(t *testing.T) {
+	spt, err := NewServicePrincipalTokenFromManagedIdentity("https://resource", nil)
 	if err != nil {
 		t.Fatalf("Failed to get MSI SPT: %v", err)
 	}

--- a/autorest/adal/token_test.go
+++ b/autorest/adal/token_test.go
@@ -91,7 +91,7 @@ func TestParseExpiresOn(t *testing.T) {
 	// get current time, round to nearest second, and add one hour
 	n := time.Now().UTC().Round(time.Second).Add(time.Hour)
 	amPM := "AM"
-	if n.Hour() > 12 {
+	if n.Hour() >= 12 {
 		amPM = "PM"
 	}
 	testcases := []struct {
@@ -1052,7 +1052,7 @@ func TestGetVMEndpoint(t *testing.T) {
 
 func TestGetAppServiceEndpoint(t *testing.T) {
 	const testEndpoint = "http://172.16.1.2:8081/msi/token"
-	if err := os.Setenv(asMSIEndpointEnv, testEndpoint); err != nil {
+	if err := os.Setenv(msiEndpointEnv, testEndpoint); err != nil {
 		t.Fatalf("os.Setenv: %v", err)
 	}
 
@@ -1065,7 +1065,7 @@ func TestGetAppServiceEndpoint(t *testing.T) {
 		t.Fatal("Didn't get correct endpoint")
 	}
 
-	if err := os.Unsetenv(asMSIEndpointEnv); err != nil {
+	if err := os.Unsetenv(msiEndpointEnv); err != nil {
 		t.Fatalf("os.Unsetenv: %v", err)
 	}
 }
@@ -1077,11 +1077,11 @@ func TestGetMSIEndpoint(t *testing.T) {
 	)
 
 	// Test VM well-known endpoint is returned
-	if err := os.Unsetenv(asMSIEndpointEnv); err != nil {
+	if err := os.Unsetenv(msiEndpointEnv); err != nil {
 		t.Fatalf("os.Unsetenv: %v", err)
 	}
 
-	if err := os.Unsetenv(asMSISecretEnv); err != nil {
+	if err := os.Unsetenv(msiSecretEnv); err != nil {
 		t.Fatalf("os.Unsetenv: %v", err)
 	}
 
@@ -1095,11 +1095,11 @@ func TestGetMSIEndpoint(t *testing.T) {
 	}
 
 	// Test App Service endpoint is returned
-	if err := os.Setenv(asMSIEndpointEnv, testEndpoint); err != nil {
+	if err := os.Setenv(msiEndpointEnv, testEndpoint); err != nil {
 		t.Fatalf("os.Setenv: %v", err)
 	}
 
-	if err := os.Setenv(asMSISecretEnv, testSecret); err != nil {
+	if err := os.Setenv(msiSecretEnv, testSecret); err != nil {
 		t.Fatalf("os.Setenv: %v", err)
 	}
 
@@ -1112,25 +1112,25 @@ func TestGetMSIEndpoint(t *testing.T) {
 		t.Fatal("Didn't get correct endpoint")
 	}
 
-	if err := os.Unsetenv(asMSIEndpointEnv); err != nil {
+	if err := os.Unsetenv(msiEndpointEnv); err != nil {
 		t.Fatalf("os.Unsetenv: %v", err)
 	}
 
-	if err := os.Unsetenv(asMSISecretEnv); err != nil {
+	if err := os.Unsetenv(msiSecretEnv); err != nil {
 		t.Fatalf("os.Unsetenv: %v", err)
 	}
 }
 
 func TestClientSecretWithASESet(t *testing.T) {
-	if err := os.Setenv(asMSIEndpointEnv, "http://172.16.1.2:8081/msi/token"); err != nil {
+	if err := os.Setenv(msiEndpointEnv, "http://172.16.1.2:8081/msi/token"); err != nil {
 		t.Fatalf("os.Setenv: %v", err)
 	}
-	if err := os.Setenv(asMSISecretEnv, "the_secret"); err != nil {
+	if err := os.Setenv(msiSecretEnv, "the_secret"); err != nil {
 		t.Fatalf("os.Setenv: %v", err)
 	}
 	defer func() {
-		os.Unsetenv(asMSIEndpointEnv)
-		os.Unsetenv(asMSISecretEnv)
+		os.Unsetenv(msiEndpointEnv)
+		os.Unsetenv(msiSecretEnv)
 	}()
 	spt := newServicePrincipalToken()
 	if isIMDS(spt.inner.OauthConfig.TokenEndpoint) {

--- a/autorest/adal/token_test.go
+++ b/autorest/adal/token_test.go
@@ -372,8 +372,7 @@ func TestServicePrincipalTokenFromASE(t *testing.T) {
 		os.Unsetenv("MSI_SECRET")
 	}()
 	resource := "https://resource"
-	endpoint, _ := GetMSIEndpoint()
-	spt, err := NewServicePrincipalTokenFromMSI(endpoint, resource)
+	spt, err := NewServicePrincipalTokenFromMSI("", resource)
 	if err != nil {
 		t.Fatalf("Failed to get MSI SPT: %v", err)
 	}
@@ -1230,7 +1229,7 @@ func TestMarshalServicePrincipalCertificateSecret(t *testing.T) {
 }
 
 func TestMarshalServicePrincipalMSISecret(t *testing.T) {
-	spt, err := newServicePrincipalTokenFromMSI("http://msiendpoint/", "https://resource", "", nil)
+	spt, err := newServicePrincipalTokenFromMSI("http://msiendpoint/", "https://resource", "", "")
 	if err != nil {
 		t.Fatalf("failed to get MSI SPT: %+v", err)
 	}


### PR DESCRIPTION
This back-ports a portion of the managed identity environment detection logic from `azidentity`.  It does not add support for other managed identity environments that weren't already present in this package.
