### PR TITLE
Add logging for authentication requests/responses

### DIFF
--- a/autorest/adal/go.mod
+++ b/autorest/adal/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Azure/go-autorest v14.2.0+incompatible
 	github.com/Azure/go-autorest/autorest/date v0.3.0
 	github.com/Azure/go-autorest/autorest/mocks v0.4.1
-	github.com/Azure/go-autorest/logger v0.2.0
+	github.com/Azure/go-autorest/logger v0.2.1
 	github.com/Azure/go-autorest/tracing v0.6.0
 	github.com/form3tech-oss/jwt-go v3.2.2+incompatible
 	golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0

--- a/autorest/adal/go.sum
+++ b/autorest/adal/go.sum
@@ -4,8 +4,8 @@ github.com/Azure/go-autorest/autorest/date v0.3.0 h1:7gUk1U5M/CQbp9WoqinNzJar+8K
 github.com/Azure/go-autorest/autorest/date v0.3.0/go.mod h1:BI0uouVdmngYNUzGWeSYnokU+TrmwEsOqdt8Y6sso74=
 github.com/Azure/go-autorest/autorest/mocks v0.4.1 h1:K0laFcLE6VLTOwNgSxaGbUcLPuGXlNkbVvq4cW4nIHk=
 github.com/Azure/go-autorest/autorest/mocks v0.4.1/go.mod h1:LTp+uSrOhSkaKrUy935gNZuuIPPVsHlr9DSOxSayd+k=
-github.com/Azure/go-autorest/logger v0.2.0 h1:e4RVHVZKC5p6UANLJHkM4OfR1UKZPj8Wt8Pcx+3oqrE=
-github.com/Azure/go-autorest/logger v0.2.0/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZmbF5NWuPV8+WeEW8=
+github.com/Azure/go-autorest/logger v0.2.1 h1:IG7i4p/mDa2Ce4TRyAO8IHnVhAVF3RFU+ZtXWSmf4Tg=
+github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZmbF5NWuPV8+WeEW8=
 github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUMfuitfgcfuo=
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible h1:TcekIExNqud5crz4xD2pavyTgWiPvpYe4Xau31I0PRk=

--- a/autorest/adal/token.go
+++ b/autorest/adal/token.go
@@ -966,6 +966,12 @@ func (spt *ServicePrincipalToken) refreshInternal(ctx context.Context, resource 
 	req.Header.Add("User-Agent", UserAgent())
 	req = req.WithContext(ctx)
 	var resp *http.Response
+	authBodyFilter := func(b []byte) []byte {
+		if logger.Level() != logger.LogAuth {
+			return []byte("**REDACTED** authentication body")
+		}
+		return b
+	}
 	if msiSecret, ok := spt.inner.Secret.(*ServicePrincipalMSISecret); ok {
 		switch msiSecret.msiType {
 		case msiTypeAppServiceV20170901:
@@ -989,6 +995,7 @@ func (spt *ServicePrincipalToken) refreshInternal(ctx context.Context, resource 
 			req.Header.Set("Metadata", "true")
 			break
 		}
+		logger.Instance.WriteRequest(req, logger.Filter{Body: authBodyFilter})
 		resp, err = retryForIMDS(spt.sender, req, spt.MaxMSIRefreshAttempts)
 	} else {
 		v := url.Values{}
@@ -1019,6 +1026,7 @@ func (spt *ServicePrincipalToken) refreshInternal(ctx context.Context, resource 
 		req.ContentLength = int64(len(s))
 		req.Header.Set(contentType, mimeTypeFormPost)
 		req.Body = body
+		logger.Instance.WriteRequest(req, logger.Filter{Body: authBodyFilter})
 		resp, err = spt.sender.Do(req)
 	}
 
@@ -1027,6 +1035,7 @@ func (spt *ServicePrincipalToken) refreshInternal(ctx context.Context, resource 
 		return fmt.Errorf("adal: Failed to execute the refresh request. Error = '%v'", err)
 	}
 
+	logger.Instance.WriteResponse(resp, logger.Filter{Body: authBodyFilter})
 	defer resp.Body.Close()
 	rb, err := ioutil.ReadAll(resp.Body)
 


### PR DESCRIPTION
The logging of request/response bodies is explicitly opt-in via the
LogAuth setting, so that LogDebug won't disclose credential data.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
