### PR TITLE
Print error to info log before backing off

### DIFF
--- a/autorest/sender.go
+++ b/autorest/sender.go
@@ -272,7 +272,7 @@ func DoRetryForAttempts(attempts int, backoff time.Duration) SendDecorator {
 				if err == nil {
 					return resp, err
 				}
-				logger.Instance.Writef(logger.LogInfo, "DoRetryForAttempts: received error for attempt %d: %v\n", attempt+1, err)
+				logger.Instance.Writef(logger.LogError, "DoRetryForAttempts: received error for attempt %d: %v\n", attempt+1, err)
 				if !DelayForBackoff(backoff, attempt, r.Context().Done()) {
 					return nil, r.Context().Err()
 				}
@@ -328,7 +328,7 @@ func doRetryForStatusCodesImpl(s Sender, r *http.Request, count429 bool, attempt
 			return resp, err
 		}
 		if err != nil {
-			logger.Instance.Writef(logger.LogInfo, "DoRetryForStatusCodes: received error for attempt %d: %v\n", attempt+1, err)
+			logger.Instance.Writef(logger.LogError, "DoRetryForStatusCodes: received error for attempt %d: %v\n", attempt+1, err)
 		}
 		delayed := DelayWithRetryAfter(resp, r.Context().Done())
 		// if this was a 429 set the delay cap as specified.
@@ -396,7 +396,7 @@ func DoRetryForDuration(d time.Duration, backoff time.Duration) SendDecorator {
 				if err == nil {
 					return resp, err
 				}
-				logger.Instance.Writef(logger.LogInfo, "DoRetryForDuration: received error for attempt %d: %v\n", attempt+1, err)
+				logger.Instance.Writef(logger.LogError, "DoRetryForDuration: received error for attempt %d: %v\n", attempt+1, err)
 				if !DelayForBackoff(backoff, attempt, r.Context().Done()) {
 					return nil, r.Context().Err()
 				}

--- a/autorest/sender.go
+++ b/autorest/sender.go
@@ -272,6 +272,7 @@ func DoRetryForAttempts(attempts int, backoff time.Duration) SendDecorator {
 				if err == nil {
 					return resp, err
 				}
+				logger.Instance.Writef(logger.LogInfo, "DoRetryForAttempts: received error for attempt %d: %v\n", attempt+1, err)
 				if !DelayForBackoff(backoff, attempt, r.Context().Done()) {
 					return nil, r.Context().Err()
 				}
@@ -325,6 +326,9 @@ func doRetryForStatusCodesImpl(s Sender, r *http.Request, count429 bool, attempt
 		// resp and err will both have a value, so in this case we don't want to retry as it will never succeed.
 		if err == nil && !ResponseHasStatusCode(resp, codes...) || IsTokenRefreshError(err) {
 			return resp, err
+		}
+		if err != nil {
+			logger.Instance.Writef(logger.LogInfo, "DoRetryForStatusCodes: received error for attempt %d: %v\n", attempt+1, err)
 		}
 		delayed := DelayWithRetryAfter(resp, r.Context().Done())
 		// if this was a 429 set the delay cap as specified.
@@ -392,6 +396,7 @@ func DoRetryForDuration(d time.Duration, backoff time.Duration) SendDecorator {
 				if err == nil {
 					return resp, err
 				}
+				logger.Instance.Writef(logger.LogInfo, "DoRetryForDuration: received error for attempt %d: %v\n", attempt+1, err)
 				if !DelayForBackoff(backoff, attempt, r.Context().Done()) {
 					return nil, r.Context().Err()
 				}


### PR DESCRIPTION
Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [x] I've tested my changes, adding unit tests if applicable.
 - [x] I've added Apache 2.0 Headers to the top of any new source files.

-----------------------------------------------------------------

This is a small change I made that should help users of the Azure SDK debugging networking issues whenever DelayForBackoff(WithCap) is called. Normally you will have to wait until the cap is reached to actually see the error. With this change, it should be printed to the info log (assuming `AZURE_GO_SDK_LOG_LEVEL` is set at least to `Info`) before DelayForBackoff(WithCap) is called, so that potential errors can be detected quicker.