### PR TITLE
Create a default transport

### DIFF
--- a/autorest/adal/sender.go
+++ b/autorest/adal/sender.go
@@ -16,9 +16,11 @@ package adal
 
 import (
 	"crypto/tls"
+	"net"
 	"net/http"
 	"net/http/cookiejar"
 	"sync"
+	"time"
 
 	"github.com/Azure/go-autorest/tracing"
 )
@@ -72,15 +74,18 @@ func sender() Sender {
 	// note that we can't init defaultSender in init() since it will
 	// execute before calling code has had a chance to enable tracing
 	defaultSenderInit.Do(func() {
-		// Use behaviour compatible with DefaultTransport, but require TLS minimum version.
-		defaultTransport := http.DefaultTransport.(*http.Transport)
+		// copied from http.DefaultTransport with a TLS minimum version.
 		transport := &http.Transport{
-			Proxy:                 defaultTransport.Proxy,
-			DialContext:           defaultTransport.DialContext,
-			MaxIdleConns:          defaultTransport.MaxIdleConns,
-			IdleConnTimeout:       defaultTransport.IdleConnTimeout,
-			TLSHandshakeTimeout:   defaultTransport.TLSHandshakeTimeout,
-			ExpectContinueTimeout: defaultTransport.ExpectContinueTimeout,
+			Proxy: http.ProxyFromEnvironment,
+			DialContext: (&net.Dialer{
+				Timeout:   30 * time.Second,
+				KeepAlive: 30 * time.Second,
+			}).DialContext,
+			ForceAttemptHTTP2:     true,
+			MaxIdleConns:          100,
+			IdleConnTimeout:       90 * time.Second,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
 			TLSClientConfig: &tls.Config{
 				MinVersion: tls.VersionTLS12,
 			},

--- a/autorest/sender.go
+++ b/autorest/sender.go
@@ -143,7 +143,8 @@ func sender(renengotiation tls.RenegotiationSupport) Sender {
 			TLSHandshakeTimeout:   10 * time.Second,
 			ExpectContinueTimeout: 1 * time.Second,
 			TLSClientConfig: &tls.Config{
-				MinVersion: tls.VersionTLS12,
+				MinVersion:    tls.VersionTLS12,
+				Renegotiation: renengotiation,
 			},
 		}
 		var roundTripper http.RoundTripper = transport

--- a/autorest/sender.go
+++ b/autorest/sender.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"log"
 	"math"
+	"net"
 	"net/http"
 	"net/http/cookiejar"
 	"strconv"
@@ -129,18 +130,20 @@ func sender(renengotiation tls.RenegotiationSupport) Sender {
 	// note that we can't init defaultSenders in init() since it will
 	// execute before calling code has had a chance to enable tracing
 	defaultSenders[renengotiation].init.Do(func() {
-		// Use behaviour compatible with DefaultTransport, but require TLS minimum version.
-		defaultTransport := http.DefaultTransport.(*http.Transport)
+		// copied from http.DefaultTransport with a TLS minimum version.
 		transport := &http.Transport{
-			Proxy:                 defaultTransport.Proxy,
-			DialContext:           defaultTransport.DialContext,
-			MaxIdleConns:          defaultTransport.MaxIdleConns,
-			IdleConnTimeout:       defaultTransport.IdleConnTimeout,
-			TLSHandshakeTimeout:   defaultTransport.TLSHandshakeTimeout,
-			ExpectContinueTimeout: defaultTransport.ExpectContinueTimeout,
+			Proxy: http.ProxyFromEnvironment,
+			DialContext: (&net.Dialer{
+				Timeout:   30 * time.Second,
+				KeepAlive: 30 * time.Second,
+			}).DialContext,
+			ForceAttemptHTTP2:     true,
+			MaxIdleConns:          100,
+			IdleConnTimeout:       90 * time.Second,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
 			TLSClientConfig: &tls.Config{
-				MinVersion:    tls.VersionTLS12,
-				Renegotiation: renengotiation,
+				MinVersion: tls.VersionTLS12,
 			},
 		}
 		var roundTripper http.RoundTripper = transport


### PR DESCRIPTION
Type-asserting the http.DefaultTransport can fail if it was replaced
with a custom RoundTripper.  Instead, create a new http.Transport with
the settings copied from http.DefaultTransport.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
