### PR TITLE
Changing default polling interval from 60 to 30

### DIFF
--- a/autorest/client.go
+++ b/autorest/client.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	// DefaultPollingDelay is a reasonable delay between polling requests.
-	DefaultPollingDelay = 60 * time.Second
+	DefaultPollingDelay = 30 * time.Second
 
 	// DefaultPollingDuration is a reasonable total polling duration.
 	DefaultPollingDuration = 15 * time.Minute


### PR DESCRIPTION
Proposing this change following email discussion on making it less conservative. What do you think of this change?

Now it makes me think, can we update the `DefaultRetryDuration` from 30 seconds to 15 seconds if the change above is fine?

---
Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.
As part of submitting, please make sure you can make the following assertions:
 - [X] I've tested my changes, adding unit tests if applicable.
 - [X] I've added Apache 2.0 Headers to the top of any new source files.
