### PR TITLE
Don't raise an error from Client.AddToUserAgent

### DIFF
--- a/autorest/client.go
+++ b/autorest/client.go
@@ -222,12 +222,10 @@ func newClient(ua string, renegotiation tls.RenegotiationSupport) Client {
 }
 
 // AddToUserAgent adds an extension to the current user agent
-func (c *Client) AddToUserAgent(extension string) error {
+func (c *Client) AddToUserAgent(extension string) {
 	if extension != "" {
 		c.UserAgent = fmt.Sprintf("%s %s", c.UserAgent, extension)
-		return nil
 	}
-	return fmt.Errorf("Extension was empty, User Agent stayed as %s", c.UserAgent)
 }
 
 // Do implements the Sender interface by invoking the active Sender after applying authorization.

--- a/autorest/client_test.go
+++ b/autorest/client_test.go
@@ -169,10 +169,7 @@ func TestAddToUserAgent(t *testing.T) {
 	ua := "UserAgent"
 	c := NewClientWithUserAgent(ua)
 	ext := "extension"
-	err := c.AddToUserAgent(ext)
-	if err != nil {
-		t.Fatalf("autorest: AddToUserAgent returned error -- expected nil, received %s", err)
-	}
+	c.AddToUserAgent(ext)
 	completeUA := fmt.Sprintf("%s %s %s", UserAgent(), ua, ext)
 
 	if c.UserAgent != completeUA {
@@ -180,11 +177,7 @@ func TestAddToUserAgent(t *testing.T) {
 			completeUA, c.UserAgent)
 	}
 
-	err = c.AddToUserAgent("")
-	if err == nil {
-		t.Fatalf("autorest: AddToUserAgent didn't return error -- expected %s, received nil",
-			fmt.Errorf("Extension was empty, User Agent stayed as %s", c.UserAgent))
-	}
+	c.AddToUserAgent("")
 	if c.UserAgent != completeUA {
 		t.Fatalf("autorest: AddToUserAgent failed to not add an empty extension to the UserAgent -- expected %s, received %s",
 			completeUA, c.UserAgent)


### PR DESCRIPTION
This is essentially just string concatenation, there is no real reason
to return an error here. This causes clients to write dozens of lines
of pointless error handling or just not handle the err.

Thinking about the contract of this function, if I've asked for it to
append "" (empty string) to the user agent, and it does nothing, then
it has been a success. Raising an error in that case is a bit weird.

`"foo" + ""` does not result in an error, which is essentially what
this is doing.

---

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [x] I've tested my changes, adding unit tests if applicable.
 - [x] ~I've added Apache 2.0 Headers to the top of any new source files.~ Not applicable
