### PR TITLE
Update comment to reference the correct env var

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -182,7 +182,7 @@ var Instance Writer
 // default log level
 var logLevel = LogNone
 
-// Level returns the value specified in AZURE_GO_AUTOREST_LOG_LEVEL.
+// Level returns the value specified in AZURE_GO_SDK_LOG_LEVEL.
 // If no value was specified the default value is LogNone.
 // Custom loggers can call this to retrieve the configured log level.
 func Level() LevelType {


### PR DESCRIPTION
The correct environment variable which is used for initializing the default logger is `AZURE_GO_SDK_LOG_LEVEL` not `AZURE_GO_AUTOREST_LOG_LEVEL` as referenced https://github.com/Azure/go-autorest/blob/master/logger/logger.go#L200

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [x] I've tested my changes, adding unit tests if applicable.
 - [x] I've added Apache 2.0 Headers to the top of any new source files.
