### PR TITLE
Stop retriable request from adding a non-nil Body

### DIFF
--- a/autorest/retriablerequest_1.7.go
+++ b/autorest/retriablerequest_1.7.go
@@ -33,7 +33,7 @@ type RetriableRequest struct {
 func (rr *RetriableRequest) Prepare() (err error) {
 	// preserve the request body; this is to support retry logic as
 	// the underlying transport will always close the reqeust body
-	if rr.req.Body != nil {
+	if rr.req.Body != nil && rr.req.Body != http.NoBody {
 		if rr.br != nil {
 			_, err = rr.br.Seek(0, 0 /*io.SeekStart*/)
 			rr.req.Body = io.NopCloser(rr.br)

--- a/autorest/retriablerequest_1.8.go
+++ b/autorest/retriablerequest_1.8.go
@@ -34,7 +34,7 @@ type RetriableRequest struct {
 func (rr *RetriableRequest) Prepare() (err error) {
 	// preserve the request body; this is to support retry logic as
 	// the underlying transport will always close the reqeust body
-	if rr.req.Body != nil {
+	if rr.req.Body != nil && rr.req.Body != http.NoBody {
 		if rr.rc != nil {
 			rr.req.Body = rr.rc
 		} else if rr.br != nil {


### PR DESCRIPTION
When azure is responding with an error the retriable request that is generated ends up getting a non nil noOpcloser added to it with a reader interface. Ultimately this ends up sending a GET request to Azure that has a post body. As the http spec says that the body SHOULD be ignored this is not a critical error, but for people using custom transports this is problematic. It's also sending unnecessary bytes.

Example of the request being sent with an initial request: `Body:{} GetBody:<nil>`
This is the body when the same request is then retried: `Body:{Reader:} GetBody:<nil>`

I attempted to write a test for this but it turns out much of the test suite is leveraging GET with bodies in them. Inserting an error into the mocks for GET's with non-nil and non-empty request bodies broke a number of assumptions within the test framework. So I didn't end up adding an explicit test for this situation. The test suite does cover these lines already with unit tests to some degree and they are all still passing. I verified this locally with manual testing to confirm that 

Thank you for your contribution to Go-AutoRest! We will triage and review it as soon as we can.

As part of submitting, please make sure you can make the following assertions:
 - [x] I've tested my changes, adding unit tests if applicable.
 - [ ] I've added Apache 2.0 Headers to the top of any new source files.
