### PR TITLE
Remove IMDS probe when determining environment

### DIFF
--- a/autorest/adal/token.go
+++ b/autorest/adal/token.go
@@ -1316,8 +1316,11 @@ func NewMultiTenantServicePrincipalTokenFromCertificate(multiTenantCfg MultiTena
 }
 
 // MSIAvailable returns true if the MSI endpoint is available for authentication.
-func MSIAvailable(ctx context.Context, sender Sender) bool {
-	resp, err := getMSIEndpoint(ctx, sender)
+func MSIAvailable(ctx context.Context, s Sender) bool {
+	if s == nil {
+		s = sender()
+	}
+	resp, err := getMSIEndpoint(ctx, s)
 	if err == nil {
 		resp.Body.Close()
 	}

--- a/autorest/adal/token.go
+++ b/autorest/adal/token.go
@@ -676,8 +676,6 @@ const (
 
 func (m msiType) String() string {
 	switch m {
-	case msiTypeUnavailable:
-		return "unavailable"
 	case msiTypeAppServiceV20170901:
 		return "AppServiceV20170901"
 	case msiTypeCloudShell:
@@ -699,13 +697,9 @@ func getMSIType() (msiType, string, error) {
 		}
 		// if ONLY the env var MSI_ENDPOINT is set the msiType is CloudShell
 		return msiTypeCloudShell, endpointEnvVar, nil
-	} else if msiAvailableHook(context.Background(), sender()) {
-		// if MSI_ENDPOINT is NOT set AND the IMDS endpoint is available the msiType is IMDS. This will timeout after 500 milliseconds
-		return msiTypeIMDS, msiEndpoint, nil
-	} else {
-		// if MSI_ENDPOINT is NOT set and IMDS endpoint is not available Managed Identity is not available
-		return msiTypeUnavailable, "", errors.New("MSI not available")
 	}
+	// if MSI_ENDPOINT is NOT set assume the msiType is IMDS
+	return msiTypeIMDS, msiEndpoint, nil
 }
 
 // GetMSIVMEndpoint gets the MSI endpoint on Virtual Machines.
@@ -1328,9 +1322,4 @@ func MSIAvailable(ctx context.Context, sender Sender) bool {
 		resp.Body.Close()
 	}
 	return err == nil
-}
-
-// used for testing purposes
-var msiAvailableHook = func(ctx context.Context, sender Sender) bool {
-	return MSIAvailable(ctx, sender)
 }

--- a/autorest/adal/token_1.13.go
+++ b/autorest/adal/token_1.13.go
@@ -25,7 +25,7 @@ import (
 )
 
 func getMSIEndpoint(ctx context.Context, sender Sender) (*http.Response, error) {
-	tempCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	tempCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 	// http.NewRequestWithContext() was added in Go 1.13
 	req, _ := http.NewRequestWithContext(tempCtx, http.MethodGet, msiEndpoint, nil)

--- a/autorest/adal/token_legacy.go
+++ b/autorest/adal/token_legacy.go
@@ -24,7 +24,7 @@ import (
 )
 
 func getMSIEndpoint(ctx context.Context, sender Sender) (*http.Response, error) {
-	tempCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	tempCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 	req, _ := http.NewRequest(http.MethodGet, msiEndpoint, nil)
 	req = req.WithContext(tempCtx)

--- a/autorest/adal/token_test.go
+++ b/autorest/adal/token_test.go
@@ -44,13 +44,6 @@ const (
 	defaultManualFormData = "client_id=id&grant_type=refresh_token&refresh_token=refreshtoken&resource=resource"
 )
 
-func init() {
-	// fake that the IMDS endpoint is available
-	msiAvailableHook = func(ctx context.Context, sender Sender) bool {
-		return true
-	}
-}
-
 func TestTokenExpires(t *testing.T) {
 	tt := time.Now().Add(5 * time.Second)
 	tk := newTokenExpiresAt(tt)


### PR DESCRIPTION
Assume IMDS when other env vars aren't set.  If the request fails,
regular retry logic will kick in.
Bump up the health check probe to two seconds.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
