### PR TITLE
Retract `adal` versions with token refresh errors

### DIFF
--- a/autorest/adal/go.mod
+++ b/autorest/adal/go.mod
@@ -11,3 +11,5 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.0.0
 	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa
 )
+
+retract [v0.9.5, v0.9.19] // retracted due to token refresh errors


### PR DESCRIPTION
Signed-off-by: Bernd Verst <github@bernd.dev>

This retracts a range of `adal` library versions which have errors in the handling of Token Refresh calls.

These errors can results in a huge range of subtle failures, such as inability to refresh a service principal token obtained via managed identity / MSI.

This retraction does not break builds using this particular version, but will print a warning to anyone impacted. `v0.9.20` is the first working version.

For this retraction to become effective a new release `v0.9.22` (since `v0.9.21` is the latest right now) needs to be tagged.