### PR TITLE
feat: allow getting authorizer from existing file settings

### DIFF
--- a/autorest/azure/auth/auth.go
+++ b/autorest/azure/auth/auth.go
@@ -250,6 +250,17 @@ func NewAuthorizerFromFile(resourceBaseURI string) (autorest.Authorizer, error) 
 	if err != nil {
 		return nil, err
 	}
+	return settings.GetAuthorizer(resourceBaseURI)
+}
+
+// GetAuthorizer create an Authorizer in the following order.
+// 1. Client credentials
+// 2. Client certificate
+// resourceBaseURI - used to determine the resource type
+func (settings FileSettings) GetAuthorizer(resourceBaseURI string) (autorest.Authorizer, error) {
+	if resourceBaseURI == "" {
+		resourceBaseURI = azure.PublicCloud.ServiceManagementEndpoint
+	}
 	if a, err := settings.ClientCredentialsAuthorizer(resourceBaseURI); err == nil {
 		return a, err
 	}

--- a/autorest/azure/auth/auth_test.go
+++ b/autorest/azure/auth/auth_test.go
@@ -268,6 +268,23 @@ func TestFileClientCertificateAuthorizer(t *testing.T) {
 	}
 }
 
+func TestFileGetAuthorizerClientCert(t *testing.T) {
+	os.Setenv("AZURE_AUTH_LOCATION", "./testdata/credsutf8.json")
+	settings, err := GetSettingsFromFile()
+	if err != nil {
+		t.Logf("failed to load file settings: %v", err)
+		t.Fail()
+	}
+	// add certificate settings
+	settings.Values[CertificatePath] = "~/fake/path/cert.pfx"
+	settings.Values[CertificatePassword] = "fake-password"
+	_, err = settings.GetAuthorizer("https://management.azure.com")
+	if err == nil {
+		t.Log("unexpected nil error")
+		t.Fail()
+	}
+}
+
 func TestMultitenantClientCredentials(t *testing.T) {
 	setDefaultEnv()
 	os.Setenv(AuxiliaryTenantIDs, "aux-tenant-1;aux-tenant-2;aux-tenant3")

--- a/autorest/azure/auth/auth_test.go
+++ b/autorest/azure/auth/auth_test.go
@@ -269,7 +269,7 @@ func TestFileClientCertificateAuthorizer(t *testing.T) {
 }
 
 func TestFileGetAuthorizerClientCert(t *testing.T) {
-	os.Setenv("AZURE_AUTH_LOCATION", "./testdata/credsutf8.json")
+	t.Setenv("AZURE_AUTH_LOCATION", "./testdata/credsutf8.json")
 	settings, err := GetSettingsFromFile()
 	if err != nil {
 		t.Logf("failed to load file settings: %v", err)
@@ -278,10 +278,13 @@ func TestFileGetAuthorizerClientCert(t *testing.T) {
 	// add certificate settings
 	settings.Values[CertificatePath] = "~/fake/path/cert.pfx"
 	settings.Values[CertificatePassword] = "fake-password"
-	_, err = settings.GetAuthorizer("https://management.azure.com")
-	if err == nil {
-		t.Log("unexpected nil error")
+	auth, err := settings.GetAuthorizer("https://management.azure.com")
+	if err != nil {
+		t.Logf("failed to get authorizer: %v", err)
 		t.Fail()
+	}
+	if _, ok := auth.(*autorest.BearerAuthorizer); !ok {
+		t.Fatalf("unexpected authorizer type %T", auth)
 	}
 }
 


### PR DESCRIPTION
Currently we have to read the file config twice if we want to create an authorizer plus read other stuff from the config. This change allows getting the authorizer from an existing file settings object.

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [x] I've tested my changes, adding unit tests if applicable.
 - [x] I've added Apache 2.0 Headers to the top of any new source files.
