### PR TITLE
Return an error if resp and err are nil

### DIFF
--- a/autorest/adal/token.go
+++ b/autorest/adal/token.go
@@ -1030,9 +1030,11 @@ func (spt *ServicePrincipalToken) refreshInternal(ctx context.Context, resource 
 		resp, err = spt.sender.Do(req)
 	}
 
+	// don't return a TokenRefreshError here; this will allow retry logic to apply
 	if err != nil {
-		// don't return a TokenRefreshError here; this will allow retry logic to apply
 		return fmt.Errorf("adal: Failed to execute the refresh request. Error = '%v'", err)
+	} else if resp == nil {
+		return fmt.Errorf("adal: received nil response and error")
 	}
 
 	logger.Instance.WriteResponse(resp, logger.Filter{Body: authBodyFilter})


### PR DESCRIPTION
This will allow retry logic to kick in and also avoid up-stream panics
due to both the response and the error being nil.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
