### PR TITLE
all: remove unnecessary string([]byte) conversion in fmt.Sprintf yet %s

### DIFF
--- a/autorest/azure/azure.go
+++ b/autorest/azure/azure.go
@@ -68,7 +68,7 @@ func (se ServiceError) Error() string {
 		if err != nil {
 			result += fmt.Sprintf(" Details=%v", se.Details)
 		}
-		result += fmt.Sprintf(" Details=%v", string(d))
+		result += fmt.Sprintf(" Details=%s", d)
 	}
 
 	if se.InnerError != nil {
@@ -76,7 +76,7 @@ func (se ServiceError) Error() string {
 		if err != nil {
 			result += fmt.Sprintf(" InnerError=%v", se.InnerError)
 		}
-		result += fmt.Sprintf(" InnerError=%v", string(d))
+		result += fmt.Sprintf(" InnerError=%s", d)
 	}
 
 	if se.AdditionalInfo != nil {
@@ -84,7 +84,7 @@ func (se ServiceError) Error() string {
 		if err != nil {
 			result += fmt.Sprintf(" AdditionalInfo=%v", se.AdditionalInfo)
 		}
-		result += fmt.Sprintf(" AdditionalInfo=%v", string(d))
+		result += fmt.Sprintf(" AdditionalInfo=%s", d)
 	}
 
 	return result
@@ -335,13 +335,13 @@ func WithErrorUnlessStatusCode(codes ...int) autorest.RespondDecorator {
 				b, decodeErr := autorest.CopyAndDecode(encodedAs, resp.Body, &e)
 				resp.Body = ioutil.NopCloser(&b)
 				if decodeErr != nil {
-					return fmt.Errorf("autorest/azure: error response cannot be parsed: %q error: %v", b.String(), decodeErr)
+					return fmt.Errorf("autorest/azure: error response cannot be parsed: %q error: %v", b, decodeErr)
 				}
 				if e.ServiceError == nil {
 					// Check if error is unwrapped ServiceError
 					decoder := autorest.NewDecoder(encodedAs, bytes.NewReader(b.Bytes()))
 					if err := decoder.Decode(&e.ServiceError); err != nil {
-						return fmt.Errorf("autorest/azure: error response cannot be parsed: %q error: %v", b.String(), err)
+						return fmt.Errorf("autorest/azure: error response cannot be parsed: %q error: %v", b, err)
 					}
 
 					// for example, should the API return the literal value `null` as the response
@@ -364,7 +364,7 @@ func WithErrorUnlessStatusCode(codes ...int) autorest.RespondDecorator {
 					rawBody := map[string]interface{}{}
 					decoder := autorest.NewDecoder(encodedAs, bytes.NewReader(b.Bytes()))
 					if err := decoder.Decode(&rawBody); err != nil {
-						return fmt.Errorf("autorest/azure: error response cannot be parsed: %q error: %v", b.String(), err)
+						return fmt.Errorf("autorest/azure: error response cannot be parsed: %q error: %v", b, err)
 					}
 
 					e.ServiceError = &ServiceError{


### PR DESCRIPTION
Noticed from Orijtech's continuous benchmarking product "Bencher" per

https://dashboard.github.orijtech.com/benchmark/3245b8e4bbbd44a597480319aaa4b9fe

that there is a bunch of code in the wild that invokes:

    fmt.Sprintf("%s", string([]byte(...)))

yet the "%s" format specifier in fmt has a purpose:

    %s	the uninterpreted bytes of the string or slice

as well as using the "%c" format specifier

which led to big improvements across every dimension:
* CPU time reduction by 11+% (ns/op)
* throughput improvement by 13+% (MBs/op)
* allocations reduction by 45+% (B/op)
* number of allocations reduction by 18+% (alloc/op)

Also (*bytes.Buffer).String is invoked when "%q" or "%s" is passed in so
no need to use it.