### PR TITLE
LRO update status per `status` in response also applies to Location Poll

### DIFF
--- a/autorest/azure/async.go
+++ b/autorest/azure/async.go
@@ -561,7 +561,7 @@ Default:
 }
 
 func (pt *pollingTrackerBase) updatePollingState(provStateApl bool) error {
-	if pt.Pm == PollingAsyncOperation && pt.rawBody["status"] != nil {
+	if pt.Pm == PollingAsyncOperation || pt.Pm == PollingLocation && pt.rawBody["status"] != nil {
 		pt.State = pt.rawBody["status"].(string)
 	} else {
 		if pt.resp.StatusCode == http.StatusAccepted {


### PR DESCRIPTION
This PR extends the LRO pt status update based on the response `status` filed to location polling type.

This is to fix issues like: https://github.com/Azure/azure-rest-api-specs/issues/18844
