### PR TITLE
chore: should use xx.String() instead of string(xx.Bytes())

### DIFF
--- a/autorest/authorization_storage.go
+++ b/autorest/authorization_storage.go
@@ -190,7 +190,7 @@ func buildCanonicalizedResource(accountName, uri string, keyType SharedKeyType) 
 		}
 	}
 
-	return string(cr.Bytes()), nil
+	return cr.String(), nil
 }
 
 func getCanonicalizedAccountName(accountName string) string {
@@ -289,7 +289,7 @@ func buildCanonicalizedHeader(headers http.Header) string {
 		ch.WriteRune('\n')
 	}
 
-	return strings.TrimSuffix(string(ch.Bytes()), "\n")
+	return strings.TrimSuffix(ch.String(), "\n")
 }
 
 func createAuthorizationHeader(accountName string, accountKey []byte, canonicalizedString string, keyType SharedKeyType) string {


### PR DESCRIPTION
Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [ ] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
