### PR TITLE
Fix validation in resource id parsing

### DIFF
--- a/autorest/azure/azure.go
+++ b/autorest/azure/azure.go
@@ -214,7 +214,7 @@ func (r Resource) String() string {
 // See https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/template-functions-resource?tabs=json#resourceid.
 func ParseResourceID(resourceID string) (Resource, error) {
 
-	const resourceIDPatternText = `(?i)subscriptions/(.+)/resourceGroups/(.+)/providers/(.+?)/(.+?)/(.+)`
+	const resourceIDPatternText = `(?i)^/subscriptions/(.+)/resourceGroups/(.+)/providers/(.+?)/(.+?)/(.+)$`
 	resourceIDPattern := regexp.MustCompile(resourceIDPatternText)
 	match := resourceIDPattern.FindStringSubmatch(resourceID)
 


### PR DESCRIPTION
Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.


Before fix, 'ANYSTRING+valid id' can also be parsed as valid id, that's not correct.

As part of submitting, please make sure you can make the following assertions:
 - [x] I've tested my changes, adding unit tests if applicable.
 - [x] I've added Apache 2.0 Headers to the top of any new source files.
