### PR TITLE
URL-encode semicolons in query parameters

### DIFF
--- a/autorest/preparer.go
+++ b/autorest/preparer.go
@@ -241,6 +241,8 @@ func WithBaseURL(baseURL string) PrepareDecorator {
 					return r, fmt.Errorf("autorest: No scheme detected in URL %s", baseURL)
 				}
 				if u.RawQuery != "" {
+					// handle unencoded semicolons (ideally the server would send them already encoded)
+					u.RawQuery = strings.Replace(u.RawQuery, ";", "%3B", -1)
 					q, err := url.ParseQuery(u.RawQuery)
 					if err != nil {
 						return r, err

--- a/autorest/preparer_test.go
+++ b/autorest/preparer_test.go
@@ -405,12 +405,12 @@ func TestCreatePreparerRunsDecoratorsInOrder(t *testing.T) {
 }
 
 func TestWithBaseURLEncodeQueryParams(t *testing.T) {
-	p := CreatePreparer(WithBaseURL("https://contoso.com/path?$qp1=something/else&$qp2=do/this"))
+	p := CreatePreparer(WithBaseURL("https://contoso.com/path?$qp1=something/else&$qp2=do/this&$skipToken=US1:0637720028736481134:ad5b2d5b;AS1:-1:FFFFFFFF"))
 	r, err := p.Prepare(&http.Request{})
 	if err != nil {
 		t.Fatalf("autorest: CreatePreparer failed (%v)", err)
 	}
-	want := "https://contoso.com/path?%24qp1=something%2Felse&%24qp2=do%2Fthis"
+	want := "https://contoso.com/path?%24qp1=something%2Felse&%24qp2=do%2Fthis&%24skipToken=US1%3A0637720028736481134%3Aad5b2d5b%3BAS1%3A-1%3AFFFFFFFF"
 	if u := r.URL.String(); u != want {
 		t.Fatalf("unexpected URL, got %s, want %s", u, want)
 	}


### PR DESCRIPTION
Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
