### PR TITLE
Brfole/add retry headers

### DIFF
--- a/autorest/azure/rp.go
+++ b/autorest/azure/rp.go
@@ -32,7 +32,7 @@ func DoRetryWithRegistration(client autorest.Client) autorest.SendDecorator {
 		return autorest.SenderFunc(func(r *http.Request) (resp *http.Response, err error) {
 			rr := autorest.NewRetriableRequest(r)
 			for currentAttempt := 0; currentAttempt < client.RetryAttempts; currentAttempt++ {
-				err = rr.Prepare()
+				err = rr.PrepareWithRetryHeader(currentAttempt)
 				if err != nil {
 					return resp, err
 				}

--- a/autorest/retriablerequest.go
+++ b/autorest/retriablerequest.go
@@ -39,7 +39,7 @@ func (rr *RetriableRequest) Request() *http.Request {
 
 // PrepareWithRetryHeader adds retry attempt headers to the request and
 // signals the request is about to be sent
-func (rr *RetriableRequest) PrepareWithRetryHeader(attempt int) (error) {
+func (rr *RetriableRequest) PrepareWithRetryHeader(attempt int) error {
 	setHeader(rr.req, http.CanonicalHeaderKey(HeaderRetryAttempt), strconv.Itoa(attempt))
 	return rr.Prepare()
 }

--- a/autorest/retriablerequest.go
+++ b/autorest/retriablerequest.go
@@ -19,6 +19,12 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"strconv"
+)
+
+const (
+	// HeaderRetryAttempt is the header
+	HeaderRetryAttempt = "x-retry-attempt"
 )
 
 // NewRetriableRequest returns a wrapper around an HTTP request that support retry logic.
@@ -29,6 +35,13 @@ func NewRetriableRequest(req *http.Request) *RetriableRequest {
 // Request returns the wrapped HTTP request.
 func (rr *RetriableRequest) Request() *http.Request {
 	return rr.req
+}
+
+// PrepareWithRetryHeader adds retry attempt headers to the request and
+// signals the request is about to be sent
+func (rr *RetriableRequest) PrepareWithRetryHeader(attempt int) (error) {
+	setHeader(rr.req, http.CanonicalHeaderKey(HeaderRetryAttempt), strconv.Itoa(attempt))
+	return rr.Prepare()
 }
 
 func (rr *RetriableRequest) prepareFromByteReader() (err error) {

--- a/autorest/retriablerequest.go
+++ b/autorest/retriablerequest.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	// HeaderRetryAttempt is the header
+	// HeaderRetryAttempt is the header containing retry attempt count
 	HeaderRetryAttempt = "x-retry-attempt"
 )
 

--- a/autorest/sender.go
+++ b/autorest/sender.go
@@ -262,7 +262,7 @@ func DoRetryForAttempts(attempts int, backoff time.Duration) SendDecorator {
 		return SenderFunc(func(r *http.Request) (resp *http.Response, err error) {
 			rr := NewRetriableRequest(r)
 			for attempt := 0; attempt < attempts; attempt++ {
-				err = rr.Prepare()
+				err = rr.PrepareWithRetryHeader(attempt)
 				if err != nil {
 					return resp, err
 				}
@@ -314,7 +314,7 @@ func doRetryForStatusCodesImpl(s Sender, r *http.Request, count429 bool, attempt
 	rr := NewRetriableRequest(r)
 	// Increment to add the first call (attempts denotes number of retries)
 	for attempt, delayCount := 0, 0; attempt < attempts+1; {
-		err = rr.Prepare()
+		err = rr.PrepareWithRetryHeader(attempt)
 		if err != nil {
 			return
 		}
@@ -382,7 +382,7 @@ func DoRetryForDuration(d time.Duration, backoff time.Duration) SendDecorator {
 			rr := NewRetriableRequest(r)
 			end := time.Now().Add(d)
 			for attempt := 0; time.Now().Before(end); attempt++ {
-				err = rr.Prepare()
+				err = rr.PrepareWithRetryHeader(attempt)
 				if err != nil {
 					return resp, err
 				}


### PR DESCRIPTION
In an attempt to better understand request failures and monitor for potential networking issues, I've added a retry attempt header to RetriableRequests that addes the retry attempt autorest is currently sending!

Testing succeeds and I was also trying to add verification to sender_tests, but that required editing the mock sender to verify header attempt is equivalent to mock sender attempts and it seems to be its own module.  Would that require separate PR's?

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [x] I've tested my changes, adding unit tests if applicable.
 - [x] I've added Apache 2.0 Headers to the top of any new source files.
