### PR TITLE
set MaxIdleConnsPerHost to 100 to reuse connections when there is large volume of requests

### DIFF
--- a/autorest/sender.go
+++ b/autorest/sender.go
@@ -139,6 +139,7 @@ func sender(renengotiation tls.RenegotiationSupport) Sender {
 			}).DialContext,
 			ForceAttemptHTTP2:     true,
 			MaxIdleConns:          100,
+			MaxIdleConnsPerHost:   100,
 			IdleConnTimeout:       90 * time.Second,
 			TLSHandshakeTimeout:   10 * time.Second,
 			ExpectContinueTimeout: 1 * time.Second,


### PR DESCRIPTION

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [x] I've tested my changes, adding unit tests if applicable.
 - [x] I've added Apache 2.0 Headers to the top of any new source files.
