### PR TITLE
Add support for auth with a client resource ID

### DIFF
--- a/autorest/azure/auth/auth.go
+++ b/autorest/azure/auth/auth.go
@@ -741,9 +741,15 @@ type MSIConfig struct {
 
 // ServicePrincipalToken creates a ServicePrincipalToken from MSI.
 func (mc MSIConfig) ServicePrincipalToken() (*adal.ServicePrincipalToken, error) {
-	spToken, err := adal.NewServicePrincipalTokenFromManagedIdentity(mc.Resource, &adal.ManagedIdentityOptions{
-		ClientID: mc.ClientID,
-	})
+	mio := adal.ManagedIdentityOptions{}
+
+	if strings.Contains(mc.ClientID, "/Microsoft.ManagedIdentity/userAssignedIdentities/") {
+		mio.IdentityResourceID = mc.ClientID
+	} else {
+		mio.ClientID = mc.ClientID
+	}
+
+	spToken, err := adal.NewServicePrincipalTokenFromManagedIdentity(mc.Resource, &mio)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get oauth token from MSI: %v", err)
 	}


### PR DESCRIPTION
Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [x] I've tested my changes, adding unit tests if applicable.
 - [x] I've added Apache 2.0 Headers to the top of any new source files.

This PR adds support for using a Managed Identity Resource ID in the MSI auth flow. This is a supported feature of the IMDS that is not currently supported by go-autorest.










