### PR TITLE
Update environments.go

### DIFF
--- a/autorest/azure/environments.go
+++ b/autorest/azure/environments.go
@@ -153,7 +153,7 @@ var (
 		GalleryEndpoint:              "https://gallery.usgovcloudapi.net/",
 		KeyVaultEndpoint:             "https://vault.usgovcloudapi.net/",
 		ManagedHSMEndpoint:           NotAvailable,
-		GraphEndpoint:                "https://graph.windows.net/",
+		GraphEndpoint:                "https://graph.windows.us/",
 		ServiceBusEndpoint:           "https://servicebus.usgovcloudapi.net/",
 		BatchManagementEndpoint:      "https://batch.core.usgovcloudapi.net/",
 		MicrosoftGraphEndpoint:       "https://graph.microsoft.us/",


### PR DESCRIPTION
While researching an issue for an application that uses autorest, we stumbled upon an incorrect constant defined in environments.go.

We found that one graph endpoint URL is defined as `.net` and another graph endpoint url in the same object is defined as `.us`.

These values should both reflect `.us` endpoints to ensure go applications implementing go-autorest do not run into endpoint issues.