### PR TITLE
GetTokenFromCLIWithParams fixed empty error message if command invoke failed.

### DIFF
--- a/autorest/azure/cli/token.go
+++ b/autorest/azure/cli/token.go
@@ -165,12 +165,13 @@ func GetTokenFromCLIWithParams(params GetAccessTokenParams) (*Token, error) {
 		cliCmd.Args = append(cliCmd.Args, "--tenant", params.Tenant)
 	}
 
-	var stderr bytes.Buffer
-	cliCmd.Stderr = &stderr
-
 	output, err := cliCmd.Output()
 	if err != nil {
-		return nil, fmt.Errorf("Invoking Azure CLI failed with the following error: %s", stderr.String())
+		if ee, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("Invoking Azure CLI failed with the following error: %s", ee.Stderr)
+		}
+
+		return nil, fmt.Errorf("Invoking Azure CLI failed with the following error: %s", err.Error())
 	}
 
 	tokenResponse := Token{}

--- a/autorest/azure/cli/token.go
+++ b/autorest/azure/cli/token.go
@@ -170,7 +170,7 @@ func GetTokenFromCLIWithParams(params GetAccessTokenParams) (*Token, error) {
 
 	output, err := cliCmd.Output()
 	if err != nil {
-		if _, ok := err.(*exec.ExitError); ok {
+		if stderr.Len() > 0 {
 			return nil, fmt.Errorf("Invoking Azure CLI failed with the following error: %s", stderr.String())
 		}
 

--- a/autorest/azure/cli/token.go
+++ b/autorest/azure/cli/token.go
@@ -165,10 +165,13 @@ func GetTokenFromCLIWithParams(params GetAccessTokenParams) (*Token, error) {
 		cliCmd.Args = append(cliCmd.Args, "--tenant", params.Tenant)
 	}
 
+	var stderr bytes.Buffer
+	cliCmd.Stderr = &stderr
+
 	output, err := cliCmd.Output()
 	if err != nil {
-		if ee, ok := err.(*exec.ExitError); ok {
-			return nil, fmt.Errorf("Invoking Azure CLI failed with the following error: %s", ee.Stderr)
+		if _, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("Invoking Azure CLI failed with the following error: %s", stderr.String())
 		}
 
 		return nil, fmt.Errorf("Invoking Azure CLI failed with the following error: %s", err.Error())


### PR DESCRIPTION
Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [X] I've tested my changes, adding unit tests if applicable.
 - [X] I've added Apache 2.0 Headers to the top of any new source files.

Fixes the Issue: #652 