### PR TITLE
Add CosmosDB Resource Identifier

### DIFF
--- a/autorest/azure/environments.go
+++ b/autorest/azure/environments.go
@@ -50,6 +50,7 @@ type ResourceIdentifier struct {
 	Synapse             string `json:"synapse"`
 	ServiceBus          string `json:"serviceBus"`
 	SQLDatabase         string `json:"sqlDatabase"`
+	CosmosDB            string `json:"cosmosDB"`
 }
 
 // Environment represents a set of endpoints for each of Azure's Clouds.
@@ -123,6 +124,7 @@ var (
 			Synapse:             "https://dev.azuresynapse.net",
 			ServiceBus:          "https://servicebus.azure.net/",
 			SQLDatabase:         "https://database.windows.net/",
+			CosmosDB:            "https://cosmos.azure.com",
 		},
 	}
 
@@ -165,6 +167,7 @@ var (
 			Synapse:             NotAvailable,
 			ServiceBus:          "https://servicebus.azure.net/",
 			SQLDatabase:         "https://database.usgovcloudapi.net/",
+			CosmosDB:            "https://cosmos.azure.com",
 		},
 	}
 
@@ -207,6 +210,7 @@ var (
 			Synapse:             "https://dev.azuresynapse.net",
 			ServiceBus:          "https://servicebus.azure.net/",
 			SQLDatabase:         "https://database.chinacloudapi.cn/",
+			CosmosDB:            "https://cosmos.azure.com",
 		},
 	}
 
@@ -249,6 +253,7 @@ var (
 			Synapse:             NotAvailable,
 			ServiceBus:          "https://servicebus.azure.net/",
 			SQLDatabase:         "https://database.cloudapi.de/",
+			CosmosDB:            "https://cosmos.azure.com",
 		},
 	}
 )

--- a/autorest/azure/environments_test.go
+++ b/autorest/azure/environments_test.go
@@ -34,6 +34,7 @@ const (
 	keyvaultResourceID   = "--keyvault-resource-id--"
 	opInsightsResourceID = "--operational-insights-resource-id--"
 	ossRDBMSResourceID   = "--oss-rdbms-resource-id--"
+	cosmosDBResourceID   = "--cosmosdb-resource-id--"
 )
 
 // This correlates to the expected contents of ./testdata/test_environment_1.json
@@ -67,6 +68,7 @@ var testEnvironment1 = Environment{
 		KeyVault:            keyvaultResourceID,
 		OperationalInsights: opInsightsResourceID,
 		OSSRDBMS:            ossRDBMSResourceID,
+		CosmosDB:            cosmosDBResourceID,
 	},
 }
 
@@ -79,7 +81,6 @@ func TestEnvironment_EnvironmentFromURL_NoOverride_Success(t *testing.T) {
 	defer ts.Close()
 
 	got, err := EnvironmentFromURL(ts.URL)
-
 	if err != nil {
 		t.Error(err)
 	}
@@ -101,7 +102,6 @@ func TestEnvironment_EnvironmentFromURL_OverrideStorageSuffix_Success(t *testing
 		Value: "fakeStorageSuffix",
 	}
 	got, err := EnvironmentFromURL(ts.URL, overrideProperty)
-
 	if err != nil {
 		t.Error(err)
 	}
@@ -228,7 +228,8 @@ func TestDeserializeEnvironment(t *testing.T) {
 			"graph": "` + graphResourceID + `",
 			"keyVault": "` + keyvaultResourceID + `",
 			"operationalInsights": "` + opInsightsResourceID + `",
-			"ossRDBMS": "` + ossRDBMSResourceID + `"
+			"ossRDBMS": "` + ossRDBMSResourceID + `",
+			"cosmosDB": "` + cosmosDBResourceID + `"
 		}
 	}`
 
@@ -319,6 +320,9 @@ func TestDeserializeEnvironment(t *testing.T) {
 	if ossRDBMSResourceID != testSubject.ResourceIdentifiers.OSSRDBMS {
 		t.Errorf("Expected ResourceIdentifiers.OperationalInsights to be "+ossRDBMSResourceID+", but got %q", testSubject.ResourceIdentifiers.OSSRDBMS)
 	}
+	if cosmosDBResourceID != testSubject.ResourceIdentifiers.CosmosDB {
+		t.Errorf("Expected ResourceIdentifiers.CosmosDB to be "+cosmosDBResourceID+", but got %q", testSubject.ResourceIdentifiers.CosmosDB)
+	}
 }
 
 func TestRoundTripSerialization(t *testing.T) {
@@ -352,6 +356,7 @@ func TestRoundTripSerialization(t *testing.T) {
 			KeyVault:            keyvaultResourceID,
 			OperationalInsights: opInsightsResourceID,
 			OSSRDBMS:            ossRDBMSResourceID,
+			CosmosDB:            cosmosDBResourceID,
 		},
 	}
 
@@ -449,6 +454,9 @@ func TestRoundTripSerialization(t *testing.T) {
 	}
 	if env.ResourceIdentifiers.OSSRDBMS != testSubject.ResourceIdentifiers.OSSRDBMS {
 		t.Errorf("Expected ResourceIdentifiers.OSSRDBMS to be %q, but got %q", env.ResourceIdentifiers.OSSRDBMS, testSubject.ResourceIdentifiers.OSSRDBMS)
+	}
+	if env.ResourceIdentifiers.CosmosDB != testSubject.ResourceIdentifiers.CosmosDB {
+		t.Errorf("Expected ResourceIdentifiers.CosmosDB to be %q, but got %q", env.ResourceIdentifiers.CosmosDB, testSubject.ResourceIdentifiers.CosmosDB)
 	}
 }
 

--- a/autorest/azure/testdata/test_environment_1.json
+++ b/autorest/azure/testdata/test_environment_1.json
@@ -27,6 +27,7 @@
         "graph": "--graph-resource-id--",
         "keyVault": "--keyvault-resource-id--",
         "operationalInsights": "--operational-insights-resource-id--",
-        "ossRDBMS": "--oss-rdbms-resource-id--"
+        "ossRDBMS": "--oss-rdbms-resource-id--",
+        "cosmosDB": "--cosmosdb-resource-id--"
     }
 }


### PR DESCRIPTION
Add CosmosDB Resource Identifier

This is required for Cosmos DB dataplane operations.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [x] I've tested my changes, adding unit tests if applicable.
 - [x] I've added Apache 2.0 Headers to the top of any new source files.
